### PR TITLE
Source parsing tests

### DIFF
--- a/fpm/src/fpm/error.f90
+++ b/fpm/src/fpm/error.f90
@@ -57,7 +57,8 @@ contains
 
 
     !> Error created when file parsing fails
-    subroutine file_parse_error(error, file_name, line, message)
+    subroutine file_parse_error(error, file_name, message, line_num, &
+                                 line_string, line_col)
 
         !> Instance of the error data
         type(error_t), allocatable, intent(out) :: error
@@ -65,19 +66,61 @@ contains
         !> Name of file
         character(len=*), intent(in) :: file_name
 
-        !> Line number of parse error
-        integer, intent(in) :: line
-
         !> Parse error message
         character(len=*), intent(in) :: message
 
-        character(50) :: line_no_string
+        !> Line number of parse error
+        integer, intent(in), optional :: line_num
 
-        write(line_no_string,'(I0)') line
+        !> Line context string
+        character(len=*), intent(in), optional :: line_string
+
+        !> Line context column
+        integer, intent(in), optional :: line_col
+
+        character(50) :: temp_string
 
         allocate(error)
-        error%message = 'Error while parsing file "'//file_name//'" on line '// &
-                        trim(line_no_string)//': '//message
+        error%message = 'Parse error: '//message//new_line('a')
+        
+        error%message = error%message//file_name
+        
+        if (present(line_num)) then
+
+            write(temp_string,'(I0)') line_num
+
+            error%message = error%message//':'//trim(temp_string)
+
+        end if
+
+        if (present(line_col)) then
+
+            if (line_col > 0) then
+
+                write(temp_string,'(I0)') line_col
+                error%message = error%message//':'//trim(temp_string)
+
+            end if
+
+        end if
+
+        if (present(line_string)) then
+
+            error%message = error%message//new_line('a')
+            error%message = error%message//'   | '//line_string
+
+            if (present(line_col)) then
+
+                if (line_col > 0) then
+
+                    error%message = error%message//new_line('a')
+                    error%message = error%message//'   | '//repeat(' ',line_col-1)//'^'
+                
+                end if
+                
+            end if
+
+        end if
 
     end subroutine file_parse_error
 

--- a/fpm/src/fpm/error.f90
+++ b/fpm/src/fpm/error.f90
@@ -5,6 +5,7 @@ module fpm_error
 
     public :: error_t
     public :: fatal_error, syntax_error, file_not_found_error
+    public :: file_parse_error
 
 
     !> Data type defining an error
@@ -53,6 +54,32 @@ contains
         error%message = "'"//file_name//"' could not be found, check if the file exists"
 
     end subroutine file_not_found_error
+
+
+    !> Error created when file parsing fails
+    subroutine file_parse_error(error, file_name, line, message)
+
+        !> Instance of the error data
+        type(error_t), allocatable, intent(out) :: error
+
+        !> Name of file
+        character(len=*), intent(in) :: file_name
+
+        !> Line number of parse error
+        integer, intent(in) :: line
+
+        !> Parse error message
+        character(len=*), intent(in) :: message
+
+        character(50) :: line_no_string
+
+        write(line_no_string,'(I0)') line
+
+        allocate(error)
+        error%message = 'Error while parsing file "'//file_name//'" on line '// &
+                        trim(line_no_string)//': '//message
+
+    end subroutine file_parse_error
 
 
 end module fpm_error

--- a/fpm/src/fpm_sources.f90
+++ b/fpm/src/fpm_sources.f90
@@ -224,15 +224,17 @@ function parse_f_source(f_filename,error) result(f_source)
 
                     temp_string = split_n(file_lines(i)%s,delims=':',n=2,stat=stat)
                     if (stat /= 0) then
-                        call file_parse_error(error,f_filename,i, &
-                                message='unable to find used module name')
+                        call file_parse_error(error,f_filename, &
+                                'unable to find used module name',i, &
+                                file_lines(i)%s,index(file_lines(i)%s,'::'))
                         return
                     end if
 
                     mod_name = split_n(temp_string,delims=' ,',n=1,stat=stat)
                     if (stat /= 0) then
