### PR TITLE
Fix bug with case in program source file name.

### DIFF
--- a/src/Build.hs
+++ b/src/Build.hs
@@ -120,7 +120,7 @@ buildProgram programDirectory libraryDirectories sourceExtensions buildDirectory
             need allObjectFiles
             need archives
             cmd compiler allObjectFiles archives ["-o", executable] flags
-          buildDirectory </> programSource -<.> "o" %> \objectFile -> do
+          buildDirectory </> (map toLower programSource) -<.> "o" %> \objectFile -> do
             let realObjectFile = foldl (</>) "" $ splitDirectories objectFile
             let sourceFile     = programDirectory </> programSource
             need [sourceFile]

--- a/test/example_packages/hello_complex/apps/say_hello/say_Hello.f90
+++ b/test/example_packages/hello_complex/apps/say_hello/say_Hello.f90
@@ -1,7 +1,7 @@
-program say_hello
+program say_Hello
     use greet_m, only: make_greeting
 
     implicit none
 
     print *, make_greeting("World")
-end program say_hello
+end program say_Hello

--- a/test/example_packages/hello_complex/fpm.toml
+++ b/test/example_packages/hello_complex/fpm.toml
@@ -4,9 +4,9 @@ name = "hello_complex"
 source-dir="source"
 
 [[executable]]
-name="say_hello"
+name="say_Hello"
 source-dir="apps/say_hello"
-main="say_hello.f90"
+main="say_Hello.f90"
 
 [[executable]]
 name="say_goodbye"


### PR DESCRIPTION
Fix #116

I guess up to now nobody had tried using uppercase in the name of their program source file. This fixes it.