### PR TITLE
Update: install script for Fortran fpm

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,32 +72,26 @@ $ cd fpm/
 
 #### Build a bootstrap version of fpm
 
-You can use the install script to perform the build of the Haskell version of *fpm* with:
+You can use the install script to bootstrap and install *fpm*:
 
 ```bash
 $ ./install.sh
 ```
 
-On Linux, the above command installs `fpm` to `${HOME}/.local/bin/`.
-
-Now you can build the Fortran *fpm* version with
+By default, the above command installs `fpm` to `${HOME}/.local/bin/`.
+To specify an alternative destination use the `--prefix=` flag, for example:
 
 ```bash
-$ cd fpm/
-$ fpm build
+$ ./install.sh --prefix=/usr/local
 ```
 
-Test that everything is working as expected
+which will install *fpm* to `/usr/local/bin`.
+
+To test that everything is working as expected you can now build *fpm*
+with itself and run the tests with:
 
 ```bash
+$ cd fpm
 $ fpm test
 ```
 
-Finally, install the Fortran *fpm* version with
-
-```bash
-$ fpm run --runner mv -- ~/.local/bin
-```
-
-Or choose another location if you do not want to overwrite the bootstrapping version.
-From now on you can rebuild *fpm* with your Fortran *fpm* version.

--- a/install.sh
+++ b/install.sh
@@ -32,7 +32,7 @@ STATIC=false
 HASKELL_ONLY=false
 
 STACK_BIN_PATH="$HOME/.local/bin"
-REF=$(git tag | tail -n1)
+REF=$(git describe --tag --abbrev=0)
 RELEASE_FLAGS="--flag -g --flag -fbacktrace --flag -O3"
 
 while [ "$1" != "" ]; do

--- a/install.sh
+++ b/install.sh
@@ -1,33 +1,131 @@
 #!/bin/sh
 
-set -u # error on use of undefined variable
 set -e # exit on error
 
-install_path="$HOME/.local/bin"
+usage()
+{
+    echo "Fortran Package Manager Bootstrap Script"
+    echo ""
+    echo "USAGE:"
+    echo "./install.sh [--help | [--prefix=PREFIX] [--update[=REF]]"
+    echo "               [--no-openmp] [--static] [--haskell] ]"
+    echo ""
+    echo " --help             Display this help text"
+    echo " --prefix=PREFIX    Install binary in 'PREFIX/bin'"
+    echo "                    Default prefix='\$HOME/.local/bin'"
+    echo " --update[=REF]     Update repository from latest release tag"
+    echo "                    or from git reference REF if specified"
+    echo " --no-openmp        Don't build fpm with openmp support"
+    echo " --static           Statically link fpm executable"
+    echo "                     (implies --no-openmp)"
+    echo " --haskell          Only install Haskell fpm"
+    echo ""
+    echo " '--no-openmp' and '--static' do not affect the Haskell fpm"
+    echo " build."
+    echo ""
+}
+
+PREFIX="$HOME/.local"
+UPDATE=false
+OMP=true
+STATIC=false
+HASKELL_ONLY=false
+
+STACK_BIN_PATH="$HOME/.local/bin"
+REF=$(git tag | tail -n1)
+RELEASE_FLAGS="--flag -g --flag -fbacktrace --flag -O3"
+
+while [ "$1" != "" ]; do
+    PARAM=$(echo "$1" | awk -F= '{print $1}')
+    VALUE=$(echo "$1" | awk -F= '{print $2}')
+    case $PARAM in
+        -h | --help)
+            usage
+            exit
+            ;;
+        --prefix)
+            PREFIX=$VALUE
+            ;;
+        --update)
+            UPDATE=true
+            if [ "$VALUE" != "" ]; then
+              REF=$VALUE
+            fi
+            ;;
+        --no-openmp)
+            OMP=false
+            ;;
+        --static)
+            STATIC=true
+            OMP=false
+            ;;
+        --haskell)
+            HASKELL_ONLY=true
+            ;;
+        *)
+            echo "ERROR: unknown parameter \"$PARAM\""
+            usage
+            exit 1
+            ;;
+    esac
+    shift
+done
+
+set -u # error on use of undefined variable
+
+INSTALL_PATH="$PREFIX/bin"
 
 if command -v stack 1> /dev/null 2>&1 ; then
-  echo "found stack"
+  echo "Found stack"
 else
   echo "Haskell stack not found."
-  echo "Installing Haskell stack to."
+  echo "Installing Haskell stack"
   curl -sSL https://get.haskellstack.org/ | sh
   if command -v stack 1> /dev/null 2>&1 ; then
     echo "Haskell stack installation successful."
   else
-    echo "Haskell stack installation unsuccessful."
+    echo "ERROR: Haskell stack installation unsuccessful."
     exit 1
   fi
 fi
 
-if [ -x "$install_path/fpm" ]; then
-  echo "Overwriting existing fpm installation in $install_path"
+if [ -x "$INSTALL_PATH/fpm" ]; then
+  echo "Overwriting existing fpm installation in $INSTALL_PATH"
+fi
+
+if [ "$UPDATE" = true ]; then
+  git checkout "$REF"
+  if [ $? != 0 ]; then
+    echo "ERROR: Unable to checkout $REF."
+    exit 1
+  fi
 fi
 
 cd bootstrap
 stack install
 
-if [ -x "$install_path/fpm" ]; then
-  echo "fpm installed successfully to $install_path"
+if [ "$STACK_BIN_PATH" != "$INSTALL_PATH" ]; then
+  mv "$STACK_BIN_PATH/fpm" "$INSTALL_PATH/"
+fi
+
+if [ "$HASKELL_ONLY" = true ]; then
+  exit
+fi
+
+if [ "$STATIC" = true ]; then
+  RELEASE_FLAGS="$RELEASE_FLAGS --flag -static"
+fi
+
+if [ "$OMP" = true ]; then
+  RELEASE_FLAGS="$RELEASE_FLAGS --flag -fopenmp"
+fi
+
+cd ../fpm
+"$INSTALL_PATH/fpm" run $RELEASE_FLAGS --runner mv -- "$INSTALL_PATH/"
+
+if [ -x "$INSTALL_PATH/fpm" ]; then
+  echo "fpm installed successfully to $INSTALL_PATH"
 else
-  echo "fpm installation unsuccessful: fpm not found in $install_path"
+  echo "ERROR: fpm installation unsuccessful: fpm not found in $INSTALL_PATH"
+  exit 1
 fi


### PR DESCRIPTION
Inline with the goal of #253 this PR updates the install script to build and install Fortran *fpm* by default after bootstrapping with the Haskell implementation. Based on the discussion in #344 I also added an `--update` flag to optionally pull from the latest tag similar to @brocolis' [implementation](https://gist.github.com/brocolis/e2fc06743652f939d95d351b16721f5c). The existing behaviour of the install script is preserved if invoked with `./install.sh --haskell` which will only install the Haskell implementation.
Additional flags are provided to specify the install location and whether to build with openmp and static linking.

This simplifies the bootstrapping process and the workflow for updating *fpm*.