### PR TITLE
Fix CI to test release build

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -29,9 +29,10 @@ jobs:
           STACK_CACHE_VERSION: ""
           GET_VERSION_CMD: echo ${{ github.ref }} | cut -dv -f2
           CHECK_VERSION_CMD: grep $(cat fpm_version)
-          RELEASE_CMD: "fpm run $RELEASE_FLAGS --runner cp -- fpm-v$(cat fpm_version)-linux-x86_64"
+          RELEASE_CMD: "cp -- fpm-v$(cat fpm_version)-linux-x86_64"
           BOOTSTRAP_RELEASE_CMD: cp /home/runner/.local/bin/fpm fpm-bootstrap-v$(cat fpm_version)-linux-x86_64
           HASH_CMD: ls fpm-*|xargs -i{} sh -c 'sha256sum $1 > $1.sha256' -- {}
+          RELEASE_FLAGS: --flag --static --flag -g --flag -fbacktrace --flag -O3
 
         - os: macos-latest
           STACK_CACHE: |
@@ -40,9 +41,10 @@ jobs:
           STACK_CACHE_VERSION: "v2"
           GET_VERSION_CMD: echo ${{ github.ref }} | cut -dv -f2
           CHECK_VERSION_CMD: grep $(cat fpm_version)
-          RELEASE_CMD: "fpm run $RELEASE_FLAGS --runner cp -- fpm-v$(cat fpm_version)-macos-x86_64"
+          RELEASE_CMD: "cp -- fpm-v$(cat fpm_version)-macos-x86_64"
           BOOTSTRAP_RELEASE_CMD: cp /Users/runner/.local/bin/fpm fpm-bootstrap-v$(cat fpm_version)-macos-x86_64
           HASH_CMD: ls fpm-*|xargs -I{} sh -c 'shasum -a 256 $1 > $1.sha256' -- {}
+          RELEASE_FLAGS: --flag -g --flag -fbacktrace --flag -O3
 
         - os: windows-latest
           STACK_CACHE: |
@@ -51,14 +53,14 @@ jobs:
           STACK_CACHE_VERSION: "v2"
           GET_VERSION_CMD: ("${{ github.ref }}" -Split "v")[1]
           CHECK_VERSION_CMD: Select-String -Pattern Version | Where-Object { if ($_ -like -join("*",(Get-Content fpm_version),"*")) {echo $_} else {Throw} }
-          RELEASE_CMD: fpm run $RELEASE_FLAGS --runner copy -- (-join("fpm-v",(Get-Content fpm_version),"-windows-x86_64.exe"))
+          RELEASE_CMD: copy -- (-join("fpm-v",(Get-Content fpm_version),"-windows-x86_64.exe"))
           BOOTSTRAP_RELEASE_CMD: copy C:\Users\runneradmin\AppData\Roaming\local\bin\fpm.exe (-join("fpm-bootstrap-v",(Get-Content fpm_version),"-windows-x86_64.exe"))
           HASH_CMD: Get-ChildItem -File -Filter "fpm-*" | Foreach-Object {echo (Get-FileHash -Algorithm SHA256 $PSItem | Select-Object hash | Format-Table -HideTableHeaders | Out-String) > (-join($PSItem,".sha256"))}
+          RELEASE_FLAGS: --flag --static --flag -g --flag -fbacktrace --flag -O3
 
     env:
       FC: gfortran
       GCC_V: ${{ matrix.gcc_v }}
-      RELEASE_FLAGS: --flag -g --flag -fbacktrace --flag -O3
 
     steps:
     - name: Checkout code
@@ -121,13 +123,13 @@ jobs:
       if: contains(matrix.os, 'ubuntu') || contains(matrix.os, 'macos')
       run: |
         ci/run_tests.sh
-        ci/run_tests.sh ${{ env.RELEASE_FLAGS }}
+        ci/run_tests.sh ${{ matrix.RELEASE_FLAGS }}
 
     - name: Build and run Fortran fpm (Windows)
       if: contains(matrix.os, 'windows')
       run: |
         ci\run_tests.bat
-        ci\run_tests.bat ${{ env.RELEASE_FLAGS }}
+        ci\run_tests.bat ${{ matrix.RELEASE_FLAGS }}
 
     # ----- Upload binaries if creating a release -----
     - name: Check that fpm --version matches release tag
@@ -141,7 +143,7 @@ jobs:
       if: github.event_name == 'release'
       run: |
         cd fpm
