### PR TITLE
Update readme and executable name

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,24 +2,31 @@
 
 A prototype version.
 
-## How to try it out
+## Getting started
 
 ### Install Haskell
 
-Install Haskell Stack from (https://haskellstack.org/). E.g., to install on
-Linux without root access, follow the [manual download](https://docs.haskellstack.org/en/stable/install_and_upgrade/#manual-download_2):
+To install [Haskell Stack](https://haskellstack.org/) on
+Linux without root access, follow the [manual download](https://docs.haskellstack.org/en/stable/install_and_upgrade/#manual-download_2) procedure:
 ```
 wget https://get.haskellstack.org/stable/linux-x86_64-static.tar.gz
 tar xaf linux-x86_64-static.tar.gz
 ```
-and put the `stack` binary in your path, for example by:
+and put the `stack` binary in your path, for example:
 ```
 export PATH="$PATH:`pwd`/stack-2.1.3-linux-x86_64-static/"
 ```
 
+### Download this repo
+
+```
+git clone https://github.com/fortran-lang/fpm
+cd fpm
+```
+
 ### Build and Test FPM
 
-Build using:
+Build FPM using:
 ```
 stack build
 ```
@@ -27,3 +34,18 @@ To test:
 ```
 stack test
 ```
+To install:
+```
+stack install
+```
+
+### Building your Fortran project with FPM
+
+1. Copy `example_fpm.toml` from this repository 
+to the base directory of your Fortran project.
+2. Rename it to `fpm.toml`.
+3. Edit `fpm.toml` for your package.
+4. Type `fpm build`.
+5. (optional) If you have tests, type `fpm test`.
+6. (optional) If your package is an executable program,
+run it by typing `fpm run`. 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ To install:
 stack install
 ```
 
+On Linux, the above command installs `stack` to `${HOME}/.local/bin`.
+
 ### Building your Fortran project with FPM
 
 1. Copy `example_fpm.toml` from this repository 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ and put the `stack` binary in your path, for example:
 export PATH="$PATH:`pwd`/stack-2.1.3-linux-x86_64-static/"
 ```
 
-### Download this repo
+### Download this repository
 
 ```
 git clone https://github.com/fortran-lang/fpm

--- a/package.yaml
+++ b/package.yaml
@@ -36,7 +36,7 @@ library:
   source-dirs: src
 
 executables:
-  fpm-exe:
+  fpm:
     main:                Main.hs
     source-dirs:         app
     ghc-options:


### PR DESCRIPTION
This PR:

* Updates install instructions in the README and adds instructions on how to use fpm.
* Renames FPM executable from fpm-exe to fpm.

Fixes #55 