### PR TITLE
Fix ordering for library archive list

### DIFF
--- a/src/Fpm.hs
+++ b/src/Fpm.hs
@@ -569,7 +569,7 @@ buildDependencies
   -> IO [(FilePath, FilePath)]
 buildDependencies buildPrefix compiler flags dependencies = do
   built <- concatMapM (buildDependency buildPrefix compiler flags) dependencies
-  return $ nub built
+  return $ reverse (nub (reverse built))
 
 buildDependency
   :: String -> String -> [String] -> DependencyTree -> IO [(FilePath, FilePath)]


### PR DESCRIPTION
Found a bug in how the library archive paths are kept. Caused a link time error for complicated dependency trees.