### PR TITLE
fpm command placeholders and expand help message

### DIFF
--- a/fpm/app/main.f90
+++ b/fpm/app/main.f90
@@ -17,8 +17,8 @@ else if (command_argument_count() == 1) then
         case("run")
             call cmd_run()
         case default
-            print *, "Unknown command: " // trim(cmdarg)
-            call print_help()
+            print *, "fpm error: No such command " // trim(cmdarg)
+            error stop
     end select
 else
     print *, "Too many arguments"

--- a/fpm/app/main.f90
+++ b/fpm/app/main.f90
@@ -7,12 +7,13 @@ if (command_argument_count() == 0) then
     call print_help()
 else if (command_argument_count() == 1) then
     call get_command_argument(1, cmdarg)
-    if (cmdarg == "build") then
-        call cmd_build()
-    else
-        print *, "Unknown command: ", cmdarg
-        error stop
-    end if
+    select case(trim(cmdarg))
+        case("build")
+            call cmd_build()
+        case default
+            print *, "Unknown command: ", cmdarg
+            error stop
+    end select
 else
     print *, "Too many arguments"
     error stop

--- a/fpm/app/main.f90
+++ b/fpm/app/main.f90
@@ -18,10 +18,10 @@ else if (command_argument_count() == 1) then
             call cmd_run()
         case default
             print *, "fpm error: No such command " // trim(cmdarg)
-            error stop
+            error stop 1
     end select
 else
     print *, "Too many arguments"
-    error stop
+    error stop 1
 end if
 end program main

--- a/fpm/app/main.f90
+++ b/fpm/app/main.f90
@@ -1,5 +1,5 @@
 program main
-use fpm, only: print_help, cmd_build
+use fpm, only: print_help, cmd_build, cmd_install, cmd_new, cmd_run, cmd_test
 implicit none
 character(100) :: cmdarg
 
@@ -10,9 +10,15 @@ else if (command_argument_count() == 1) then
     select case(trim(cmdarg))
         case("build")
             call cmd_build()
+        case("install")
+            call cmd_install()
+        case("new")
+            call cmd_new()
+        case("run")
+            call cmd_run()
         case default
-            print *, "Unknown command: ", cmdarg
-            error stop
+            print *, "Unknown command: " // trim(cmdarg)
+            call print_help()
     end select
 else
     print *, "Too many arguments"

--- a/fpm/src/fpm.f90
+++ b/fpm/src/fpm.f90
@@ -114,6 +114,16 @@ select case (get_os_type())
     case (OS_WINDOWS)
         print *, "OS Type: Windows"
 end select
+print *
+print *, "USAGE:"
+print *, "    fpm [COMMAND]"
+print *
+print *, "Valid fpm commands are:"
+print *, "    build    Compile the current package"
+print *, "    install  Install a Fortran binary or library (not implemented)"
+print *, "    new      Create a new Fortran package (not implemented)"
+print *, "    run      Run a binary of the local package (not implemented)"
+print *, "    test     Run the tests (not implemented)"
 end subroutine
 
 subroutine run(cmd)

--- a/fpm/src/fpm.f90
+++ b/fpm/src/fpm.f90
@@ -105,7 +105,7 @@ close(u)
 end subroutine
 
 subroutine print_help()
-print *, "Fortran Package Manager (fpm)"
+print *, "fpm - A Fortran package manager and build system"
 select case (get_os_type())
     case (OS_LINUX)
         print *, "OS Type: Linux"
@@ -115,7 +115,7 @@ select case (get_os_type())
         print *, "OS Type: Windows"
 end select
 print *
-print *, "USAGE:"
+print *, "Usage:"
 print *, "    fpm [COMMAND]"
 print *
 print *, "Valid fpm commands are:"

--- a/fpm/src/fpm.f90
+++ b/fpm/src/fpm.f90
@@ -1,7 +1,7 @@
 module fpm
 implicit none
 private
-public :: print_help, cmd_build
+public :: print_help, cmd_build, cmd_install, cmd_new, cmd_run, cmd_test
 
 integer, parameter :: OS_LINUX = 1
 integer, parameter :: OS_MACOS = 2
@@ -172,6 +172,22 @@ end do
 call run("gfortran -c app/main.f90 -o main.o")
 call package_name(pkg_name)
 call run("gfortran main.o " // linking // " -o " // pkg_name)
+end subroutine
+
+subroutine cmd_install()
+    print *, "fpm error: 'fpm install' not implemented."
+end subroutine
+
+subroutine cmd_new()
+    print *, "fpm error: 'fpm new' not implemented."
+end subroutine
+
+subroutine cmd_run()
+    print *, "fpm error: 'fpm run' not implemented."
+end subroutine
+
+subroutine cmd_test()
+    print *, "fpm error: 'fpm test' not implemented."
 end subroutine
 
 end module fpm

--- a/fpm/src/fpm.f90
+++ b/fpm/src/fpm.f90
@@ -186,18 +186,22 @@ end subroutine
 
 subroutine cmd_install()
     print *, "fpm error: 'fpm install' not implemented."
+    error stop 1
 end subroutine
 
 subroutine cmd_new()
     print *, "fpm error: 'fpm new' not implemented."
+    error stop 1
 end subroutine
 
 subroutine cmd_run()
     print *, "fpm error: 'fpm run' not implemented."
+    error stop 1
 end subroutine
 
 subroutine cmd_test()
     print *, "fpm error: 'fpm test' not implemented."
+    error stop 1
 end subroutine
 
 end module fpm


### PR DESCRIPTION
To warm up my Fortran fingers before the workday, I made a few benign UI improvements:

* Expand the print message, borrowing from fpm-haskell and Cargo
* Add placeholder new, install, run, test commands and "not implemented" messages