### PR TITLE
add Ubuntu 20.04 package pre-requisite to `README`

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ cd fpm
 
 ### Build and Test fpm
 
+Make sure that the developers library of `gmp` is installed (e.g. `sudo apt install libgmp-dev` on Debian-derived Linux distributions)
+
 Build fpm using:
 ```
 stack build

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ cd fpm
 
 ### Build and Test fpm
 
-Make sure that the developers library of `gmp` is installed (e.g. `sudo apt install libgmp-dev` on Debian-derived Linux distributions)
+Make sure that the development library of `gmp` is installed (e.g. `sudo apt install libgmp-dev` on Debian-derived Linux distributions)
 
 Build fpm using:
 ```

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ To install:
 stack install
 ```
 
-On Linux, the above command installs `stack` to `${HOME}/.local/bin`.
+On Linux, the above command installs `fpm` to `${HOME}/.local/bin`.
 
 ### Building your Fortran project with fpm
 


### PR DESCRIPTION
Testing the building process, I have identified a pre-requisite on my machine with Ubuntu 20.04. Fixed a trivial typo, too.