### PR TITLE
Add workflow to build and deploy documentation

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,24 @@
+name: docs
+
+on: [push, pull_request]
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v1
+      with:
+        python-version: '3.x'
+    - name: Install dependencies
+      run: pip install ford
+    - name: Build Documentation
+      run: ford docs.md
+    - uses: JamesIves/github-pages-deploy-action@3.6.1
+      if: github.event_name == 'push' && github.repository == 'fortran-lang/fpm' && ( startsWith( github.ref, 'refs/tags/' ) || github.ref == 'refs/heads/master' )
+      with:
+        GITHUB_TOKEN: ${{ secrets.ACTIONS_DEPLOY_KEY }}
+        BRANCH: gh-pages
+        FOLDER: fpm-doc
+        CLEAN: true
+

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,7 +17,7 @@ jobs:
     - uses: JamesIves/github-pages-deploy-action@3.6.1
       if: github.event_name == 'push' && github.repository == 'fortran-lang/fpm' && ( startsWith( github.ref, 'refs/tags/' ) || github.ref == 'refs/heads/master' )
       with:
-        GITHUB_TOKEN: ${{ secrets.ACTIONS_DEPLOY_KEY }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         BRANCH: gh-pages
         FOLDER: fpm-doc
         CLEAN: true


### PR DESCRIPTION
Adds a workflow to build and deploy the fpm documentation (based on workflow I use in toml-f):

- build documentation with ford (branch and PR)
- deploy on master to branch gh-pages branch in same repository

**TODO**

- might require somebody with owner rights to add API-tokens