### PR TITLE
Fix enumeration of non-library link objects

### DIFF
--- a/example_packages/hello_complex_2/app/say_hello/app_extra_mod.f90
+++ b/example_packages/hello_complex_2/app/say_hello/app_extra_mod.f90
@@ -1,0 +1,6 @@
+module app_extra_mod
+implicit none
+
+character(len=5) :: greet_object = "World"
+
+end module app_extra_mod

--- a/example_packages/hello_complex_2/app/say_hello/app_hello_mod.f90
+++ b/example_packages/hello_complex_2/app/say_hello/app_hello_mod.f90
@@ -1,4 +1,5 @@
 module app_hello_mod
+use app_extra_mod, only: greet_object
 implicit none
 
 integer :: hello_int = 42

--- a/example_packages/hello_complex_2/app/say_hello/say_Hello.f90
+++ b/example_packages/hello_complex_2/app/say_hello/say_Hello.f90
@@ -1,8 +1,8 @@
 program say_Hello
     use greet_m, only: make_greeting
-    use app_hello_mod
+    use app_hello_mod, only: greet_object
 
     implicit none
 
-    print *, make_greeting("World")
+    print *, make_greeting(greet_object)
 end program say_Hello

--- a/fpm/src/fpm_targets.f90
+++ b/fpm/src/fpm_targets.f90
@@ -259,12 +259,14 @@ function find_module_dependency(targets,module_name,include_dir) result(target_p
 end function find_module_dependency
 
 
-!> For link targets, enumerate any dependency objects required for linking
+!> For libraries and executables, build a list of objects required for linking
+!>
+!> stored in `target%link_objects`
+!>
 subroutine resolve_target_linking(targets)
     type(build_target_ptr), intent(inout), target :: targets(:)
 
-    integer :: i,j,k
-    type(string_t) :: link_object
+    integer :: i
 
     do i=1,size(targets)
 
@@ -272,46 +274,65 @@ subroutine resolve_target_linking(targets)
 
             allocate(target%link_objects(0))
 
-            do j=1,size(target%dependencies)
-            
-                if (target%target_type == FPM_TARGET_ARCHIVE ) then
-            
-                    ! Construct object list for archive
-                    link_object%s = target%dependencies(j)%ptr%output_file
-                    target%link_objects = [target%link_objects, link_object]
-            
-                else if (target%target_type == FPM_TARGET_EXECUTABLE .and. &
-                        target%dependencies(j)%ptr%target_type ==  FPM_TARGET_OBJECT) then
-                    
-                    associate(exe_obj => target%dependencies(j)%ptr)
+            if (target%target_type == FPM_TARGET_ARCHIVE) then
 
-                        ! Construct object list for executable
-                        link_object%s = exe_obj%output_file
-                        target%link_objects = [target%link_objects, link_object]
-                            
-                        ! Include non-library object dependencies
-                        do k=1,size(exe_obj%dependencies)
-                
-                            if (allocated(exe_obj%dependencies(k)%ptr%source)) then
-                                if (exe_obj%dependencies(k)%ptr%source%unit_scope == &
-                                     exe_obj%source%unit_scope) then
+                call get_link_objects(target%link_objects,target,is_exe=.false.)
 
-                                    link_object%s = exe_obj%dependencies(k)%ptr%output_file
-                                    target%link_objects = [target%link_objects, link_object]
+            else if (target%target_type == FPM_TARGET_EXECUTABLE) then
 
-                                end if
-                            end if
-                
-                        end do
+                call get_link_objects(target%link_objects,target,is_exe=.true.)
 
-                    end associate
-            
-                end if
+            end if
 
-            end do
         end associate
 
     end do
+
+contains
+
+    !> Wrapper to build link object list
+    !>
+    !>  For libraries: just list dependency objects of lib target
+    !>
+    !>  For executables: need to recursively discover non-library
+    !>   dependency objects. (i.e. modules in same dir as program)
+    !>
+    recursive subroutine get_link_objects(link_objects,target,is_exe)
+        type(string_t), intent(inout), allocatable :: link_objects(:)
+        type(build_target_t), intent(in) :: target
+        logical, intent(in) :: is_exe
+
+        integer :: i
+        type(string_t) :: temp_str
+
+        if (.not.allocated(target%dependencies)) return
+
+        do i=1,size(target%dependencies)
+
+            associate(dep => target%dependencies(i)%ptr)
+            
+                if (.not.allocated(dep%source)) cycle
+                
+                ! Skip library dependencies for executable targets
+                !  since the library archive will always be linked 
+                if (is_exe.and.(dep%source%unit_scope == FPM_SCOPE_LIB)) cycle
+                
+                ! Skip if dependency object already listed
+                if (dep%output_file .in. link_objects) cycle
+
+                ! Add dependency object file to link object list
+                temp_str%s = dep%output_file
+                link_objects = [link_objects, temp_str]
+
+                ! For executable objects, also need to include non-library 
+                !  dependencies from dependencies (recurse)
+                if (is_exe) call get_link_objects(link_objects,dep,is_exe=.true.)
+            
+            end associate
+
+        end do
+
+    end subroutine get_link_objects
 
 end subroutine resolve_target_linking
 

--- a/fpm/test/fpm_test/test_module_dependencies.f90
+++ b/fpm/test/fpm_test/test_module_dependencies.f90
@@ -72,7 +72,6 @@ contains
         if (allocated(error)) then
             return
         end if
-        
         if (size(model%targets) /= 3) then
             call test_failed(error,'Incorrect number of model%targets - expecting three')
             return


### PR DESCRIPTION
- Fixes #263 caused by missing out some non-library dependencies in `link_objects` list for executable targets.
- Update target dependency test-suite to build and check the `link_objects` list for link targets
- Update `hello_complex_2` example package to include an indirectly use'd non-library module dependency

[iso_varying_string](https://gitlab.com/everythingfunctional/iso_varying_string) now builds with Fortran `fpm` and unit tests pass (`fpm test unit_test`).