### PR TITLE
Add more example packages

### DIFF
--- a/ci/run_tests.bat
+++ b/ci/run_tests.bat
@@ -52,3 +52,10 @@ if errorlevel 1 exit 1
 
 .\build\gfortran_debug\app\with_c
 if errorlevel 1 exit 1
+
+
+cd ..\submodules
+if errorlevel 1 exit 1
+
+..\..\..\fpm\build\gfortran_debug\app\fpm build
+if errorlevel 1 exit 1

--- a/ci/run_tests.bat
+++ b/ci/run_tests.bat
@@ -42,3 +42,13 @@ if errorlevel 1 exit 1
 
 .\build\gfortran_debug\test\farewell_test
 if errorlevel 1 exit 1
+
+
+cd ..\with_c
+if errorlevel 1 exit 1
+
+..\..\..\fpm\build\gfortran_debug\app\fpm build
+if errorlevel 1 exit 1
+
+.\build\gfortran_debug\app\with_c
+if errorlevel 1 exit 1

--- a/ci/run_tests.sh
+++ b/ci/run_tests.sh
@@ -22,3 +22,6 @@ cd ../hello_complex
 cd ../with_c
 ../../../fpm/build/gfortran_debug/app/fpm build
 ./build/gfortran_debug/app/with_c
+
+cd ../submodules
+../../../fpm/build/gfortran_debug/app/fpm build

--- a/ci/run_tests.sh
+++ b/ci/run_tests.sh
@@ -18,3 +18,7 @@ cd ../hello_complex
 ./build/gfortran_debug/app/say_goodbye
 ./build/gfortran_debug/test/greet_test
 ./build/gfortran_debug/test/farewell_test
+
+cd ../with_c
+../../../fpm/build/gfortran_debug/app/fpm build
+./build/gfortran_debug/app/with_c

--- a/fpm/src/fpm_sources.f90
+++ b/fpm/src/fpm_sources.f90
@@ -310,7 +310,7 @@ function parse_f_source(f_filename,error) result(f_source)
                 if (.not.validate_name(mod_name)) then
                     call file_parse_error(error,f_filename, &
                           'empty or invalid name for module',i, &
-                          file_lines(i)%s)
+                          file_lines(i)%s, index(file_lines(i)%s,mod_name))
                     return
                 end if
 
@@ -326,6 +326,22 @@ function parse_f_source(f_filename,error) result(f_source)
 
             ! Extract name of submodule if is submodule
             if (index(adjustl(lower(file_lines(i)%s)),'submodule') == 1) then
+
+                mod_name = split_n(file_lines(i)%s,n=3,delims='()',stat=stat)
+                if (stat /= 0) then
+                    call file_parse_error(error,f_filename, &
+                          'unable to get submodule name',i, &
+                          file_lines(i)%s)
+                    return
+                end if
+                if (.not.validate_name(mod_name)) then
+                    call file_parse_error(error,f_filename, &
+                          'empty or invalid name for submodule',i, &
+                          file_lines(i)%s, index(file_lines(i)%s,mod_name))
+                    return
+                end if
+
+                n_mod = n_mod + 1
 
                 temp_string = split_n(file_lines(i)%s,n=2,delims='()',stat=stat)
                 if (stat /= 0) then
@@ -347,14 +363,16 @@ function parse_f_source(f_filename,error) result(f_source)
                         
                     end if
 
-                    f_source%modules_used(n_use)%s = lower(temp_string)
-
                     if (.not.validate_name(temp_string)) then
                         call file_parse_error(error,f_filename, &
                           'empty or invalid name for submodule parent',i, &
                           file_lines(i)%s, index(file_lines(i)%s,temp_string))
                         return
                     end if
+
+                    f_source%modules_used(n_use)%s = lower(temp_string)
+
+                    f_source%modules_provided(n_mod)%s = lower(mod_name)
 
                 end if
 

--- a/fpm/src/fpm_sources.f90
+++ b/fpm/src/fpm_sources.f90
@@ -526,7 +526,7 @@ function split_n(string,delims,n,stat) result(substring)
         return
     end if
 
