### PR TITLE
Update: fpm_backend with dynamic openmp scheduling

### DIFF
--- a/fpm/src/fpm_backend.f90
+++ b/fpm/src/fpm_backend.f90
@@ -68,7 +68,7 @@ subroutine build_package(model)
     do i=1,size(schedule_ptr)-1
 
         ! Build targets in schedule region i
-        !$omp parallel do default(shared)
+        !$omp parallel do default(shared) schedule(dynamic,1)
         do j=schedule_ptr(i),(schedule_ptr(i+1)-1)
 
             call build_target(model,queue(j)%ptr)


### PR DESCRIPTION
I noticed the parallel compilation time for my [stdlib-fpm](https://github.com/LKedward/stdlib-fpm) package was quite poor (on 4 threads) and realised the default static scheduling of threads was causing poor utilisation since compilation times can vary significantly between individual targets. (This is less of a problem for higher core counts)

This PR makes dynamic scheduling explicit when using OpenMP for parallel compilation which gives much better utilisation (2x improvement for stdlib-fpm) and avoids implementation-dependent choice of scheduling. We have no pressing need for static scheduling and the overhead for dynamic scheduling appears to be small compared to the time for compilation.