### PR TITLE
FIx tests on macOS

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -27,6 +27,13 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v1
 
+    - name: Install GFortran macOS
+      if: contains(matrix.os, 'macos')
+      run: |
+          ln -s /usr/local/bin/gfortran-${GCC_V} /usr/local/bin/gfortran
+          which gfortran-${GCC_V}
+          which gfortran
+
     - name: Install Haskell macOS
       if: contains(matrix.os, 'macos')
       run: |

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -30,6 +30,7 @@ jobs:
     - name: Install Haskell macOS
       if: contains(matrix.os, 'macos')
       run: |
+          mkdir /Users/runner/.local/bin
           curl -L https://gist.github.com/certik/0e35f35753ae76f0f575d9b3d3f53633/raw/4cde02cc9215635c9401c2257a46be319e7ab6dd/osx-x86_64.tar.gz | tar xz --strip-components=1 --include '*/stack' -C /Users/runner/.local/bin
 
     - name: Install Haskell Linux

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -27,6 +27,11 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v1
 
+    - name: Install Haskell Linux / macOS (manual)
+      if: contains(matrix.os, 'macos')
+      run: |
+          curl --insecure -L https://get.haskellstack.org/stable/osx-x86_64.tar.gz | tar xz --strip-components=1 --include '*/stack' -C /Users/runner/.local/bin
+
     - name: Install Haskell Linux / macOS
       if: contains(matrix.os, 'ubuntu') || contains(matrix.os, 'macos')
       uses: mstksg/setup-stack@v1

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -27,13 +27,13 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v1
 
-    - name: Install Haskell Linux / macOS (manual)
+    - name: Install Haskell macOS
       if: contains(matrix.os, 'macos')
       run: |
-          curl --insecure -L https://get.haskellstack.org/stable/osx-x86_64.tar.gz | tar xz --strip-components=1 --include '*/stack' -C /Users/runner/.local/bin
+          curl -L https://gist.github.com/certik/0e35f35753ae76f0f575d9b3d3f53633/raw/4cde02cc9215635c9401c2257a46be319e7ab6dd/osx-x86_64.tar.gz | tar xz --strip-components=1 --include '*/stack' -C /Users/runner/.local/bin
 
-    - name: Install Haskell Linux / macOS
-      if: contains(matrix.os, 'ubuntu') || contains(matrix.os, 'macos')
+    - name: Install Haskell Linux
+      if: contains(matrix.os, 'ubuntu')
       uses: mstksg/setup-stack@v1
 
     - name: Install Haskell Windows


### PR DESCRIPTION
It turns out there were several problems on the macOS runner, all of which this PR fixes:

* the download of the Haskell binary failed due to some SSL handshake error
* the "bin" directory which would host the `stack` binary does not exist
* the `gfortran` binary is no longer pre-installed on macOS (only `gfortran-9`)

Fixes #134.