### PR TITLE
Source processing bug fixes

### DIFF
--- a/fpm/src/fpm_sources.f90
+++ b/fpm/src/fpm_sources.f90
@@ -300,21 +300,26 @@ function parse_f_source(f_filename,error) result(f_source)
             end if
 
             ! Process 'INCLUDE' statements
-            if (index(adjustl(lower(file_lines(i)%s)),'include') == 1) then
-    
-                n_include = n_include + 1
+            ic = index(adjustl(lower(file_lines(i)%s)),'include')
+            if ( ic == 1 ) then
+                ic = index(lower(file_lines(i)%s),'include')
+                if (index(adjustl(file_lines(i)%s(ic+7:)),'"') == 1 .or. &
+                    index(adjustl(file_lines(i)%s(ic+7:)),"'") == 1 ) then
 
-                if (pass == 2) then
-                    f_source%include_dependencies(n_include)%s = &
-                     & split_n(file_lines(i)%s,n=2,delims="'"//'"',stat=stat)
-                    if (stat /= 0) then
-                        call file_parse_error(error,f_filename, &
-                              'unable to find include file name',i, &
-                              file_lines(i)%s)
-                        return
+    
+                    n_include = n_include + 1
+
+                    if (pass == 2) then
+                        f_source%include_dependencies(n_include)%s = &
+                         & split_n(file_lines(i)%s,n=2,delims="'"//'"',stat=stat)
+                        if (stat /= 0) then
+                            call file_parse_error(error,f_filename, &
+                                  'unable to find include file name',i, &
+                                  file_lines(i)%s)
+                            return
+                        end if
                     end if
                 end if
-
             end if
 
             ! Extract name of module if is module

--- a/fpm/test/fpm_test/test_source_parsing.f90
+++ b/fpm/test/fpm_test/test_source_parsing.f90
@@ -198,11 +198,11 @@ contains
         write(unit, '(a)') &
             & 'program test', &
             & ' implicit none', &
-            & ' include "included_file.f90"', &
-            & ' logical :: include_comments', &
-            & ' include_comments = .false.', &
+            & ' include  "included_file.f90"', &
+            & ' character(*) :: include_comments', &
+            & ' include_comments = "some comments"', &
             & ' contains ', &
-            & '  include "second_include.f90"', &
+            & '  include"second_include.f90"', &
             & 'end program test'
         close(unit)
 

--- a/fpm/test/fpm_test/test_source_parsing.f90
+++ b/fpm/test/fpm_test/test_source_parsing.f90
@@ -199,6 +199,8 @@ contains
             & 'program test', &
             & ' implicit none', &
             & ' include "included_file.f90"', &
+            & ' logical :: include_comments', &
+            & ' include_comments = .false.', &
             & ' contains ', &
             & '  include "second_include.f90"', &
             & 'end program test'

--- a/test/example_packages/hello_complex_2/app/say_hello/app_hello_mod.f90
+++ b/test/example_packages/hello_complex_2/app/say_hello/app_hello_mod.f90
@@ -1,4 +1,6 @@
 module app_hello_mod
 implicit none
 
+integer :: hello_int = 42
+
 end module app_hello_mod


### PR DESCRIPTION
- Fixes bug where app modules are duplicated in the source list if auto-discovery is used and the app is specified in the manifest - this leads to duplicated symbols at linking;

- Fixes bug where `include` statements are incorrectly detected where there are none;

- Tests updated accordingly.