-                        call file_parse_error(error,f_filename,i, &
-                                 message='unable to find used module name')
+                        call file_parse_error(error,f_filename, &
+                                 'unable to find used module name',i, &
+                                 file_lines(i)%s)
                         return
                     end if
                     mod_name = lower(mod_name)
@@ -241,8 +243,9 @@ function parse_f_source(f_filename,error) result(f_source)
 
                     mod_name = split_n(file_lines(i)%s,n=2,delims=' ,',stat=stat)
                     if (stat /= 0) then
-                        call file_parse_error(error,f_filename,i, &
-                                message='unable to find used module name')
+                        call file_parse_error(error,f_filename, &
+                                'unable to find used module name',i, &
+                                file_lines(i)%s)
                         return
                     end if
                     mod_name = lower(mod_name)
@@ -277,8 +280,9 @@ function parse_f_source(f_filename,error) result(f_source)
                     f_source%include_dependencies(n_include)%s = &
                      & split_n(file_lines(i)%s,n=2,delims="'"//'"',stat=stat)
                     if (stat /= 0) then
-                        call file_parse_error(error,f_filename,i, &
-                              message='unable to find include file name')
+                        call file_parse_error(error,f_filename, &
+                              'unable to find include file name',i, &
+                              file_lines(i)%s)
                         return
                     end if
                 end if
@@ -290,8 +294,9 @@ function parse_f_source(f_filename,error) result(f_source)
 
                 mod_name = lower(split_n(file_lines(i)%s,n=2,delims=' ',stat=stat))
                 if (stat /= 0) then
-                    call file_parse_error(error,f_filename,i, &
-                          message='unable to find module name')
+                    call file_parse_error(error,f_filename, &
+                          'unable to find module name',i, &
+                          file_lines(i)%s)
                     return
                 end if
 
@@ -303,8 +308,9 @@ function parse_f_source(f_filename,error) result(f_source)
                 end if
 
                 if (.not.validate_name(mod_name)) then
-                    call file_parse_error(error,f_filename,i, &
-                          message='empty or invalid name for module')
+                    call file_parse_error(error,f_filename, &
+                          'empty or invalid name for module',i, &
+                          file_lines(i)%s)
                     return
                 end if
 
@@ -323,8 +329,9 @@ function parse_f_source(f_filename,error) result(f_source)
 
                 temp_string = split_n(file_lines(i)%s,n=2,delims='()',stat=stat)
                 if (stat /= 0) then
-                    call file_parse_error(error,f_filename,i, &
-                          message='unable to get submodule ancestry')
+                    call file_parse_error(error,f_filename, &
+                          'unable to get submodule ancestry',i, &
+                          file_lines(i)%s)
                     return
                 end if
 
@@ -343,8 +350,9 @@ function parse_f_source(f_filename,error) result(f_source)
                     f_source%modules_used(n_use)%s = lower(temp_string)
 
                     if (.not.validate_name(temp_string)) then
-                        call file_parse_error(error,f_filename,i, &
-                          message='empty or invalid name for submodule parent')
+                        call file_parse_error(error,f_filename, &
+                          'empty or invalid name for submodule parent',i, &
+                          file_lines(i)%s, index(file_lines(i)%s,temp_string))
                         return
                     end if
 
@@ -461,8 +469,9 @@ function parse_c_source(c_filename,error) result(c_source)
                     c_source%include_dependencies(n_include)%s = &
                      &   split_n(file_lines(i)%s,n=2,delims='"',stat=stat)
                     if (stat /= 0) then
-                        call file_parse_error(error,c_filename,i, &
-                            message='unable to get c include file')
+                        call file_parse_error(error,c_filename, &
+                            'unable to get c include file',i, &
+                            file_lines(i)%s,index(file_lines(i)%s,'"'))
                         return
                     end if
 

--- a/fpm/test/main.f90
+++ b/fpm/test/main.f90
@@ -4,6 +4,7 @@ program fpm_testing
     use testsuite, only : run_testsuite
     use test_toml, only : collect_toml
     use test_manifest, only : collect_manifest
+    use test_source_parsing, only : collect_source_parsing
     implicit none
     integer :: stat
     character(len=*), parameter :: fmt = '("#", *(1x, a))'
@@ -18,6 +19,14 @@ program fpm_testing
 
     write(error_unit, fmt) "Testing:", "fpm_manifest"
     call run_testsuite(collect_manifest, error_unit, stat)
+
+    if (stat > 0) then
+        write(error_unit, '(i0, 1x, a)') stat, "tests failed!"
+        error stop 1
+    end if
+
+    write(error_unit, fmt) "Testing:", "fpm_sources (parsing)"
+    call run_testsuite(collect_source_parsing, error_unit, stat)
 
     if (stat > 0) then
         write(error_unit, '(i0, 1x, a)') stat, "tests failed!"

--- a/fpm/test/test_source_parsing.f90
+++ b/fpm/test/test_source_parsing.f90
@@ -1,0 +1,621 @@
+!> Define tests for the `fpm_sources` module (parsing routines)
+module test_source_parsing
+    use testsuite, only : new_unittest, unittest_t, error_t, test_failed
+    use fpm_filesystem, only: get_temp_filename
+    use fpm_sources, only: parse_f_source, parse_c_source
+    use fpm_model, only: srcfile_t, FPM_UNIT_PROGRAM, FPM_UNIT_MODULE, &
+                         FPM_UNIT_SUBMODULE, FPM_UNIT_SUBPROGRAM, FPM_UNIT_CSOURCE
+    use fpm_strings, only: operator(.in.)
+    implicit none
+    private
+
+    public :: collect_source_parsing
+
+contains
+
+
+    !> Collect all exported unit tests
+    subroutine collect_source_parsing(testsuite)
+
+        !> Collection of tests
+        type(unittest_t), allocatable, intent(out) :: testsuite(:)
+
+        testsuite = [ &
+            & new_unittest("modules-used", test_modules_used), &
+            & new_unittest("intrinsic-modules-used", test_intrinsic_modules_used), &
+            & new_unittest("include-stmt", test_include_stmt), &
+            & new_unittest("module", test_module), &
+            & new_unittest("submodule", test_submodule), &
+            & new_unittest("submodule-ancestor", test_submodule_ancestor), &
+            & new_unittest("subprogram", test_subprogram), &
+            & new_unittest("csource", test_csource), &
+            & new_unittest("invalid-use-stmt", &
+                           test_invalid_use_stmt, should_fail=.true.), &
+            & new_unittest("invalid-include-stmt", &
+                           test_invalid_include_stmt, should_fail=.true.), &
+            & new_unittest("invalid-module", &
+                           test_invalid_module, should_fail=.true.), &
+            & new_unittest("invalid-submodule", &
+                           test_invalid_submodule, should_fail=.true.) &
+            ]
+
+    end subroutine collect_source_parsing
+
+
+    !> Check parsing of module 'USE' statements
+    subroutine test_modules_used(error)
+
+        !> Error handling
+        type(error_t), allocatable, intent(out) :: error
+
+        integer :: unit
+        character(:), allocatable :: temp_file
+        type(srcfile_t), allocatable :: f_source
+
+        allocate(temp_file, source=get_temp_filename())
+
+        open(file=temp_file, newunit=unit)
+        write(unit, '(a)') &
+            & 'program test', &
+            & ' use module_one', &
+            & ' use :: module_two', &
+            & ' use module_three, only: a, b, c', &
+            & ' use :: module_four, only: a => b', &
+            & '! use module_not_used', &
+            & ' implicit none', &
+            & 'end program test'
+        close(unit)
+
+        f_source = parse_f_source(temp_file,error)
+        if (allocated(error)) then
+            return
+        end if
+
+        if (f_source%unit_type /= FPM_UNIT_PROGRAM) then
+            call test_failed(error,'Wrong unit type detected - expecting FPM_UNIT_PROGRAM')
+            return
+        end if
+
+        if (size(f_source%modules_provided) /= 0) then
+            call test_failed(error,'Unexpected modules_provided - expecting zero')
+            return
+        end if
+
+        if (size(f_source%modules_used) /= 4) then
+            call test_failed(error,'Incorrect number of modules_used - expecting four')
+            return
+        end if
+
+        if (.not.('module_one' .in. f_source%modules_used)) then
+            call test_failed(error,'Missing module in modules_used')
+            return
+        end if
+
+        if (.not.('module_two' .in. f_source%modules_used)) then
+            call test_failed(error,'Missing module in modules_used')
+            return
+        end if
+
+        if (.not.('module_three' .in. f_source%modules_used)) then
+            call test_failed(error,'Missing module in modules_used')
+            return
+        end if
+
+        if (.not.('module_four' .in. f_source%modules_used)) then
+            call test_failed(error,'Missing module in modules_used')
+            return
+        end if
+
+        if ('module_not_used' .in. f_source%modules_used) then
+            call test_failed(error,'Commented module found in modules_used')
+            return
+        end if
+
+    end subroutine test_modules_used
+
+
+    !> Check that intrinsic modules are properly ignore
+    subroutine test_intrinsic_modules_used(error)
+
+        !> Error handling
+        type(error_t), allocatable, intent(out) :: error
+
+        integer :: unit
+        character(:), allocatable :: temp_file
+        type(srcfile_t), allocatable :: f_source
+
+        allocate(temp_file, source=get_temp_filename())
+
+        open(file=temp_file, newunit=unit)
+        write(unit, '(a)') &
+            & 'program test', &
+            & ' use iso_c_binding', &
+            & ' use iso_fortran_env', &
+            & ' use ieee_arithmetic', &
+            & ' use ieee_exceptions', &
+            & ' use ieee_features', &
+            & ' implicit none', &
+            & 'end program test'
+        close(unit)
+
+        f_source = parse_f_source(temp_file,error)
+        if (allocated(error)) then
+            return
+        end if
+
+        if (size(f_source%modules_provided) /= 0) then
+            call test_failed(error,'Unexpected modules_provided - expecting zero')
+            return
+        end if
+
+        if (size(f_source%modules_used) /= 0) then
+            call test_failed(error,'Incorrect number of modules_used - expecting zero')
+            return
+        end if
+
+        if ('iso_c_binding' .in. f_source%modules_used) then
+            call test_failed(error,'Intrinsic module found in modules_used')
+            return
+        end if
+
+        if ('iso_fortran_env' .in. f_source%modules_used) then
+            call test_failed(error,'Intrinsic module found in modules_used')
+            return
+        end if
+
+        if ('ieee_arithmetic' .in. f_source%modules_used) then
+            call test_failed(error,'Intrinsic module found in modules_used')
+            return
+        end if
+
+        if ('ieee_exceptions' .in. f_source%modules_used) then
+            call test_failed(error,'Intrinsic module found in modules_used')
+            return
+        end if
+
+        if ('ieee_features' .in. f_source%modules_used) then
+            call test_failed(error,'Intrinsic module found in modules_used')
+            return
+        end if
+
+    end subroutine test_intrinsic_modules_used
+
+
+    !> Check parsing of include statements
+    subroutine test_include_stmt(error)
+
+        !> Error handling
+        type(error_t), allocatable, intent(out) :: error
+
+        integer :: unit
+        character(:), allocatable :: temp_file
+        type(srcfile_t), allocatable :: f_source
+
+        allocate(temp_file, source=get_temp_filename())
+
+        open(file=temp_file, newunit=unit)
+        write(unit, '(a)') &
+            & 'program test', &
+            & ' implicit none', &
+            & ' include "included_file.f90"', &
+            & ' contains ', &
+            & '  include "second_include.f90"', &
+            & 'end program test'
+        close(unit)
+
+        f_source = parse_f_source(temp_file,error)
+        if (allocated(error)) then
+            return
+        end if
+
+        if (size(f_source%modules_provided) /= 0) then
+            call test_failed(error,'Unexpected modules_provided - expecting zero')
+            return
+        end if
+
+        if (size(f_source%modules_used) /= 0) then
+            call test_failed(error,'Incorrect number of modules_used - expecting zero')
+            return
+        end if
+
+        if (size(f_source%include_dependencies) /= 2) then
+            call test_failed(error,'Incorrect number of include_dependencies - expecting two')
+            return
+        end if
+
+        if (.not.('included_file.f90' .in. f_source%include_dependencies)) then
+            call test_failed(error,'Missing include file in include_dependencies')
+            return
+        end if
+
+        if (.not.('second_include.f90' .in. f_source%include_dependencies)) then
+            call test_failed(error,'Missing include file in include_dependencies')
+            return
+        end if
+
+    end subroutine test_include_stmt
+
+
+    !> Try to parse fortran module
+    subroutine test_module(error)
+
+        !> Error handling
+        type(error_t), allocatable, intent(out) :: error
+
+        integer :: unit
+        character(:), allocatable :: temp_file
+        type(srcfile_t), allocatable :: f_source
+
+        allocate(temp_file, source=get_temp_filename())
+
+        open(file=temp_file, newunit=unit)
+        write(unit, '(a)') &
+            & 'module  my_mod', &
+            & 'use module_one', &
+            & 'interface', &
+            & '  module subroutine f()', &
+            & 'end interface', &
+            & 'contains', &
+            & 'module procedure f()', &
+            & 'end procedure f', &
+            & 'end submodule test'
+        close(unit)
+
+        f_source = parse_f_source(temp_file,error)
+        if (allocated(error)) then
+            return
+        end if
+
+        if (f_source%unit_type /= FPM_UNIT_MODULE) then
+            call test_failed(error,'Wrong unit type detected - expecting FPM_UNIT_MODULE')
+            return
+        end if
+
+        if (size(f_source%modules_provided) /= 1) then
+            call test_failed(error,'Unexpected modules_provided - expecting one')
+            return
+        end if
+
+        if (size(f_source%modules_used) /= 1) then
+            call test_failed(error,'Incorrect number of modules_used - expecting one')
+            return
+        end if
+
+        if (.not.('my_mod' .in. f_source%modules_provided)) then
+            call test_failed(error,'Missing module in modules_provided')
+            return
+        end if
+
+        if (.not.('module_one' .in. f_source%modules_used)) then
+            call test_failed(error,'Missing parent module in modules_used')
+            return
+        end if
+
+    end subroutine test_module
+
+
+    !> Try to parse fortran submodule for ancestry
+    subroutine test_submodule(error)
+
+        !> Error handling
+        type(error_t), allocatable, intent(out) :: error
+
+        integer :: unit
+        character(:), allocatable :: temp_file
+        type(srcfile_t), allocatable :: f_source
+
+        allocate(temp_file, source=get_temp_filename())
+
+        open(file=temp_file, newunit=unit)
+        write(unit, '(a)') &
+            & 'submodule (parent) :: child', &
+            & 'use module_one', &
+            & 'end submodule test'
+        close(unit)
+
+        f_source = parse_f_source(temp_file,error)
+        if (allocated(error)) then
+            return
+        end if
+
+        if (f_source%unit_type /= FPM_UNIT_SUBMODULE) then
+            call test_failed(error,'Wrong unit type detected - expecting FPM_UNIT_SUBMODULE')
+            return
+        end if
+
+        if (size(f_source%modules_provided) /= 0) then
+            call test_failed(error,'Unexpected modules_provided - expecting zero')
+            return
+        end if
+
+        if (size(f_source%modules_used) /= 2) then
+            call test_failed(error,'Incorrect number of modules_used - expecting two')
+            return
+        end if
+
+        if (.not.('module_one' .in. f_source%modules_used)) then
+            call test_failed(error,'Missing module in modules_used')
+            return
+        end if
+
+        if (.not.('parent' .in. f_source%modules_used)) then
+            call test_failed(error,'Missing parent module in modules_used')
+            return
+        end if
+
+    end subroutine test_submodule
+
+
+    !> Try to parse fortran multi-level submodule for ancestry
+    subroutine test_submodule_ancestor(error)
+
+        !> Error handling
+        type(error_t), allocatable, intent(out) :: error
+
+        integer :: unit
+        character(:), allocatable :: temp_file
+        type(srcfile_t), allocatable :: f_source
+
+        allocate(temp_file, source=get_temp_filename())
+
+        open(file=temp_file, newunit=unit)
+        write(unit, '(a)') &
+            & 'submodule (ancestor:parent) :: child', &
+            & 'use module_one', &
+            & 'end submodule test'
+        close(unit)
+
+        f_source = parse_f_source(temp_file,error)
+        if (allocated(error)) then
+            return
+        end if
+
+        if (f_source%unit_type /= FPM_UNIT_SUBMODULE) then
+            call test_failed(error,'Wrong unit type detected - expecting FPM_UNIT_SUBMODULE')
+            return
+        end if
+
+        if (size(f_source%modules_provided) /= 0) then
+            call test_failed(error,'Unexpected modules_provided - expecting zero')
+            return
+        end if
+
+        if (size(f_source%modules_used) /= 2) then
+            call test_failed(error,'Incorrect number of modules_used - expecting two')
+            return
+        end if
+
+        if (.not.('module_one' .in. f_source%modules_used)) then
+            call test_failed(error,'Missing module in modules_used')
+            return
+        end if
+
+        if (.not.('parent' .in. f_source%modules_used)) then
+            call test_failed(error,'Missing parent module in modules_used')
+            return
+        end if
+
+    end subroutine test_submodule_ancestor
+
+
+    !> Try to parse standard fortran sub-program (non-module) source
+    subroutine test_subprogram(error)
+
+        !> Error handling
+        type(error_t), allocatable, intent(out) :: error
+
+        integer :: unit
+        character(:), allocatable :: temp_file
+        type(srcfile_t), allocatable :: f_source
+
+        allocate(temp_file, source=get_temp_filename())
+
+        open(file=temp_file, newunit=unit)
+        write(unit, '(a)') &
+            & 'subroutine my_sub(a)', &
+            & ' use module_one', &
+            & ' integer, intent(in) :: a', &
+            & 'end subroutine my_sub'
+        close(unit)
+
+        f_source = parse_f_source(temp_file,error)
+        if (allocated(error)) then
+            return
+        end if
+
+        if (f_source%unit_type /= FPM_UNIT_SUBPROGRAM) then
+            call test_failed(error,'Wrong unit type detected - expecting FPM_UNIT_SUBPROGRAM')
+            return
+        end if
+
+        if (size(f_source%modules_provided) /= 0) then
+            call test_failed(error,'Unexpected modules_provided - expecting zero')
+            return
+        end if
+
+        if (size(f_source%modules_used) /= 1) then
+            call test_failed(error,'Incorrect number of modules_used - expecting one')
+            return
+        end if
+
+        if (.not.('module_one' .in. f_source%modules_used)) then
+            call test_failed(error,'Missing module in modules_used')
+            return
+        end if
+
+    end subroutine test_subprogram
+
+
+    !> Try to parse standard c source for includes
+    subroutine test_csource(error)
+
+        !> Error handling
+        type(error_t), allocatable, intent(out) :: error
+
+        integer :: unit
+        character(:), allocatable :: temp_file
+        type(srcfile_t), allocatable :: f_source
+
+        allocate(temp_file, source=get_temp_filename())
+        temp_file = temp_file//'.c'
+
+        open(file=temp_file, newunit=unit)
+        write(unit, '(a)') &
+            & '#include "proto.h"', &
+            & 'void c_func(int a) {', &
+            & ' #include "function_body.c"', &
+            & ' return', &
+            & '}'
+        close(unit)
+
+        f_source = parse_c_source(temp_file,error)
+        if (allocated(error)) then
+            return
+        end if
+
+        if (f_source%unit_type /= FPM_UNIT_CSOURCE) then
+            call test_failed(error,'Wrong unit type detected - expecting FPM_UNIT_CSOURCE')
+            return
+        end if
+
+        if (size(f_source%modules_provided) /= 0) then
+            call test_failed(error,'Unexpected modules_provided - expecting zero')
+            return
+        end if
+
+        if (size(f_source%modules_used) /= 0) then
+            call test_failed(error,'Incorrect number of modules_used - expecting zero')
+            return
+        end if
+
+        if (size(f_source%include_dependencies) /= 2) then
+            call test_failed(error,'Incorrect number of include_dependencies - expecting two')
+            return
+        end if
+
+        if (.not.('proto.h' .in. f_source%include_dependencies)) then
+            call test_failed(error,'Missing file in include_dependencies')
+            return
+        end if
+
+        if (.not.('function_body.c' .in. f_source%include_dependencies)) then
+            call test_failed(error,'Missing file in include_dependencies')
+            return
+        end if
+
+    end subroutine test_csource
+
+    
+    !> Try to parse fortran program with invalid use statement
+    subroutine test_invalid_use_stmt(error)
+
+        !> Error handling
+        type(error_t), allocatable, intent(out) :: error
+
+        integer :: unit
+        character(:), allocatable :: temp_file
+        type(srcfile_t), allocatable :: f_source
+
+        allocate(temp_file, source=get_temp_filename())
+
+        open(file=temp_file, newunit=unit)
+        write(unit, '(a)') &
+            & 'program test', &
+            & 'use module_one', &
+            & 'use :: ', &
+            & 'end program test'
+        close(unit)
+
+        f_source = parse_f_source(temp_file,error)
+        if (allocated(error)) then
+            return
+        end if
+
+    end subroutine test_invalid_use_stmt
+
+
+    !> Try to parse fortran program with invalid use statement
+    subroutine test_invalid_include_stmt(error)
+
+        !> Error handling
+        type(error_t), allocatable, intent(out) :: error
+
+        integer :: unit
+        character(:), allocatable :: temp_file
+        type(srcfile_t), allocatable :: f_source
+
+        allocate(temp_file, source=get_temp_filename())
+
+        open(file=temp_file, newunit=unit)
+        write(unit, '(a)') &
+            & 'program test', &
+            & ' include "', &
+            & 'end program test'
+        close(unit)
+
+        f_source = parse_f_source(temp_file,error)
+        if (allocated(error)) then
+            return
+        end if
+
+    end subroutine test_invalid_include_stmt
+
+
+    !> Try to parse incorrect fortran module syntax
+    subroutine test_invalid_module(error)
+
+        !> Error handling
+        type(error_t), allocatable, intent(out) :: error
+
+        integer :: unit
+        character(:), allocatable :: temp_file
+        type(srcfile_t), allocatable :: f_source
+
+        allocate(temp_file, source=get_temp_filename())
+
+        open(file=temp_file, newunit=unit)
+        write(unit, '(a)') &
+            & 'module :: my_mod', &
+            & 'end module test'
+        close(unit)
+
+        f_source = parse_f_source(temp_file,error)
+        if (allocated(error)) then
+            return
+        end if
+
+        write(*,*) '"',f_source%modules_used(1)%s,'"'
+
+    end subroutine test_invalid_module
+
+
+    !> Try to parse incorrect fortran submodule syntax
+    subroutine test_invalid_submodule(error)
+
+        !> Error handling
+        type(error_t), allocatable, intent(out) :: error
+
+        integer :: unit
+        character(:), allocatable :: temp_file
+        type(srcfile_t), allocatable :: f_source
+
+        allocate(temp_file, source=get_temp_filename())
+
+        open(file=temp_file, newunit=unit)
+        write(unit, '(a)') &
+            & 'submodule :: child', &
+            & 'end submodule test'
+        close(unit)
+
+        f_source = parse_f_source(temp_file,error)
+        if (allocated(error)) then
+            return
+        end if
+
+        write(*,*) '"',f_source%modules_used(1)%s,'"'
+
+    end subroutine test_invalid_submodule
+
+
+
+end module test_source_parsing


### PR DESCRIPTION
As discussed in #155, this uses the `error_t` type to return and propagate errors from the new source parsing routines.
Adds a test suite for the parsing routines - any difficult parsing edge cases can be added in there as they are found.

There are other regions from #155 that still require test coverage.