### PR TITLE
Add support for same compilers as Fortran version to Haskell version

### DIFF
--- a/bootstrap/src/Build.hs
+++ b/bootstrap/src/Build.hs
@@ -75,7 +75,7 @@ buildProgram programDirectory' libraryDirectories sourceExtensions buildDirector
     libraryModules <- findAvailableModules libraryDirectories
     let programDirectory = foldl1 (</>) (splitDirectories programDirectory')
     let buildDirectory   = foldl1 (</>) (splitDirectories buildDirectory')
-    let includeFlags     = map (includeFlag ++) libraryDirectories
+    let includeFlags     = (includeFlag ++ buildDirectory) : map (includeFlag ++) libraryDirectories
     sourceFiles <- getDirectoriesFiles [programDirectory] sourceExtensions
     rawSources  <- mapM sourceFileToRawSource sourceFiles
     let sources' = map processRawSource rawSources
@@ -130,7 +130,7 @@ buildLibrary
 buildLibrary libraryDirectory sourceExtensions buildDirectory (CompilerSettings { compilerSettingsCompiler = compiler, compilerSettingsFlags = flags, compilerSettingsModuleFlag = moduleFlag, compilerSettingsIncludeFlag = includeFlag }) libraryName otherLibraryDirectories
   = do
     otherModules <- findAvailableModules otherLibraryDirectories
-    let includeFlags = map (includeFlag ++) otherLibraryDirectories
+    let includeFlags = (includeFlag ++ buildDirectory) : map (includeFlag ++) otherLibraryDirectories
     sourceFiles <- getDirectoriesFiles [libraryDirectory] sourceExtensions
     rawSources  <- mapM sourceFileToRawSource sourceFiles
     let sources          = map processRawSource rawSources

--- a/bootstrap/src/Build.hs
+++ b/bootstrap/src/Build.hs
@@ -108,7 +108,7 @@ buildProgram programDirectory' libraryDirectories sourceExtensions buildDirector
                 in  fileMatcher &?> \(objectFile : _) -> do
                       need (sourceFile : directDependencies)
                       cmd compiler
-                          ["-c", moduleFlag ++ buildDirectory]
+                          ["-c", moduleFlag, buildDirectory]
                           includeFlags
                           flags
                           ["-o", objectFile, sourceFile]
@@ -160,7 +160,7 @@ buildLibrary libraryDirectory sourceExtensions buildDirectory (CompilerSettings 
                 in  fileMatcher &?> \(objectFile : _) -> do
                       need (sourceFile : directDependencies)
                       cmd compiler
-                          ["-c", moduleFlag ++ buildDirectory]
+                          ["-c", moduleFlag, buildDirectory]
                           includeFlags
                           flags
                           ["-o", objectFile, sourceFile]

--- a/bootstrap/src/Fpm.hs
+++ b/bootstrap/src/Fpm.hs
@@ -748,6 +748,7 @@ defineCompilerSettings specifiedFlags compiler release
               [ "-fp-model", "precise"
               , "-pc", "64"
               , "-align", "all"
+              , "-coarray"
               , "-error-limit", "1"
               , "-reentrancy", "threaded"
               , "-nogen-interfaces"
@@ -757,6 +758,7 @@ defineCompilerSettings specifiedFlags compiler release
             else
               [ "-warn", "all"
               , "-check:all:noarg_temp_created"
+              , "-coarray"
               , "-error-limit", "1"
               , "-O0"
               , "-g"

--- a/bootstrap/src/Fpm.hs
+++ b/bootstrap/src/Fpm.hs
@@ -748,7 +748,7 @@ defineCompilerSettings specifiedFlags compiler release
               [ "-fp-model", "precise"
               , "-pc", "64"
               , "-align", "all"
-              , "-coarray"
+              , "-coarray=single"
               , "-error-limit", "1"
               , "-reentrancy", "threaded"
               , "-nogen-interfaces"
@@ -758,7 +758,7 @@ defineCompilerSettings specifiedFlags compiler release
             else
               [ "-warn", "all"
               , "-check:all:noarg_temp_created"
-              , "-coarray"
+              , "-coarray=single"
               , "-error-limit", "1"
               , "-O0"
               , "-g"

--- a/bootstrap/src/Fpm.hs
+++ b/bootstrap/src/Fpm.hs
@@ -745,24 +745,24 @@ defineCompilerSettings specifiedFlags compiler release
   = let flags = case specifiedFlags of
           [] -> if release
             then
-              [ "-fp-model precise"
-              , "-pc 64"
-              , "-align all"
+              [ "-fp-model", "precise"
+              , "-pc", "64"
+              , "-align", "all"
               , "-coarray"
-              , "-error-limit 1"
-              , "-reentrancy threaded"
+              , "-error-limit", "1"
+              , "-reentrancy", "threaded"
               , "-nogen-interfaces"
-              , "-assume byterecl"
-              , "-assume nounderscore"
+              , "-assume", "byterecl"
+              , "-assume", "nounderscore"
               ]
             else
-              [ "-warn all"
+              [ "-warn", "all"
               , "-check:all:noarg_temp_created"
               , "-coarray"
-              , "-error-limit 1"
+              , "-error-limit", "1"
               , "-O0"
               , "-g"
-              , "-assume byterecl"
+              , "-assume", "byterecl"
               , "-traceback"
               ]
           fs -> fs

--- a/bootstrap/src/Fpm.hs
+++ b/bootstrap/src/Fpm.hs
@@ -748,7 +748,6 @@ defineCompilerSettings specifiedFlags compiler release
               [ "-fp-model", "precise"
               , "-pc", "64"
               , "-align", "all"
-              , "-coarray"
               , "-error-limit", "1"
               , "-reentrancy", "threaded"
               , "-nogen-interfaces"
@@ -758,7 +757,6 @@ defineCompilerSettings specifiedFlags compiler release
             else
               [ "-warn", "all"
               , "-check:all:noarg_temp_created"
-              , "-coarray"
               , "-error-limit", "1"
               , "-O0"
               , "-g"

--- a/bootstrap/src/Fpm.hs
+++ b/bootstrap/src/Fpm.hs
@@ -690,6 +690,187 @@ defineCompilerSettings specifiedFlags compiler release
                                   , compilerSettingsModuleFlag  = "-J"
                                   , compilerSettingsIncludeFlag = "-I"
                                   }
+  | "f95" `isInfixOf` compiler
+  = let flags = case specifiedFlags of
+          [] -> if release
+            then
+              [ "-O3"
+              , "-Wimplicit-interface"
+              , "-fPIC"
+              , "-fmax-errors=1"
+              , "-ffast-math"
+              , "-funroll-loops"
+              ]
+            else
+              [ "-Wall"
+              , "-Wextra"
+              , "-Wimplicit-interface"
+              , "-fPIC"
+              , "-fmax-errors=1"
+              , "-g"
+              , "-fbounds-check"
+              , "-fcheck-array-temporaries"
+              , "-Wno-maybe-uninitialized"
+              , "-Wno-uninitialized"
+              , "-fbacktrace"
+              ]
+          fs -> fs
+  in  return $ CompilerSettings { compilerSettingsCompiler    = compiler
+                                , compilerSettingsFlags       = flags
+                                , compilerSettingsModuleFlag  = "-J"
+                                , compilerSettingsIncludeFlag = "-I"
+                                }
+  | "nvfortran" `isInfixOf` compiler
+  = let flags = case specifiedFlags of
+          [] -> if release
+            then
+              [ "-Mbackslash"
+              ]
+            else
+              [ "-Minform=inform"
+              , "-Mbackslash"
+              , "-g"
+              , "-Mbounds"
+              , "-Mchkptr"
+              , "-Mchkstk"
+              , "-traceback"
+              ]
+          fs -> fs
+  in  return $ CompilerSettings { compilerSettingsCompiler    = compiler
+                                , compilerSettingsFlags       = flags
+                                , compilerSettingsModuleFlag  = "-module"
+                                , compilerSettingsIncludeFlag = "-I"
+                                }
+  | "ifort" `isInfixOf` compiler
+  = let flags = case specifiedFlags of
+          [] -> if release
+            then
+              [ "-fp-model precise"
+              , "-pc 64"
+              , "-align all"
+              , "-coarray"
+              , "-error-limit 1"
+              , "-reentrancy threaded"
+              , "-nogen-interfaces"
+              , "-assume byterecl"
+              , "-assume nounderscore"
+              ]
+            else
+              [ "-warn all"
+              , "-check:all:noarg_temp_created"
+              , "-coarray"
+              , "-error-limit 1"
+              , "-O0"
+              , "-g"
+              , "-assume byterecl"
+              , "-traceback"
+              ]
+          fs -> fs
+  in  return $ CompilerSettings { compilerSettingsCompiler    = compiler
+                                , compilerSettingsFlags       = flags
+                                , compilerSettingsModuleFlag  = "-module"
+                                , compilerSettingsIncludeFlag = "-I"
+                                }
+  | "ifx" `isInfixOf` compiler
+  = let flags = case specifiedFlags of
+          [] -> if release
+            then
+              []
+            else
+              []
+          fs -> fs
+  in  return $ CompilerSettings { compilerSettingsCompiler    = compiler
+                                , compilerSettingsFlags       = flags
+                                , compilerSettingsModuleFlag  = "-module"
+                                , compilerSettingsIncludeFlag = "-I"
+                                }
+  | "pgfortran" `isInfixOf` compiler || "pgf90" `isInfixOf` compiler || "pgf95" `isInfixOf` compiler
+  = let flags = case specifiedFlags of
+          [] -> if release
+            then
+              []
+            else
+              []
+          fs -> fs
+  in  return $ CompilerSettings { compilerSettingsCompiler    = compiler
+                                , compilerSettingsFlags       = flags
+                                , compilerSettingsModuleFlag  = "-module"
+                                , compilerSettingsIncludeFlag = "-I"
+                                }
+  | "flang" `isInfixOf` compiler
+  = let flags = case specifiedFlags of
+          [] -> if release
+            then
+              []
+            else
+              []
+          fs -> fs
+  in  return $ CompilerSettings { compilerSettingsCompiler    = compiler
+                                , compilerSettingsFlags       = flags
+                                , compilerSettingsModuleFlag  = "-module"
+                                , compilerSettingsIncludeFlag = "-I"
+                                }
+  | "lfc" `isInfixOf` compiler
+  = let flags = case specifiedFlags of
+          [] -> if release
+            then
+              []
+            else
+              []
+          fs -> fs
+  in  return $ CompilerSettings { compilerSettingsCompiler    = compiler
+                                , compilerSettingsFlags       = flags
+                                , compilerSettingsModuleFlag  = "-M"
+                                , compilerSettingsIncludeFlag = "-I"
+                                }
+  | "nagfor" `isInfixOf` compiler
+  = let flags = case specifiedFlags of
+          [] -> if release
+            then
+              [ "-O4"
+              , "-coarray=single"
+              , "-PIC"
+              ]
+            else
+              [ "-g"
+              , "-C=all"
+              , "-O0"
+              , "-gline"
+              , "-coarray=single"
+              , "-PIC"
+              ]
+          fs -> fs
+  in  return $ CompilerSettings { compilerSettingsCompiler    = compiler
+                                , compilerSettingsFlags       = flags
+                                , compilerSettingsModuleFlag  = "-mdir"
+                                , compilerSettingsIncludeFlag = "-I"
+                                }
+  | "crayftn" `isInfixOf` compiler
+  = let flags = case specifiedFlags of
+          [] -> if release
+            then
+              []
+            else
+              []
+          fs -> fs
+  in  return $ CompilerSettings { compilerSettingsCompiler    = compiler
+                                , compilerSettingsFlags       = flags
+                                , compilerSettingsModuleFlag  = "-J"
+                                , compilerSettingsIncludeFlag = "-I"
+                                }
+  | "xlf90" `isInfixOf` compiler
+  = let flags = case specifiedFlags of
+          [] -> if release
+            then
+              []
+            else
+              []
+          fs -> fs
+  in  return $ CompilerSettings { compilerSettingsCompiler    = compiler
+                                , compilerSettingsFlags       = flags
+                                , compilerSettingsModuleFlag  = "-qmoddir"
+                                , compilerSettingsIncludeFlag = "-I"
+                                }
   | otherwise
   = do
     putStrLn $ "Sorry, compiler is currently unsupported: " ++ compiler

--- a/bootstrap/src/Fpm.hs
+++ b/bootstrap/src/Fpm.hs
@@ -749,7 +749,6 @@ defineCompilerSettings specifiedFlags compiler release
               [ "-fp-model", "precise"
               , "-pc", "64"
               , "-align", "all"
-              , "-coarray=single"
               , "-error-limit", "1"
               , "-reentrancy", "threaded"
               , "-nogen-interfaces"
@@ -759,7 +758,6 @@ defineCompilerSettings specifiedFlags compiler release
             else
               [ "-warn", "all"
               , "-check:all:noarg_temp_created"
-              , "-coarray=single"
               , "-error-limit", "1"
               , "-O0"
               , "-g"


### PR DESCRIPTION
This adds support for the same compilers as is currently in the Fortran version to the Haskell version. I would appreciate if anyone with access to these compilers to do some testing.