### PR TITLE
Create package manifest with toml-f build interface

### DIFF
--- a/fpm/fpm.toml
+++ b/fpm/fpm.toml
@@ -8,7 +8,7 @@ copyright = "2020 fpm contributors"
 [dependencies]
 [dependencies.toml-f]
 git = "https://github.com/toml-f/toml-f"
-tag = "v0.2"
+rev = "970a48997b0fd9d9b799d273cf2abab5ea1f5b7b"
 
 [dependencies.M_CLI2]
 git = "https://github.com/urbanjost/M_CLI2.git"

--- a/fpm/src/fpm/toml.f90
+++ b/fpm/src/fpm/toml.f90
@@ -14,11 +14,12 @@
 module fpm_toml
     use fpm_error, only : error_t, fatal_error, file_not_found_error
     use tomlf, only : toml_table, toml_array, toml_key, toml_stat, get_value, &
-        & set_value, toml_parse, toml_error, new_table, add_table, add_array, len
+        & set_value, toml_parse, toml_error, new_table, add_table, add_array, &
+        & toml_serializer, len
     implicit none
     private
 
-    public :: read_package_file
+    public :: read_package_file, write_package_file
     public :: toml_table, toml_array, toml_key, toml_stat, get_value, set_value
     public :: new_table, add_table, add_array, len
 
@@ -60,6 +61,46 @@ contains
         end if
 
     end subroutine read_package_file
+
+
+    !> Process the configuration file to a TOML data structure
+    subroutine write_package_file(table, manifest, error, overwrite)
+
+        !> TOML data structure
+        type(toml_table), intent(inout) :: table
+
+        !> Name of the package configuration file
+        character(len=*), intent(in) :: manifest
+
+        !> Error status of the operation
+        type(error_t), allocatable, intent(out) :: error
+
+        !> Overwrite existing files
+        logical, intent(in), optional :: overwrite
+
+        type(toml_serializer) :: ser
+        logical :: allow_overwrite, exist
+        integer :: unit
+
+        if (present(overwrite)) then
+            allow_overwrite = overwrite
+        else
+            allow_overwrite = .true.
+        end if
+
+        inquire(file=manifest, exist=exist)
+
+        if (.not.allow_overwrite .and. exist) then
+            call fatal_error(error, manifest//" already present, not overwriting")
+            return
+        end if
+
+        open(file=manifest, newunit=unit)
+        ser = toml_serializer(unit)
+        call table%accept(ser)
+        close(unit)
+
+    end subroutine write_package_file
 
 
 end module fpm_toml


### PR DESCRIPTION
I'm experimenting a bit with the `toml-f` build interface to create a package manifest, instead of having TOML documents inlined in the source code.

- [x] use build interface to create package manifest, instead of inlining
- [ ] each manifest type should know how to translate itself to TOML
- [ ] add constructors for each type to rapidly create a package manifest

To discuss:
- preferred style for package manifest (`toml-f` serializer is not style preserving, but serializer can be customized)
- for `fpm new` in case we find an existing manifest, we can (a) do nothing, (b) overwrite or (c) merge

Related:
- #201 requires fpm to rewrite the package manifest