### PR TITLE
Use different strategy to fetch git dependencies

### DIFF
--- a/bootstrap/src/Fpm.hs
+++ b/bootstrap/src/Fpm.hs
@@ -617,19 +617,23 @@ fetchDependency name version = do
         undefined
       GitVersion versionSpec -> do
         system
-          ("git clone " ++ gitVersionSpecUrl versionSpec ++ " " ++ clonePath)
+          ("git init " ++ clonePath)
         case gitVersionSpecRef versionSpec of
-          Just ref -> withCurrentDirectory clonePath $ do
+          Just ref -> do
             system
-              (  "git checkout "
+              ("git -C " ++ clonePath ++ " fetch " ++ gitVersionSpecUrl versionSpec ++ " "
               ++ (case ref of
                    Tag    tag    -> tag
                    Branch branch -> branch
                    Commit commit -> commit
                  )
               )
-            return (name, clonePath)
-          Nothing -> return (name, clonePath)
+          Nothing -> do
+            system
+              ("git -C " ++ clonePath ++ " fetch " ++ gitVersionSpecUrl versionSpec)
+        system
+          ("git -C " ++ clonePath ++ " checkout -qf FETCH_HEAD")
+        return (name, clonePath)
       PathVersion versionSpec -> return (name, pathVersionSpecPath versionSpec)
 
 {-


### PR DESCRIPTION
- matches strategy of GitHub's `actions/checkout` workflow
- use `init` -> `fetch` -> `checkout -qf FETCH_HEAD` instead of current `clone` [-> `checkout`] strategy
- always works in detached HEAD
- allows to update the git dependency with the same commands (Related: #121)
- change directory with `-C` command (easier to match for later Fortran implementation, available since git 1.8.5)

Can probably be implemented much nicer, but my Haskell skills don't go beyond the *Try it!* tutorial on haskell.org