### PR TITLE
Remove bashism from install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -19,14 +19,14 @@ else
   fi
 fi
 
-if [[ -x "$install_path/fpm" ]]; then
+if [ -x "$install_path/fpm" ]; then
   echo "Overwriting existing fpm installation in $install_path"
 fi
 
 cd bootstrap
 stack install
 
-if [[ -x "$install_path/fpm" ]]; then
+if [ -x "$install_path/fpm" ]; then
   echo "fpm installed successfully to $install_path"
 else
   echo "fpm installation unsuccessful: fpm not found in $install_path"


### PR DESCRIPTION
`/bin/sh` doesn't allow double square brackets so this pull request switches to single brackets