### PR TITLE
Add -fcoarray=single to default gfortran flags

### DIFF
--- a/bootstrap/src/Fpm.hs
+++ b/bootstrap/src/Fpm.hs
@@ -639,6 +639,7 @@ defineCompilerSettings specifiedFlags compiler release
               , "-march=native"
               , "-ffast-math"
               , "-funroll-loops"
+              , "-fcoarray=single"
               ]
             else
               [ "-Wall"
@@ -650,6 +651,7 @@ defineCompilerSettings specifiedFlags compiler release
               , "-fbounds-check"
               , "-fcheck-array-temporaries"
               , "-fbacktrace"
+              , "-fcoarray=single"
               ]
           fs -> fs
     in  return $ CompilerSettings { compilerSettingsCompiler    = compiler


### PR DESCRIPTION
By adding this flag to the default set, fpm can at least compile code using coarray features by default if not actually run multiple images.