-        ${{ matrix.RELEASE_CMD }}
+        fpm run ${{ matrix.RELEASE_FLAGS }} --runner ${{ matrix.RELEASE_CMD }}
         ${{ matrix.BOOTSTRAP_RELEASE_CMD }}
         ${{ matrix.HASH_CMD }}
     

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -29,7 +29,7 @@ jobs:
           STACK_CACHE_VERSION: ""
           GET_VERSION_CMD: echo ${{ github.ref }} | cut -dv -f2
           CHECK_VERSION_CMD: grep $(cat fpm_version)
-          RELEASE_CMD: "fpm run --flag --static --flag -g --flag -fbacktrace --flag -O3 --runner cp -- fpm-v$(cat fpm_version)-linux-x86_64"
+          RELEASE_CMD: "fpm run ${{ env.RELEASE_FLAGS }} --runner cp -- fpm-v$(cat fpm_version)-linux-x86_64"
           BOOTSTRAP_RELEASE_CMD: cp /home/runner/.local/bin/fpm fpm-bootstrap-v$(cat fpm_version)-linux-x86_64
           HASH_CMD: ls fpm-*|xargs -i{} sh -c 'sha256sum $1 > $1.sha256' -- {}
 
@@ -40,7 +40,7 @@ jobs:
           STACK_CACHE_VERSION: "v2"
           GET_VERSION_CMD: echo ${{ github.ref }} | cut -dv -f2
           CHECK_VERSION_CMD: grep $(cat fpm_version)
-          RELEASE_CMD: "fpm run --flag -g --flag -fbacktrace --flag -O3 --runner cp -- fpm-v$(cat fpm_version)-macos-x86_64"
+          RELEASE_CMD: "fpm run ${{ env.RELEASE_FLAGS }} --runner cp -- fpm-v$(cat fpm_version)-macos-x86_64"
           BOOTSTRAP_RELEASE_CMD: cp /Users/runner/.local/bin/fpm fpm-bootstrap-v$(cat fpm_version)-macos-x86_64
           HASH_CMD: ls fpm-*|xargs -I{} sh -c 'shasum -a 256 $1 > $1.sha256' -- {}
 
@@ -51,13 +51,14 @@ jobs:
           STACK_CACHE_VERSION: "v2"
           GET_VERSION_CMD: ("${{ github.ref }}" -Split "v")[1]
           CHECK_VERSION_CMD: Select-String -Pattern Version | Where-Object { if ($_ -like -join("*",(Get-Content fpm_version),"*")) {echo $_} else {Throw} }
-          RELEASE_CMD: fpm run --flag --static --flag -g --flag -fbacktrace --flag -O3 --runner copy -- (-join("fpm-v",(Get-Content fpm_version),"-windows-x86_64.exe"))
+          RELEASE_CMD: fpm run ${{ env.RELEASE_FLAGS }} --runner copy -- (-join("fpm-v",(Get-Content fpm_version),"-windows-x86_64.exe"))
           BOOTSTRAP_RELEASE_CMD: copy C:\Users\runneradmin\AppData\Roaming\local\bin\fpm.exe (-join("fpm-bootstrap-v",(Get-Content fpm_version),"-windows-x86_64.exe"))
           HASH_CMD: Get-ChildItem -File -Filter "fpm-*" | Foreach-Object {echo (Get-FileHash -Algorithm SHA256 $PSItem | Select-Object hash | Format-Table -HideTableHeaders | Out-String) > (-join($PSItem,".sha256"))}
 
     env:
       FC: gfortran
       GCC_V: ${{ matrix.gcc_v }}
+      RELEASE_FLAGS: --flag -g --flag -fbacktrace --flag -O3
 
     steps:
     - name: Checkout code
@@ -120,11 +121,13 @@ jobs:
       if: contains(matrix.os, 'ubuntu') || contains(matrix.os, 'macos')
       run: |
         ci/run_tests.sh
+        ci/run_tests.sh ${{ env.RELEASE_FLAGS }}
 
     - name: Build and run Fortran fpm (Windows)
       if: contains(matrix.os, 'windows')
       run: |
         ci\run_tests.bat
+        ci\run_tests.bat ${{ env.RELEASE_FLAGS }}
 
     # ----- Upload binaries if creating a release -----
     - name: Check that fpm --version matches release tag

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -27,6 +27,7 @@ jobs:
         - os: ubuntu-latest
           STACK_CACHE: "/home/runner/.stack/"
           STACK_CACHE_VERSION: ""
