### PR TITLE
Fix Windows run and test commands

### DIFF
--- a/ci/run_tests.bat
+++ b/ci/run_tests.bat
@@ -36,6 +36,9 @@ if errorlevel 1 exit 1
 .\build\gfortran_debug\app\hello_world
 if errorlevel 1 exit 1
 
+%fpm_path% run
+if errorlevel 1 exit 1
+
 
 cd ..\hello_fpm
 if errorlevel 1 exit 1
@@ -69,6 +72,9 @@ if errorlevel 1 exit 1
 
 del /q /f build
 %fpm_path% build
+if errorlevel 1 exit 1
+
+%fpm_path% test
 if errorlevel 1 exit 1
 
 .\build\gfortran_debug\app\say_Hello

--- a/ci/run_tests.sh
+++ b/ci/run_tests.sh
@@ -23,6 +23,7 @@ rm -rf ./*/build
 cd hello_world
 "${f_fpm_path}" build
 ./build/gfortran_debug/app/hello_world
+"${f_fpm_path}" run
 
 cd ../hello_fpm
 "${f_fpm_path}" build
@@ -36,6 +37,7 @@ cd ../circular_example
 
 cd ../hello_complex
 "${f_fpm_path}" build
+"${f_fpm_path}" test
 ./build/gfortran_debug/app/say_Hello
 ./build/gfortran_debug/app/say_goodbye
 ./build/gfortran_debug/test/greet_test

--- a/fpm/fpm.toml
+++ b/fpm/fpm.toml
@@ -1,5 +1,5 @@
 name = "fpm"
-version = "0.1.1"
+version = "0.1.2"
 license = "MIT"
 author = "fpm maintainers"
 maintainer = ""

--- a/fpm/src/fpm.f90
+++ b/fpm/src/fpm.f90
@@ -171,7 +171,7 @@ subroutine build_model(model, settings, package, error)
     model%fortran_compiler = 'gfortran'
 
     if(settings%release)then
-        model%output_directory = 'build/gfortran_release'
+        model%output_directory = join_path('build','gfortran_release')
         model%fortran_compile_flags=' &
             & -O3 &
             & -Wimplicit-interface &
@@ -181,7 +181,7 @@ subroutine build_model(model, settings, package, error)
             & -funroll-loops ' // &
             & '-J'//join_path(model%output_directory,model%package_name)
     else
-        model%output_directory = 'build/gfortran_debug'
+        model%output_directory = join_path('build','gfortran_debug')
         model%fortran_compile_flags = ' -Wall -Wextra -Wimplicit-interface  -fPIC -fmax-errors=1 -g '// &
                                       '-fbounds-check -fcheck-array-temporaries -fbacktrace '// &
                                       '-J'//join_path(model%output_directory,model%package_name)

--- a/fpm/src/fpm_command_line.f90
+++ b/fpm/src/fpm_command_line.f90
@@ -83,7 +83,7 @@ contains
             case default     ; os_type =  "OS Type:     UNKNOWN"
         end select
         version_text = [character(len=80) :: &
-         &  'Version:     0.1.1, alpha',                           &
+         &  'Version:     0.1.2, alpha',                           &
          &  'Program:     fpm(1)',                                     &
          &  'Description: A Fortran package manager and build system', &
          &  'Home Page:   https://github.com/fortran-lang/fpm',        &


### PR DESCRIPTION
- Removes a hard-code forward-slash in the model definition. Fixes #269.
- Updates CI scripts to invoke `fpm run` and `fpm test` for the fortran implementation. Fixes #270.