### PR TITLE
Cache Haskell stack build in CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -19,6 +19,21 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         gcc_v: [9] # Version of GFortran we want to use.
+        include:
+        - os: ubuntu-latest
+          STACK_CACHE: "/home/runner/.stack/"
+          STACK_CACHE_VERSION: ""
+        - os: macos-latest
+          STACK_CACHE: |
+           /Users/runner/.stack/snapshots
+           /Users/runner/.stack/setup-exe-src
+          STACK_CACHE_VERSION: "v2"
+        - os: windows-latest
+          STACK_CACHE: |
+           C:\Users\runneradmin\AppData\Roaming\stack
+           C:\Users\runneradmin\AppData\Local\Programs\stack
+          STACK_CACHE_VERSION: "v2"
+
     env:
       FC: gfortran
       GCC_V: ${{ matrix.gcc_v }}
@@ -60,6 +75,19 @@ jobs:
         sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-${GCC_V} 100 \
         --slave /usr/bin/gfortran gfortran /usr/bin/gfortran-${GCC_V} \
         --slave /usr/bingcov gcov /usr/bin/gcov-${GCC_V}
+
+    - name: Get Time
+      id: time
+      uses: nanzm/get-time-action@v1.0
+      with:
+        format: 'YYYY-MM'
+          
+    - name: Setup github actions cache
+      id: cache
+      uses: actions/cache@v2
+      with:
+        path: ${{matrix.STACK_CACHE}}
+        key: ${{ runner.os }}-${{ steps.time.outputs.time }}${{matrix.STACK_CACHE_VERSION}}
 
     - name: Build Haskell fpm
       run: |


### PR DESCRIPTION
Waiting up to 10min for the CI is a bit of a nuisance; especially when you rely on it for platforms you can't test yourself like MacOS.

I've played around with [actions/cache](https://github.com/actions/cache) on my own fork to cache the Haskell stack build, and managed to drop CI times down to between 1min for Ubuntu and 3min for Windows, see [this run for example](https://github.com/LKedward/fpm/runs/1106056906).

- On the first run, the CI will cache stack build files (in `/home/runner/.stack/` on Ubuntu), and reuse this cache at subsequent CI runs.

- The `stack build` command is still executed so any updates to Haskell fpm and its dependencies are still compiled each time.

- The cache is reset:
  - after a week of no CI runs;
  - if the `STACK_CACHE_VERSION` is changed manually in the workflow file;
  - every month otherwise.

