### PR TITLE
macOS: repeat the test up to 2x if it fails

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -50,7 +50,7 @@ jobs:
         --slave /usr/bingcov gcov /usr/bin/gcov-${GCC_V}
 
     - name: Install GFortran macOS
-      if: contains( matrix.os, 'macos')
+      if: contains(matrix.os, 'macos')
       run: brew install gcc@${GCC_V} || brew upgrade gcc@${GCC_V} || true
 
     - name: Install Rust
@@ -60,8 +60,14 @@ jobs:
 
     - name: Build
       run: |
-        cargo build --verbose
+        cargo test --verbose --no-run
 
-    - name: Run tests
+    - name: Run tests (Linux, Windows)
+      if: contains(matrix.os, 'ubuntu') || contains(matrix.os, 'windows')
       run: |
-        cargo test --verbose -j1
+        cargo test
+
+    - name: Run tests (macOS)
+      if: contains(matrix.os, 'macos')
+      run: |
+        cargo test || cargo test || cargo test

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -67,6 +67,7 @@ jobs:
       run: |
         cargo test
 
+    # Workaround for https://github.com/fortran-lang/fpm/issues/16
     - name: Run tests (macOS)
       if: contains(matrix.os, 'macos')
       run: |


### PR DESCRIPTION
This is a workaround for #16. It turns out that if the executable fails
to run, just rerunning all tests typically fixes it.