### PR TITLE
Remove: -ffast-math in gfortran default release flags

### DIFF
--- a/bootstrap/src/Fpm.hs
+++ b/bootstrap/src/Fpm.hs
@@ -681,7 +681,6 @@ defineCompilerSettings specifiedFlags compiler release
               , "-fmax-errors=1"
               , "-O3"
               , "-march=native"
-              , "-ffast-math"
               , "-funroll-loops"
               , "-fcoarray=single"
               ]
@@ -714,7 +713,6 @@ defineCompilerSettings specifiedFlags compiler release
               , "-fmax-errors=1"
               , "-O3"
               , "-march=native"
-              , "-ffast-math"
               , "-funroll-loops"
               ]
             else
@@ -742,7 +740,6 @@ defineCompilerSettings specifiedFlags compiler release
               , "-Wimplicit-interface"
               , "-fPIC"
               , "-fmax-errors=1"
-              , "-ffast-math"
               , "-funroll-loops"
               ]
             else

--- a/fpm/src/fpm_compiler.f90
+++ b/fpm/src/fpm_compiler.f90
@@ -54,7 +54,6 @@ character(len=:),allocatable :: mandatory ! flags required for fpm to function p
        & -Wimplicit-interface&
        & -fPIC&
        & -fmax-errors=1&
-       & -ffast-math&
        & -funroll-loops&
        &'
        mandatory=' -J '//modpath//' -I '//modpath 
@@ -76,7 +75,6 @@ character(len=:),allocatable :: mandatory ! flags required for fpm to function p
        & -Wimplicit-interface&
        & -fPIC&
        & -fmax-errors=1&
-       & -ffast-math&
        & -funroll-loops&
        & -fcoarray=single&
        &'


### PR DESCRIPTION
I think it has been agreed generally in previous discussions that `-ffast-math` should be an opt-in option by the package maintainer rather than enabled by default. This PR therefore removes `-ffast-math` from the `gfortran` default flags for `--release`.

I encountered this because the stdlib testsuite does not pass with `fpm test --release` when [using stdlib with fpm](https://github.com/LKedward/stdlib-fpm).