-    substring = trim(string_parts(i))
+    substring = trim(adjustl(string_parts(i)))
     stat = 0
 
 end function split_n
@@ -553,6 +553,7 @@ subroutine resolve_module_dependencies(sources)
 
             if (.not.associated(sources(i)%file_dependencies(j)%ptr)) then
                 write(*,*) '(!) Unable to find source for module dependency: ',sources(i)%modules_used(j)%s
+                write(*,*) '    for file ',sources(i)%file_name
                 ! stop
             end if
 

--- a/fpm/test/test_source_parsing.f90
+++ b/fpm/test/test_source_parsing.f90
@@ -308,7 +308,7 @@ contains
 
         open(file=temp_file, newunit=unit)
         write(unit, '(a)') &
-            & 'submodule (parent) :: child', &
+            & 'submodule (parent) child', &
             & 'use module_one', &
             & 'end submodule test'
         close(unit)
@@ -323,13 +323,18 @@ contains
             return
         end if
 
-        if (size(f_source%modules_provided) /= 0) then
-            call test_failed(error,'Unexpected modules_provided - expecting zero')
+        if (size(f_source%modules_provided) /= 1) then
+            call test_failed(error,'Unexpected modules_provided - expecting one')
             return
         end if
 
         if (size(f_source%modules_used) /= 2) then
             call test_failed(error,'Incorrect number of modules_used - expecting two')
+            return
+        end if
+
+        if (.not.('child' .in. f_source%modules_provided)) then
+            call test_failed(error,'Missing module in modules_provided')
             return
         end if
 
@@ -360,7 +365,7 @@ contains
 
         open(file=temp_file, newunit=unit)
         write(unit, '(a)') &
-            & 'submodule (ancestor:parent) :: child', &
+            & 'submodule (ancestor:parent) child', &
             & 'use module_one', &
             & 'end submodule test'
         close(unit)
@@ -375,13 +380,18 @@ contains
             return
         end if
 
-        if (size(f_source%modules_provided) /= 0) then
-            call test_failed(error,'Unexpected modules_provided - expecting zero')
+        if (size(f_source%modules_provided) /= 1) then
+            call test_failed(error,'Unexpected modules_provided - expecting one')
             return
         end if
 
         if (size(f_source%modules_used) /= 2) then
             call test_failed(error,'Incorrect number of modules_used - expecting two')
+            return
+        end if
+
+        if (.not.('child' .in. f_source%modules_provided)) then
+            call test_failed(error,'Missing module in modules_provided')
             return
         end if
 

--- a/test/example_packages/README.md
+++ b/test/example_packages/README.md
@@ -1,0 +1,17 @@
+# Example packages
+
+See the table below for a list of the example packages provided in this directory including
+the features demonstrated in each package and which versions of fpm are supported.
+
+
+| Name             | Features                                                      | Bootstrap (Haskell) fpm | fpm |
+|------------------|---------------------------------------------------------------|:-----------------------:|:---:|
+| circular_example | Local path dependency; circular dependency                    |            Y            |  N  |
+| circular_test    | Local path dependency; circular dependency                    |            Y            |  N  |
+| hello_complex    | Non-standard directory layout; multiple tests and executables |            Y            |  Y  |
+| hello_fpm        | App-only; local path dependency                               |            Y            |  N  |
+| hello_world      | App-only                                                      |            Y            |  Y  |
+| makefile_complex | External build command (makefile); local path dependency      |            Y            |  N  |
+| submodules       | Lib-only; submodules (3 levels)                               |            N            |  Y  |
+| with_c           | Compile with `c` source files                                 |            N            |  Y  |
+| with_makefile    | External build command (makefile)                             |            Y            |  N  |

--- a/test/example_packages/submodules/fpm.toml
+++ b/test/example_packages/submodules/fpm.toml
@@ -1,0 +1,1 @@
+name = "submodules"

