### PR TITLE
Remove -coarray=single option from ifort compiler default options

### DIFF
--- a/fpm/src/fpm_compiler.f90
+++ b/fpm/src/fpm_compiler.f90
@@ -141,7 +141,6 @@ character(len=:),allocatable :: mandatory ! flags required for fpm to function p
        & -fp-model precise&
        & -pc 64&
        & -align all&
-       & -coarray&
        & -error-limit 1&
        & -reentrancy threaded&
        & -nogen-interfaces&
@@ -153,7 +152,6 @@ character(len=:),allocatable :: mandatory ! flags required for fpm to function p
        fflags = '&
        & -warn all&
        & -check:all:noarg_temp_created&
-       & -coarray&
        & -error-limit 1&
        & -O0&
        & -g&


### PR DESCRIPTION
With the intel compiler ifort(1) use of the -coarray=single creates
an executable with images instead of just allowing the coarray
syntax as with the GNU gfortran compiler so it is being removed as
a default option and will be implemented via a more general option
allowing for user-specified compiler options. As it is, use of the
option requires developer platforms to support auxiliary libraries
not always available, and coarray does not appear to be on all
platforms supported by ifort (e.g. MacOS).

2020-12-11