### PR TITLE
Fix docs CI failing #240

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,7 +14,7 @@ jobs:
       run: pip install ford
     - name: Build Documentation
       run: ford docs.md
-    - uses: JamesIves/github-pages-deploy-action@3.6.1
+    - uses: JamesIves/github-pages-deploy-action@3.7.1
       if: github.event_name == 'push' && github.repository == 'fortran-lang/fpm' && ( startsWith( github.ref, 'refs/tags/' ) || github.ref == 'refs/heads/master' )
       with:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
I didn't found any `set-env` command in the JamesIves repo (It is all typescript), so maybe bumping the version fixes the issue.
EDIT: yep that was it.