+          TEST_SCRIPT: ci/run_tests.sh
           GET_VERSION_CMD: echo ${{ github.ref }} | cut -dv -f2
           CHECK_VERSION_CMD: grep $(cat fpm_version)
           RELEASE_CMD: "cp -- fpm-v$(cat fpm_version)-linux-x86_64"
@@ -39,6 +40,7 @@ jobs:
            /Users/runner/.stack/snapshots
            /Users/runner/.stack/setup-exe-src
           STACK_CACHE_VERSION: "v2"
+          TEST_SCRIPT: ci/run_tests.sh
           GET_VERSION_CMD: echo ${{ github.ref }} | cut -dv -f2
           CHECK_VERSION_CMD: grep $(cat fpm_version)
           RELEASE_CMD: "cp -- fpm-v$(cat fpm_version)-macos-x86_64"
@@ -51,6 +53,7 @@ jobs:
            C:\Users\runneradmin\AppData\Roaming\stack
            C:\Users\runneradmin\AppData\Local\Programs\stack
           STACK_CACHE_VERSION: "v2"
+          TEST_SCRIPT: ci\run_tests.bat
           GET_VERSION_CMD: ("${{ github.ref }}" -Split "v")[1]
           CHECK_VERSION_CMD: Select-String -Pattern Version | Where-Object { if ($_ -like -join("*",(Get-Content fpm_version),"*")) {echo $_} else {Throw} }
           RELEASE_CMD: copy -- (-join("fpm-v",(Get-Content fpm_version),"-windows-x86_64.exe"))
@@ -119,17 +122,11 @@ jobs:
         cd bootstrap
         stack test
 
-    - name: Build and run Fortran fpm (Linux / macOS)
-      if: contains(matrix.os, 'ubuntu') || contains(matrix.os, 'macos')
-      run: |
-        ci/run_tests.sh
-        ci/run_tests.sh ${{ matrix.RELEASE_FLAGS }}
+    - name: Build and test Fortran fpm
+      run: ${{ matrix.TEST_SCRIPT }}
 
-    - name: Build and run Fortran fpm (Windows)
-      if: contains(matrix.os, 'windows')
-      run: |
-        ci\run_tests.bat
-        ci\run_tests.bat ${{ matrix.RELEASE_FLAGS }}
+    - name: Build and test Fortran fpm (release version)
+      run: ${{ matrix.TEST_SCRIPT }} ${{ matrix.RELEASE_FLAGS }}
 
     # ----- Upload binaries if creating a release -----
     - name: Check that fpm --version matches release tag

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -29,7 +29,7 @@ jobs:
           STACK_CACHE_VERSION: ""
           GET_VERSION_CMD: echo ${{ github.ref }} | cut -dv -f2
           CHECK_VERSION_CMD: grep $(cat fpm_version)
-          RELEASE_CMD: "fpm run ${{ env.RELEASE_FLAGS }} --runner cp -- fpm-v$(cat fpm_version)-linux-x86_64"
+          RELEASE_CMD: "fpm run $RELEASE_FLAGS --runner cp -- fpm-v$(cat fpm_version)-linux-x86_64"
           BOOTSTRAP_RELEASE_CMD: cp /home/runner/.local/bin/fpm fpm-bootstrap-v$(cat fpm_version)-linux-x86_64
           HASH_CMD: ls fpm-*|xargs -i{} sh -c 'sha256sum $1 > $1.sha256' -- {}
 
@@ -40,7 +40,7 @@ jobs:
           STACK_CACHE_VERSION: "v2"
           GET_VERSION_CMD: echo ${{ github.ref }} | cut -dv -f2
           CHECK_VERSION_CMD: grep $(cat fpm_version)
-          RELEASE_CMD: "fpm run ${{ env.RELEASE_FLAGS }} --runner cp -- fpm-v$(cat fpm_version)-macos-x86_64"
+          RELEASE_CMD: "fpm run $RELEASE_FLAGS --runner cp -- fpm-v$(cat fpm_version)-macos-x86_64"
           BOOTSTRAP_RELEASE_CMD: cp /Users/runner/.local/bin/fpm fpm-bootstrap-v$(cat fpm_version)-macos-x86_64
           HASH_CMD: ls fpm-*|xargs -I{} sh -c 'shasum -a 256 $1 > $1.sha256' -- {}
 
@@ -51,7 +51,7 @@ jobs:
           STACK_CACHE_VERSION: "v2"
           GET_VERSION_CMD: ("${{ github.ref }}" -Split "v")[1]
           CHECK_VERSION_CMD: Select-String -Pattern Version | Where-Object { if ($_ -like -join("*",(Get-Content fpm_version),"*")) {echo $_} else {Throw} }
