### PR TITLE
Optional Fix for README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,3 @@
 .stack-work/
 fpm.cabal
 *~
-/.idea/inspectionProfiles/profiles_settings.xml
-/.idea/inspectionProfiles/Project_Default.xml
-/.idea/.gitignore
-/.idea/fpm.iml
-/.idea/misc.xml
-/.idea/modules.xml
-/.idea/vcs.xml

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,10 @@
 .stack-work/
 fpm.cabal
 *~
+/.idea/inspectionProfiles/profiles_settings.xml
+/.idea/inspectionProfiles/Project_Default.xml
+/.idea/.gitignore
+/.idea/fpm.iml
+/.idea/misc.xml
+/.idea/modules.xml
+/.idea/vcs.xml

--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ As the prototype matures and we enter production, we will do our best to stay ba
 
 ### Install Haskell
 
-To install **Haskell Stack**, follow these [instructions](https://docs.haskellstack.org/en/stable/README/)
+To install **Haskell Stack**, follow these [instructions](https://docs.haskellstack.org/en/stable/install_and_upgrade/)
+, users without superuser (admin) permissions should follow the [manual installation](https://docs.haskellstack.org/en/stable/install_and_upgrade/#manual-download_2) procedure.
 
 ### Download this repository
 
@@ -26,8 +27,6 @@ cd fpm
 ```
 
 ### Build and Test fpm
-
-Make sure that the development library of `gmp` is installed (e.g. `sudo apt install libgmp-dev` on Debian-derived Linux distributions)
 
 Build fpm using:
 ```bash

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ As the prototype matures and we enter production, we will do our best to stay ba
 
 ### Install Haskell
 
-To install [Haskell Stack](https://haskellstack.org/), follow these [instructions](https://docs.haskellstack.org/en/stable/README/)
+To install **Haskell Stack**, follow these [instructions](https://docs.haskellstack.org/en/stable/README/)
 
 ### Download this repository
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ As the prototype matures and we enter production, we will do our best to stay ba
 
 To install [Haskell Stack](https://haskellstack.org/) on
 Linux without root access, follow the [manual download](https://docs.haskellstack.org/en/stable/install_and_upgrade/#manual-download_2) procedure:
-```
+```bash
 wget https://get.haskellstack.org/stable/linux-x86_64-static.tar.gz
 tar xaf linux-x86_64-static.tar.gz
 ```
@@ -27,13 +27,13 @@ navigate to stack directory:
 cd stack-2.1.3-linux-x86_64-static/
 ```
 and put the `stack` binary in your path, for example:
-```
+```bash
 export PATH="$PATH:`pwd`"
 ```
 
 ### Download this repository
 
-```
+```bash
 git clone https://github.com/fortran-lang/fpm
 cd fpm
 ```
@@ -43,15 +43,15 @@ cd fpm
 Make sure that the development library of `gmp` is installed (e.g. `sudo apt install libgmp-dev` on Debian-derived Linux distributions)
 
 Build fpm using:
-```
+```bash
 stack build
 ```
 To test:
-```
+```bash
 stack test
 ```
 To install:
-```
+```bash
 stack install
 ```
 

--- a/README.md
+++ b/README.md
@@ -22,9 +22,13 @@ Linux without root access, follow the [manual download](https://docs.haskellstac
 wget https://get.haskellstack.org/stable/linux-x86_64-static.tar.gz
 tar xaf linux-x86_64-static.tar.gz
 ```
+navigate to stack directory:
+```bash
+cd stack-2.1.3-linux-x86_64-static/
+```
 and put the `stack` binary in your path, for example:
 ```
-export PATH="$PATH:`pwd`/stack-2.1.3-linux-x86_64-static/"
+export PATH="$PATH:`pwd`"
 ```
 
 ### Download this repository

--- a/README.md
+++ b/README.md
@@ -16,20 +16,7 @@ As the prototype matures and we enter production, we will do our best to stay ba
 
 ### Install Haskell
 
-To install [Haskell Stack](https://haskellstack.org/) on
-Linux without root access, follow the [manual download](https://docs.haskellstack.org/en/stable/install_and_upgrade/#manual-download_2) procedure:
-```bash
-wget https://get.haskellstack.org/stable/linux-x86_64-static.tar.gz
-tar xaf linux-x86_64-static.tar.gz
-```
-navigate to stack directory:
-```bash
-cd stack-2.1.3-linux-x86_64-static/
-```
-and put the `stack` binary in your path, for example:
-```bash
-export PATH="$PATH:`pwd`"
-```
+To install [Haskell Stack](https://haskellstack.org/), follow these [instructions](https://docs.haskellstack.org/en/stable/README/)
 
 ### Download this repository
 


### PR DESCRIPTION
Separating **navigating to stack directory** and **Adding to PATH**
Because some of users may navigate to stack directory first and and enter this command(_export PATH="$PATH:pwd/stack-2.1.3-linux-x86_64-static/_)  in order to install stack command that causes error below in $PATH:
```bash
No such file or directory
```