### PR TITLE
Include root dir in path to default example setup

### DIFF
--- a/fpm/src/fpm/manifest.f90
+++ b/fpm/src/fpm/manifest.f90
@@ -154,7 +154,7 @@ contains
 
         ! Populate example in case we find the default example directory
         if (.not.allocated(package%example) .and. &
-            exists(join_path("example","main.f90"))) then
+            & exists(join_path(root, "example", "main.f90"))) then
             allocate(package%example(1))
             call default_example(package%example(1), package%name)
         endif


### PR DESCRIPTION
Minor oversight on my side. Shouldn't have affected any build since examples are only built for the main project.