### PR TITLE
Suggest to move the fpm version in the boostrapping process

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ $ fpm test
 Finally, install the Fortran *fpm* version with
 
 ```bash
-$ fpm run --runner cp -- ~/.local/bin
+$ fpm run --runner mv -- ~/.local/bin
 ```
 
 Or choose another location if you do not want to overwrite the bootstrapping version.


### PR DESCRIPTION
Fixes https://github.com/fortran-lang/fpm/issues/347