### PR TITLE
Specify the correct help for `fpm run -h`

### DIFF
--- a/fpm/src/fpm_command_line.f90
+++ b/fpm/src/fpm_command_line.f90
@@ -137,7 +137,7 @@ contains
             & --runner " " &
             & --compiler "'//get_env('FPM_COMPILER','gfortran')//'" &
             & --verbose F&
-            & --',help_test,version_text)
+            & --',help_run,version_text)
 
             call check_build_vals()
 


### PR DESCRIPTION
This is just a typo that looks like have been overlooked.