### PR TITLE
simple plugin support where fpm-NAME commands are searched for

### DIFF
--- a/fpm/src/fpm_command_line.f90
+++ b/fpm/src/fpm_command_line.f90
@@ -385,8 +385,7 @@ contains
         case default
 
             if(which('fpm-'//cmdarg).ne.'')then
-                write(stderr,'(*(a))')'<CALLING> command [', 'fpm-'//trim(cmdarg)//' '//get_command_arguments_quoted(), ']'
-                call run('fpm-'//trim(cmdarg)//' '// get_command_arguments_quoted() )
+                call run('fpm-'//trim(cmdarg)//' '// get_command_arguments_quoted(),.false.)
             else
                call set_args('&
                & --list F&

--- a/fpm/src/fpm_environment.f90
+++ b/fpm/src/fpm_environment.f90
@@ -282,7 +282,6 @@ character(len=:),allocatable :: fname
             else ! check environment variable PATH
                sep=merge('\','/',index(get_env('PATH'),'\').ne.0)
                !*!write(*,*)'<WARNING>unknown system directory path separator'
-               sep='/'
             endif
          endif
       endif

--- a/fpm/src/fpm_environment.f90
+++ b/fpm/src/fpm_environment.f90
@@ -122,10 +122,17 @@ contains
         unix = os /= OS_WINDOWS
     end function os_is_unix
 
-    subroutine run(cmd)
+    subroutine run(cmd,echo)
         character(len=*), intent(in) :: cmd
+        logical,optional,intent(in)  :: echo
         integer :: stat
-        print *, '+ ', cmd
+        logical :: echo_local
+        if(present(echo))then
+           echo_local=echo
+        else
+           echo_local=.true.
+        endif
+        if(echo_local) print *, '+ ', cmd
         call execute_command_line(cmd, exitstat=stat)
         if (stat /= 0) then
             print *, 'Command failed'

--- a/fpm/src/fpm_filesystem.f90
+++ b/fpm/src/fpm_filesystem.f90
@@ -524,7 +524,7 @@ character(len=*),intent(in)     :: command
 character(len=:),allocatable    :: pathname, checkon, paths(:)
 integer                         :: i
    pathname=''
-   call split(get_env('PATH'),paths,delimiters=merge('%',':',separator().eq.'\'))
+   call split(get_env('PATH'),paths,delimiters=merge(';',':',separator().eq.'\'))
    do i=1,size(paths)
       checkon=trim(join_path(trim(paths(i)),command))
       select case(separator())

--- a/fpm/src/fpm_filesystem.f90
+++ b/fpm/src/fpm_filesystem.f90
@@ -521,33 +521,40 @@ function which(command) result(pathname)
 !!    Public Domain
 
 character(len=*),intent(in)     :: command
-character(len=:),allocatable    :: pathname, checkon, paths(:)
-integer                         :: i
+character(len=:),allocatable    :: pathname, checkon, paths(:), exts(:)
+integer                         :: i, j
    pathname=''
    call split(get_env('PATH'),paths,delimiters=merge(';',':',separator().eq.'\'))
-   do i=1,size(paths)
+   SEARCH: do i=1,size(paths)
       checkon=trim(join_path(trim(paths(i)),command))
       select case(separator())
       case('/')
          if(exists(checkon))then
             pathname=checkon
-            exit
+            exit SEARCH
          endif
       case('\')
          if(exists(checkon))then
             pathname=checkon
-            exit
+            exit SEARCH
          endif
          if(exists(checkon//'.bat'))then
             pathname=checkon//'.bat'
-            exit
+            exit SEARCH
          endif
          if(exists(checkon//'.exe'))then
             pathname=checkon//'.exe'
-            exit
+            exit SEARCH
          endif
+         call split(get_env('PATHEXT'),exts,delimiters=';')
+         do j=1,size(exts)
+            if(exists(checkon//'.'//trim(exts(j))))then
+               pathname=checkon//'.'//trim(exts(j))
+               exit SEARCH
+            endif
+         enddo
       end select
-   enddo
+   enddo SEARCH
 end function which
 
 end module fpm_filesystem

--- a/fpm/src/fpm_filesystem.f90
+++ b/fpm/src/fpm_filesystem.f90
@@ -522,21 +522,31 @@ function which(command) result(pathname)
 
 character(len=*),intent(in)     :: command
 character(len=:),allocatable    :: pathname, checkon, paths(:)
-character(len=256)              :: message
-integer                         :: stat, i
-logical                         :: existing
+integer                         :: i
    pathname=''
    call split(get_env('PATH'),paths,delimiters=merge('%',':',separator().eq.'\'))
-   existing=.false.
    do i=1,size(paths)
-      checkon=join_path(trim(paths(i)),command)
-      inquire(file=checkon,exist=existing,iostat=stat,iomsg=message)
-      if(stat.ne.0)then
-         write(*,'(a,a)')'<WARNING>*which*',trim(message)
-      elseif(existing)then
-         pathname=checkon
-         exit
-      endif
+      checkon=trim(join_path(trim(paths(i)),command))
+      select case(separator())
+      case('/')
+         if(exists(checkon))then
+            pathname=checkon
+            exit
+         endif
+      case('\')
+         if(exists(checkon))then
+            pathname=checkon
+            exit
+         endif
+         if(exists(checkon//'.bat'))then
+            pathname=checkon//'.bat'
+            exit
+         endif
+         if(exists(checkon//'.exe'))then
+            pathname=checkon//'.exe'
+            exit
+         endif
+      end select
    enddo
 end function which
 


### PR DESCRIPTION
Relating to  #361 and #211

A simplistic plugin support method whereupon when a subcommand is
not found the PATH variable is used to search for commands of the
form fpm-NAME and those are executed in lieu of an error message
indicating an unknown subcommand was entered.

The executable is simply called. No data is passed via arguments,
environment variables, or files (yet).

This allows for concurrent development. This is an alpha feature
to support testing the pros and cons of plugins, aliases, a
built-in scripting language (see Fortran scheme, lua, ...),
response files (see M_CLI2), ...

The subcommand must currently support its own help. The list subcommand
does not currently list available plugins -- that is, nothing in fpm
documents that external subcommand exists.

This allows related commands such as repository search, formatting
tools, and other utilitites to develop independently of the core
fpm functionality without bloating the core program with the many
external packages that would be potentially useful to other functions,
to allow for easier development of system-dependent subcommands, and
so on.

It could become much more useful with the ability to pass categories
of pathnames, but some of that exists with the --runner option.
With pathnames, you could say "reformat all my source files" or
"expand tabs in all my source files" or "edit my source files"
without the complex syntax required by the --runner option, and so on.

Best example so far:

install fpm-search(1) in your path, and you can use it using

fpm search 'date|time'

Since fpm-search is a stand-alone utility is requires no data to be passed
to it but feels very much a part of fpm(1))); even though it requires
a very different set of packages to be installed than the core fpm(1)
package -- and development and installation can occur concurrently.