### PR TITLE
Add place to specify other libraries when building library

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -44,6 +44,7 @@ build = do
                  "gfortran"
                  ["-g", "-Wall", "-Wextra", "-Werror", "-pedantic"]
                  "library"
+                 []
     buildPrograms "app"
                   ["build" </> "library"]
                   [".f90", ".f", ".F", ".F90", ".f95", ".f03"]

--- a/src/Build.hs
+++ b/src/Build.hs
@@ -118,8 +118,9 @@ buildLibrary
     -> FilePath
     -> [String]
     -> String
+    -> [FilePath]
     -> IO ()
-buildLibrary libraryDirectory sourceExtensions buildDirectory compiler flags libraryName
+buildLibrary libraryDirectory sourceExtensions buildDirectory compiler flags libraryName otherLibraryDirectories
     = do
         sourceFiles <- getDirectoriesFiles [libraryDirectory] sourceExtensions
         let sourceFileLookupMap = createSourceFileLookupMap
@@ -129,6 +130,10 @@ buildLibrary libraryDirectory sourceExtensions buildDirectory compiler flags lib
         let moduleLookupMap = createModuleLookupMap buildDirectory
                                                     libraryDirectory
                                                     sourceFiles
+        otherModuleMaps <- mapM getLibraryModuleMap otherLibraryDirectories
+        let allModuleMaps =
+                moduleLookupMap
+                    `Map.union` foldl Map.union Map.empty otherModuleMaps
         let archiveFile = buildDirectory </> libraryName <.> "a"
         shake shakeOptions { shakeFiles    = buildDirectory
                            , shakeChange   = ChangeModtimeAndDigest
@@ -148,11 +153,14 @@ buildLibrary libraryDirectory sourceExtensions buildDirectory compiler flags lib
                               modulesUsed <- liftIO $ getModulesUsed sourceFile
                               let
                                   moduleFilesNeeded = mapMaybe
-                                      (`Map.lookup` moduleLookupMap)
+                                      (`Map.lookup` allModuleMaps)
                                       modulesUsed
+                              let includeFlags =
+                                      map ("-I" ++) otherLibraryDirectories
                               need moduleFilesNeeded
                               cmd compiler
                                   ["-c", "-J" ++ buildDirectory]
+                                  includeFlags
                                   flags
                                   ["-o", objectFile, sourceFile]
                   archiveFile %> \a -> do


### PR DESCRIPTION
This completes all the necessary capabilities of the build system.