### PR TITLE
Update: CI workflow

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -53,16 +53,18 @@ jobs:
       if: contains(matrix.os, 'macos')
       run: |
           mkdir /Users/runner/.local/bin
-          curl -L https://gist.github.com/certik/0e35f35753ae76f0f575d9b3d3f53633/raw/4cde02cc9215635c9401c2257a46be319e7ab6dd/osx-x86_64.tar.gz | tar xz --strip-components=1 --include '*/stack' -C /Users/runner/.local/bin
+          curl -L https://github.com/commercialhaskell/stack/releases/download/v2.3.3/stack-2.3.3-osx-x86_64.tar.gz | tar xz --strip-components=1 --include '*/stack' -C /Users/runner/.local/bin
 
     - name: Install Haskell Linux
       if: contains(matrix.os, 'ubuntu')
-      uses: mstksg/setup-stack@v1
+      run: |
+          mkdir -p /home/runner/.local/bin
+          curl -L https://github.com/commercialhaskell/stack/releases/download/v2.3.3/stack-2.3.3-linux-x86_64.tar.gz | tar --strip-components 1 --wildcards -xz */stack -C /home/runner/.local/bin
 
     - name: Install Haskell Windows
       if: contains(matrix.os, 'windows')
       run: |
-          (New-Object System.Net.WebClient).DownloadFile("https://get.haskellstack.org/stable/windows-x86_64.zip", "windows-x86_64.zip")
+          (New-Object System.Net.WebClient).DownloadFile("https://github.com/commercialhaskell/stack/releases/download/v2.3.3/stack-2.3.3-windows-x86_64.zip", "windows-x86_64.zip")
           mkdir stack-tmp
           cd stack-tmp
           unzip ..\windows-x86_64.zip

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -88,7 +88,7 @@ jobs:
     - name: put fpm to PATH (Linux)
       if: contains(matrix.os, 'ubuntu')
       run: |
-          cp /home/runner/.local/bin/fpm /usr/local/bin
+          sudo cp /home/runner/.local/bin/fpm /usr/local/bin
           
     - name: Run tests on Haskell fpm
       run: |

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -49,28 +49,6 @@ jobs:
           which gfortran-${GCC_V}
           which gfortran
 
-    - name: Install Haskell macOS
-      if: contains(matrix.os, 'macos')
-      run: |
-          mkdir /Users/runner/.local/bin
-          curl -L https://github.com/commercialhaskell/stack/releases/download/v2.3.3/stack-2.3.3-osx-x86_64.tar.gz | tar xz --strip-components=1 --include '*/stack' -C /Users/runner/.local/bin
-
-    - name: Install Haskell Linux
-      if: contains(matrix.os, 'ubuntu')
-      run: |
-          mkdir -p /home/runner/.local/bin
-          curl -L https://github.com/commercialhaskell/stack/releases/download/v2.3.3/stack-2.3.3-linux-x86_64.tar.gz | tar --strip-components 1 --wildcards -xz */stack -C /home/runner/.local/bin
-
-    - name: Install Haskell Windows
-      if: contains(matrix.os, 'windows')
-      run: |
-          (New-Object System.Net.WebClient).DownloadFile("https://github.com/commercialhaskell/stack/releases/download/v2.3.3/stack-2.3.3-windows-x86_64.zip", "windows-x86_64.zip")
-          mkdir stack-tmp
-          cd stack-tmp
-          unzip ..\windows-x86_64.zip
-          copy stack.exe "C:\Program Files\Git\usr\bin"
-          cd ..
-
     - name: Install GFortran Linux
       if: contains(matrix.os, 'ubuntu')
       run: |
@@ -107,6 +85,11 @@ jobs:
       run: |
           copy "C:\Users\runneradmin\AppData\Roaming\local\bin\fpm.exe" "C:\Program Files\Git\usr\bin"
 
+    - name: put fpm to PATH (Linux)
+      if: contains(matrix.os, 'ubuntu')
+      run: |
+          cp /home/runner/.local/bin/fpm /usr/local/bin
+          
     - name: Run tests on Haskell fpm
       run: |
         cd bootstrap


### PR DESCRIPTION
~Download stack from github releases page.~

It turns out that all three OSes on github actions have the latest release (2.3.3) of stack already installed. (See [here](https://github.com/actions/virtual-environments#available-environments)).
So I've simply removed the installation steps.