### PR TITLE
Fix dependency tracking issue in bootstrap version

### DIFF
--- a/bootstrap/unit_test/ModuleToCompileInfoTest.hs
+++ b/bootstrap/unit_test/ModuleToCompileInfoTest.hs
@@ -3,7 +3,8 @@ module ModuleToCompileInfoTest
   )
 where
 
-import           BuildModel                     ( CompileTimeInfo(..)
+import           BuildModel                     ( AvailableModule(..)
+                                                , CompileTimeInfo(..)
                                                 , Source(..)
                                                 , constructCompileTimeInfo
                                                 )
@@ -43,10 +44,12 @@ exampleModule = Module
 moduleSourceFileName' :: FilePath
 moduleSourceFileName' = "some" </> "file" </> "somewhere.f90"
 
-availableModules :: [String]
-availableModules = ["module1", "module3"]
+availableModules :: [AvailableModule]
+availableModules = [ AvailableModule {availableModuleName = "module1", availableModuleFile = "build_dir" </> "module1.mod"}
+                   , AvailableModule {availableModuleName = "module3", availableModuleFile = "build_dir" </> "module3.mod"}
+                   ]
 
-doCompileTimeTransformation :: (Source, [String]) -> CompileTimeInfo
+doCompileTimeTransformation :: (Source, [AvailableModule]) -> CompileTimeInfo
 doCompileTimeTransformation (programSource, otherSources) =
   constructCompileTimeInfo programSource otherSources "build_dir"
 

--- a/bootstrap/unit_test/ProgramToCompileInfoTest.hs
+++ b/bootstrap/unit_test/ProgramToCompileInfoTest.hs
@@ -3,7 +3,8 @@ module ProgramToCompileInfoTest
   )
 where
 
-import           BuildModel                     ( CompileTimeInfo(..)
+import           BuildModel                     ( AvailableModule(..)
+                                                , CompileTimeInfo(..)
                                                 , Source(..)
                                                 , constructCompileTimeInfo
                                                 )
@@ -42,10 +43,12 @@ exampleProgram = Program
 programSourceFileName' :: FilePath
 programSourceFileName' = "some" </> "file" </> "somewhere.f90"
 
-availableModules :: [String]
-availableModules = ["module1", "module3"]
+availableModules :: [AvailableModule]
+availableModules = [ AvailableModule {availableModuleName = "module1", availableModuleFile = "build_dir" </> "module1.mod"}
+                   , AvailableModule {availableModuleName = "module3", availableModuleFile = "build_dir" </> "module3.mod"}
+                   ]
 
-doCompileTimeTransformation :: (Source, [String]) -> CompileTimeInfo
+doCompileTimeTransformation :: (Source, [AvailableModule]) -> CompileTimeInfo
 doCompileTimeTransformation (programSource, otherSources) =
   constructCompileTimeInfo programSource otherSources "build_dir"
 

--- a/bootstrap/unit_test/SubmoduleToCompileInfoTest.hs
+++ b/bootstrap/unit_test/SubmoduleToCompileInfoTest.hs
@@ -3,7 +3,8 @@ module SubmoduleToCompileInfoTest
   )
 where
 
-import           BuildModel                     ( CompileTimeInfo(..)
+import           BuildModel                     ( AvailableModule(..)
+                                                , CompileTimeInfo(..)
                                                 , Source(..)
                                                 , constructCompileTimeInfo
                                                 )
@@ -45,10 +46,12 @@ exampleSubmodule = Submodule
 submoduleSourceFileName' :: FilePath
 submoduleSourceFileName' = "some" </> "file" </> "somewhere.f90"
 
-availableModules :: [String]
-availableModules = ["module1", "module3"]
+availableModules :: [AvailableModule]
+availableModules = [ AvailableModule {availableModuleName = "module1", availableModuleFile = "build_dir" </> "module1.mod"}
+                   , AvailableModule {availableModuleName = "module3", availableModuleFile = "build_dir" </> "module3.mod"}
+                   ]
 
-doCompileTimeTransformation :: (Source, [String]) -> CompileTimeInfo
+doCompileTimeTransformation :: (Source, [AvailableModule]) -> CompileTimeInfo
 doCompileTimeTransformation (programSource, otherSources) =
   constructCompileTimeInfo programSource otherSources "build_dir"
 


### PR DESCRIPTION
The bootstrap version was not correctly marking library modules as dependencies in the compilation process, leading to improper partial rebuilds in some situations. This fixes that issue.