### PR TITLE
Minimal `fpm build` implementation

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -87,3 +87,4 @@ jobs:
         cd fpm
         fpm build
         fpm run
+        fpm run --args build

--- a/fpm/app/main.f90
+++ b/fpm/app/main.f90
@@ -1,7 +1,20 @@
 program main
-  use fpm, only: say_hello
+use fpm, only: print_help, cmd_build
+implicit none
+character(100) :: cmdarg
 
-  implicit none
-
-  call say_hello
+if (command_argument_count() == 0) then
+    call print_help()
+else if (command_argument_count() == 1) then
+    call get_command_argument(1, cmdarg)
+    if (cmdarg == "build") then
+        call cmd_build()
+    else
+        print *, "Unknown command: ", cmdarg
+        error stop
+    end if
+else
+    print *, "Too many arguments"
+    error stop
+end if
 end program main

--- a/fpm/src/fpm.f90
+++ b/fpm/src/fpm.f90
@@ -1,10 +1,30 @@
 module fpm
-  implicit none
-  private
+implicit none
+private
+public :: print_help, cmd_build
 
-  public :: say_hello
 contains
-  subroutine say_hello
-    print *, "Fortran Package Manager (fpm)"
-  end subroutine say_hello
+
+subroutine print_help()
+print *, "Fortran Package Manager (fpm)"
+end subroutine
+
+subroutine run(cmd)
+character(len=*), intent(in) :: cmd
+integer :: stat
+print *, "+ ", cmd
+call execute_command_line(cmd, exitstat=stat)
+if (stat /= 0) then
+    print *, "Command failed"
+    error stop
+end if
+end subroutine
+
+subroutine cmd_build()
+print *, "# Building project"
+call run("gfortran -c src/fpm.f90 -o fpm.o")
+call run("gfortran -c app/main.f90 -o main.o")
+call run("gfortran main.o fpm.o -o fpm")
+end subroutine
+
 end module fpm


### PR DESCRIPTION
Very minimal `fpm build` now works, it can only build `fpm` itself, but it can do it on all platforms, which is nice.

After this is in, the next step is to make it more general and build the `hello_world` example, and then execute this test also.

Towards #137.