-          RELEASE_CMD: fpm run ${{ env.RELEASE_FLAGS }} --runner copy -- (-join("fpm-v",(Get-Content fpm_version),"-windows-x86_64.exe"))
+          RELEASE_CMD: fpm run $RELEASE_FLAGS --runner copy -- (-join("fpm-v",(Get-Content fpm_version),"-windows-x86_64.exe"))
           BOOTSTRAP_RELEASE_CMD: copy C:\Users\runneradmin\AppData\Roaming\local\bin\fpm.exe (-join("fpm-bootstrap-v",(Get-Content fpm_version),"-windows-x86_64.exe"))
           HASH_CMD: Get-ChildItem -File -Filter "fpm-*" | Foreach-Object {echo (Get-FileHash -Algorithm SHA256 $PSItem | Select-Object hash | Format-Table -HideTableHeaders | Out-String) > (-join($PSItem,".sha256"))}
 

--- a/ci/run_tests.bat
+++ b/ci/run_tests.bat
@@ -3,18 +3,25 @@
 cd fpm
 if errorlevel 1 exit 1
 
-fpm build
+fpm build %*
 if errorlevel 1 exit 1
 
-fpm run
+fpm run %*
+if errorlevel 1 exit 1
+
+fpm run %* -- --help
+if errorlevel 1 exit 1
+
+fpm run %* -- --version
 if errorlevel 1 exit 1
 
 rmdir fpm_scratch_* /s /q
-fpm test
+fpm test %*
 if errorlevel 1 exit 1
 rmdir fpm_scratch_* /s /q
 
-for /f %%i in ('where /r build fpm.exe') do set fpm_path=%%i
+for /f %%i in ('fpm run %* --runner echo') do set fpm_path=%%i
+echo %fpm_path%
 
 %fpm_path%
 if errorlevel 1 exit 1
@@ -22,6 +29,7 @@ if errorlevel 1 exit 1
 cd ..\example_packages\hello_world
 if errorlevel 1 exit 1
 
+del /q /f build
 %fpm_path% build
 if errorlevel 1 exit 1
 
@@ -32,6 +40,7 @@ if errorlevel 1 exit 1
 cd ..\hello_fpm
 if errorlevel 1 exit 1
 
+del /q /f build
 %fpm_path% build
 if errorlevel 1 exit 1
 
@@ -42,6 +51,7 @@ if errorlevel 1 exit 1
 cd ..\circular_test
 if errorlevel 1 exit 1
 
+del /q /f build
 %fpm_path% build
 if errorlevel 1 exit 1
 
@@ -49,6 +59,7 @@ if errorlevel 1 exit 1
 cd ..\circular_example
 if errorlevel 1 exit 1
 
+del /q /f build
 %fpm_path% build
 if errorlevel 1 exit 1
 
@@ -56,6 +67,7 @@ if errorlevel 1 exit 1
 cd ..\hello_complex
 if errorlevel 1 exit 1
 
+del /q /f build
 %fpm_path% build
 if errorlevel 1 exit 1
 
@@ -75,6 +87,7 @@ if errorlevel 1 exit 1
 cd ..\hello_complex_2
 if errorlevel 1 exit 1
 
+del /q /f build
 %fpm_path% build
 if errorlevel 1 exit 1
 
@@ -93,6 +106,7 @@ if errorlevel 1 exit 1
 cd ..\auto_discovery_off
 if errorlevel 1 exit 1
 
+del /q /f build
 %fpm_path% build
 if errorlevel 1 exit 1
 
@@ -110,6 +124,7 @@ if exist .\build\gfortran_debug\test\unused_test exit /B 1
 cd ..\with_c
 if errorlevel 1 exit 1
 
+del /q /f build
 %fpm_path% build
 if errorlevel 1 exit 1
 
@@ -120,6 +135,7 @@ if errorlevel 1 exit 1
 cd ..\submodules
 if errorlevel 1 exit 1
 
+del /q /f build
 %fpm_path% build
 if errorlevel 1 exit 1
 
@@ -127,6 +143,7 @@ if errorlevel 1 exit 1
 cd ..\program_with_module
 if errorlevel 1 exit 1
 
+del /q /f build
 %fpm_path% build
 if errorlevel 1 exit 1
 
