### PR TITLE
Fix: missing error check after `new_package` call

### DIFF
--- a/fpm/src/fpm/manifest.f90
+++ b/fpm/src/fpm/manifest.f90
@@ -93,6 +93,7 @@ contains
         end if
 
         call new_package(package, table, error)
+        if (allocated(error)) return
 
         if (present(apply_defaults)) then
             if (apply_defaults) then


### PR DESCRIPTION
Fixes silent failure due to invalid manifest keys when `apply_defaults=.true.`