--- a/test/example_packages/submodules/src/child1.f90
+++ b/test/example_packages/submodules/src/child1.f90
@@ -1,0 +1,16 @@
+submodule(parent) child1
+implicit none
+
+interface
+    module function my_fun() result (b)
+        integer :: b
+    end function my_fun
+end interface
+
+contains
+
+module procedure my_sub1
+    a = 1
+end procedure my_sub1
+
+end submodule child1

--- a/test/example_packages/submodules/src/child2.f90
+++ b/test/example_packages/submodules/src/child2.f90
@@ -1,0 +1,10 @@
+submodule(parent) child2
+implicit none
+
+contains
+
+module procedure my_sub2
+    a = 2
+end procedure my_sub2
+
+end submodule child2

--- a/test/example_packages/submodules/src/grandchild.f90
+++ b/test/example_packages/submodules/src/grandchild.f90
@@ -1,0 +1,10 @@
+submodule(parent:child1) grandchild
+implicit none
+
+contains
+
+module procedure my_fun
+    b = 2
+end procedure my_fun
+
+end submodule grandchild

--- a/test/example_packages/submodules/src/parent.f90
+++ b/test/example_packages/submodules/src/parent.f90
@@ -1,0 +1,15 @@
+module parent
+implicit none
+
+interface
+
+    module subroutine my_sub1(a)
+        integer, intent(out) :: a
+    end subroutine my_sub1
+
+    module subroutine my_sub2(a)
+        integer, intent(out) :: a
+    end subroutine my_sub2
+end interface
+
+end module parent

--- a/test/example_packages/with_c/app/main.f90
+++ b/test/example_packages/with_c/app/main.f90
@@ -1,0 +1,10 @@
+program with_c_app
+use with_c
+implicit none
+
+write(*,*) "isdir('app') = ", system_isdir('app')
+write(*,*) "isdir('src') = ", system_isdir('src')
+write(*,*) "isdir('test') = ", system_isdir('test')
+write(*,*) "isdir('bench') = ", system_isdir('bench')
+
+end program with_c_app

--- a/test/example_packages/with_c/fpm.toml
+++ b/test/example_packages/with_c/fpm.toml
@@ -1,0 +1,1 @@
+name = "with_c"

--- a/test/example_packages/with_c/src/c_code.c
+++ b/test/example_packages/with_c/src/c_code.c
@@ -1,0 +1,10 @@
+#include <sys/stat.h>
+/*
+ *  Decides whether a given file name is a directory.
+ *  return 1 if file exists and is a directory
+ *  Source (Public domain): https://github.com/urbanjost/M_system
+ */
+int my_isdir (const char *path) {
+   struct stat sb;
+   return stat(path, &sb) == 0 && S_ISDIR (sb.st_mode);
+}

--- a/test/example_packages/with_c/src/with_c.f90
+++ b/test/example_packages/with_c/src/with_c.f90
@@ -1,0 +1,26 @@
+module with_c
+    use iso_c_binding, only: c_char, c_int, c_null_char
+    implicit none
+
+contains
+
+    function system_isdir(dirname)
+        ! Source (Public domain): https://github.com/urbanjost/M_system
+        !
+        implicit none
+        character(len=*),intent(in) :: dirname
+        logical                     :: system_isdir
+        
+        interface
+            function c_isdir(dirname) bind (C,name="my_isdir") result (c_ierr)
+            import c_char,c_int
+            character(kind=c_char,len=1),intent(in) :: dirname(*)
+            integer(kind=c_int)                     :: c_ierr
+            end function c_isdir
+        end interface
+        
+        system_isdir= c_isdir(trim(dirname)//c_null_char) == 1
+        
+    end function system_isdir
+
+end module with_c


### PR DESCRIPTION
- Adds: new example package for including c code;
- Adds: new example package for using submodules;
- Adds: README describing each example package and supported fpm version;
- Fixes: parsing bug where submodule names were not added to `modules_provided` array;
- Fixes: parsing bug where leading spaces were not removed from parsed strings.