@@ -137,8 +154,11 @@ if errorlevel 1 exit 1
 cd ..\link_executable
 if errorlevel 1 exit 1
 
+del /q /f build
 %fpm_path% build
 if errorlevel 1 exit 1
 
 .\build\gfortran_debug\app\gomp_test
 if errorlevel 1 exit 1
+
+cd ..\..

--- a/ci/run_tests.sh
+++ b/ci/run_tests.sh
@@ -1,30 +1,26 @@
 #!/bin/bash
-
-get_abs_filename() {
-  # $1 : relative filename
-  filename=$1
-  parentdir=$(dirname "${filename}")
-
-  if [ -d "${filename}" ]; then
-      echo "$(cd "${filename}" && pwd)"
-  elif [ -d "${parentdir}" ]; then
-    echo "$(cd "${parentdir}" && pwd)/$(basename "${filename}")"
-  fi
-}
-
 set -ex
 
-cd fpm
-fpm build
-fpm run
+cd $(dirname $0)/../fpm
+
+fpm build $@
+
+# Run fpm executable
+fpm run $@
+fpm run $@ -- --version
+fpm run $@ -- --help
+
+# Run tests
 rm -rf fpm_scratch_*/
-fpm test
+fpm test $@
 rm -rf fpm_scratch_*/
 
-f_fpm_path="$(get_abs_filename $(find build -regex 'build/.*/app/fpm'))"
-"${f_fpm_path}"
+# Build example packages
+f_fpm_path="$(fpm run $@ --runner echo)"
+cd ../example_packages/
+rm -rf ./*/build
 
-cd ../example_packages/hello_world
+cd hello_world
 "${f_fpm_path}" build
 ./build/gfortran_debug/app/hello_world
 
@@ -77,3 +73,6 @@ cd ../link_external
 cd ../link_executable
 "${f_fpm_path}" build
 ./build/gfortran_debug/app/gomp_test
+
+# Cleanup
+rm -rf ./*/build

--- a/fpm/fpm.toml
+++ b/fpm/fpm.toml
@@ -1,5 +1,5 @@
 name = "fpm"
-version = "0.1.0"
+version = "0.1.1"
 license = "MIT"
 author = "fpm maintainers"
 maintainer = ""

--- a/fpm/fpm.toml
+++ b/fpm/fpm.toml
@@ -12,7 +12,7 @@ tag = "v0.2.1"
 
 [dependencies.M_CLI2]
 git = "https://github.com/urbanjost/M_CLI2.git"
-rev = "893cac0ce374bf07a70ffb9556439c7390e58131"
+rev = "e59fb2bfcf36199f1af506f937b3849180454a0f"
 
 [[test]]
 name = "cli-test"

--- a/fpm/src/fpm_command_line.f90
+++ b/fpm/src/fpm_command_line.f90
@@ -83,7 +83,7 @@ contains
             case default     ; os_type =  "OS Type:     UNKNOWN"
         end select
         version_text = [character(len=80) :: &
-         &  'Version:     0.1.0, Pre-alpha',                           &
+         &  'Version:     0.1.1, alpha',                           &
          &  'Program:     fpm(1)',                                     &
          &  'Description: A Fortran package manager and build system', &
          &  'Home Page:   https://github.com/fortran-lang/fpm',        &

--- a/fpm/src/fpm_strings.f90
+++ b/fpm/src/fpm_strings.f90
@@ -155,7 +155,7 @@ subroutine split(input_line,array,delimiters,order,nulls)
 
     select case (ilen)
 
-    case (:0)                                                      ! command was totally blank
+    case (0)                                                      ! command was totally blank
 
     case default                                                   ! there is at least one non-delimiter in INPUT_LINE if get here
         icol=1                                                      ! initialize pointer into input line


### PR DESCRIPTION
- Fixes the CI so that it also tests the release build
  - Arguments to the CI scripts are passed on to `fpm build`, `fpm run` and `fpm test` to parameterize the test scripts
- Fixes #254: workaround for compiler bug in Windows release build
  - Update `M_CLI2` revision to include upstream fix (<https://github.com/urbanjost/M_CLI2/pull/4>)

See [here](https://github.com/LKedward/fpm/runs/1474691833?check_suite_focus=true) for a successful workflow with the updated CI. (See [here](https://github.com/LKedward/fpm/runs/1474580272?check_suite_focus=true) for the same workflow run prior to applying the Windows fixes.)

Since this PR affects our CI checks and our release binaries, I think it should be prioritised over the several existing PRs, and I would be grateful for reviews.