### PR TITLE
Allow extra section in manifest

### DIFF
--- a/fpm/src/fpm/manifest/package.f90
+++ b/fpm/src/fpm/manifest/package.f90
@@ -26,6 +26,8 @@
 !  [dev-dependencies]
 !  [[executable]]
 !  [[test]]
+!  [build]
+!  [extra]
 !  ```
 module fpm_manifest_package
     use fpm_manifest_build_config, only: build_config_t, new_build_config
@@ -209,7 +211,7 @@ contains
             case("version", "license", "author", "maintainer", "copyright", &
                     & "description", "keywords", "categories", "homepage", "build", &
                     & "dependencies", "dev-dependencies", "test", "executable", &
-                    & "library")
+                    & "library", "extra")
                 continue
 
             end select

--- a/manifest-reference.md
+++ b/manifest-reference.md
@@ -41,6 +41,8 @@ Every manifest file consists of the following sections:
     Project library dependencies
   - [*dev-dependencies*](#development-dependencies):
     Dependencies only needed for tests
+- [*extra*](#additional-information):
+  Free manifest section for additional information
 
 [TOML]: https://toml.io/
 
@@ -359,3 +361,11 @@ rev = "2f5eaba864ff630ba0c3791126a3f811b6e437f3"
 ### Development dependencies
 
 Development dependencies allow to declare *dev-dependencies* in the manifest root, which are available to all tests but not exported with the project.
+
+
+## Additional information
+
+The manifest also allows to specify additional information in the *extra* section.
+This section is not subject to any constraints by fpm and not used by fpm for any purpose.
+Third party tools can store additional information here.
+Also, the fpm registry can use this section to stage new entries for the manifest.


### PR DESCRIPTION
This PR adds an *extra* section to the package manifest. It is excluded from checks in Fortran fpm.

The general idea behind this section is:
- allow third party tools to store information in the package manifest
- stage new entries for the fpm registry without requiring a change in the manifest reference