### PR TITLE
Simplify example project

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -3,7 +3,7 @@
 module Main where
 
 import           Build                          ( buildLibrary
-                                                , buildPrograms
+                                                , buildProgram
                                                 )
 import           Data.Text                      ( Text
                                                 , unpack
@@ -61,12 +61,14 @@ build settings = do
                ["-g", "-Wall", "-Wextra", "-Werror", "-pedantic"]
                "library"
                []
-  buildPrograms "app"
-                ["build" </> "library"]
-                [".f90", ".f", ".F", ".F90", ".f95", ".f03"]
-                ("build" </> "app")
-                (unpack $ compiler settings)
-                ["-g", "-Wall", "-Wextra", "-Werror", "-pedantic"]
+  buildProgram "app"
+               ["build" </> "library"]
+               [".f90", ".f", ".F", ".F90", ".f95", ".f03"]
+               ("build" </> "app")
+               (unpack $ compiler settings)
+               ["-g", "-Wall", "-Wextra", "-Werror", "-pedantic"]
+               "example_project"
+               "main.f90"
 
 getArguments :: IO Arguments
 getArguments = execParser

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -32,7 +32,13 @@ import qualified Toml
 
 newtype Arguments = Arguments { command' :: Command }
 
-data Settings = Settings { compiler :: !Text }
+data Settings = Settings {
+      settingsCompiler :: !Text
+    , settingsProjectName :: !Text
+    , settingsDebugOptions :: ![Text]
+    , settingsLibrary :: !Library }
+
+data Library = Library { librarySourceDir :: !Text }
 
 data Command = Run | Test | Build
 
@@ -43,7 +49,8 @@ main = do
   let settings = Toml.decode settingsCodec fpmContents
   case settings of
     Left  err      -> print err
-    Right settings -> app args settings
+    Right settings -> do
+      app args settings
 
 app :: Arguments -> Settings -> IO ()
 app args settings = case command' args of
@@ -54,20 +61,25 @@ app args settings = case command' args of
 build :: Settings -> IO ()
 build settings = do
   putStrLn "Building"
-  buildLibrary "src"
+  let compiler          = unpack $ settingsCompiler settings
+  let projectName       = unpack $ settingsProjectName settings
+  let flags             = map unpack $ settingsDebugOptions settings
+  let librarySettings   = settingsLibrary settings
+  let librarySourceDir' = unpack $ librarySourceDir librarySettings
+  buildLibrary librarySourceDir'
                [".f90", ".f", ".F", ".F90", ".f95", ".f03"]
                ("build" </> "library")
-               (unpack $ compiler settings)
-               ["-g", "-Wall", "-Wextra", "-Werror", "-pedantic"]
-               "library"
+               compiler
+               flags
+               projectName
                []
   buildProgram "app"
                ["build" </> "library"]
                [".f90", ".f", ".F", ".F90", ".f95", ".f03"]
                ("build" </> "app")
-               (unpack $ compiler settings)
-               ["-g", "-Wall", "-Wextra", "-Werror", "-pedantic"]
-               "example_project"
+               compiler
+               flags
+               projectName
                "main.f90"
 
 getArguments :: IO Arguments
@@ -102,4 +114,16 @@ getDirectoriesFiles dirs exts = getDirectoryFilesIO "" newPatterns
   appendExts dir = map ((dir <//> "*") ++) exts
 
 settingsCodec :: TomlCodec Settings
-settingsCodec = Settings <$> Toml.text "compiler" .= compiler
+settingsCodec =
+  Settings
+    <$> Toml.text "compiler"
+    .=  settingsCompiler
+    <*> Toml.text "name"
+    .=  settingsProjectName
+    <*> Toml.arrayOf Toml._Text "debug-options"
+    .=  settingsDebugOptions
+    <*> Toml.table libraryCodec "library"
+    .=  settingsLibrary
+
+libraryCodec :: TomlCodec Library
+libraryCodec = Library <$> Toml.text "source-dir" .= librarySourceDir

--- a/example_project/app/main.f90
+++ b/example_project/app/main.f90
@@ -1,7 +1,7 @@
-program Hello_world
+program example_project
     use Hello_m, only: sayHello
 
     implicit none
 
     call sayHello("World")
-end program Hello_world
+end program example_project

--- a/example_project/fpm.toml
+++ b/example_project/fpm.toml
@@ -6,14 +6,13 @@ maintainer = "example@example.com"
 copyright = "2020 Author"
 dependencies = []
 compiler = "gfortran"
-devel-options = ["-g", "-Wall", "-Wextra", "-Werror", "-pedantic"]
+debug-options = ["-g", "-Wall", "-Wextra", "-Werror", "-pedantic"]
 release-options = ["-O3"]
 
 [library]
-source-dirs = "src"
+    source-dir = "src"
 
 [executables.example_project]
 main = "main.f90"
-source-dirs = "app"
-linker-options = ["-O3"]
+source-dir = "app"
 dependencies = []

--- a/example_project/fpm.toml
+++ b/example_project/fpm.toml
@@ -12,8 +12,8 @@ release-options = ["-O3"]
 [library]
 source-dirs = "src"
 
-[executables.Hello_world]
-main = "Hello_world.f90"
+[executables.example_project]
+main = "main.f90"
 source-dirs = "app"
 linker-options = ["-O3"]
 dependencies = []


### PR DESCRIPTION
This simplifies the example project and sets things up to begin building according to the settings read from `fpm.toml`