### PR TITLE
close #371

### DIFF
--- a/fpm/src/fpm.f90
+++ b/fpm/src/fpm.f90
@@ -69,6 +69,9 @@ subroutine build_model(model, settings, package, error)
     model%output_directory = join_path('build',basename(model%fortran_compiler)//'_'//settings%build_name)
 
     call add_compile_flag_defaults(settings%build_name, basename(model%fortran_compiler), model)
+    if(settings%verbose)then
+       write(*,*)'<INFO>COMPILER OPTIONS:  ', model%fortran_compile_flags 
+    endif
 
     model%link_flags = ''
 

--- a/fpm/src/fpm_compiler.f90
+++ b/fpm/src/fpm_compiler.f90
@@ -12,7 +12,7 @@ type(fpm_model_t), intent(inout) :: model
 ! could just be a function to return a string instead of passing model
 ! but likely to change other components like matching C compiler
 
-character(len=:),allocatable :: fflags  ! optional flags that might be overridden by user
+character(len=:),allocatable :: fflags    ! optional flags that might be overridden by user
 character(len=:),allocatable :: modpath 
 character(len=:),allocatable :: mandatory ! flags required for fpm to function properly;
                                           ! ie. add module path and module include directory as appropriate
@@ -42,6 +42,24 @@ character(len=:),allocatable :: mandatory ! flags required for fpm to function p
 ! G95               ?          ?       -fmod=          -I            -fopenmp   discontinued
 ! Open64            ?          ?       -module         -I            -mp        discontinued
 ! Unisys            ?          ?       ?               ?             ?          discontinued
+character(len=*),parameter :: names(*)=[ character(len=10) :: &
+& 'caf', &
+& 'gfortran', &
+& 'f95', &
+& 'nvfortran', &
+& 'ifort', &
+& 'ifx', &
+& 'pgfortran', &
+& 'pgf90', &
+& 'pgf95', &
+& 'flang', &
+& 'lfc', &
+& 'nagfor', &
+& 'crayftn', &
+& 'xlf90', &
+& 'unknown']
+integer :: i
+
     modpath=join_path(model%output_directory,model%package_name)
     fflags=''
     mandatory=''
@@ -143,7 +161,6 @@ character(len=:),allocatable :: mandatory ! flags required for fpm to function p
        & -reentrancy threaded&
        & -nogen-interfaces&
        & -assume byterecl&
-       & -assume nounderscore&
        &'
        mandatory=' -module '//modpath//' -I '//modpath 
     case('debug_ifort')
@@ -219,10 +236,8 @@ character(len=:),allocatable :: mandatory ! flags required for fpm to function p
     case default
        fflags = ' '
        mandatory=' -module '//modpath//' -I '//modpath 
-       write(*,*)'<WARNING> unknown compiler (',compiler,')'
-       write(*,*)'          and build name (',build_name,')'
-       write(*,*)'          combination.'
-       write(*,*)'          known compilers are gfortran, nvfortran, ifort'
+       write(*,'(*(a))')'<WARNING> unknown compiler (',compiler,') and build name (',build_name,') combination.'
+       write(*,'(a,*(T31,6(a:,", "),/))')'          known compilers are ',(trim(names(i)),i=1,size(names)-1)
     end select
 
     model%fortran_compile_flags = fflags//' '//mandatory


### PR DESCRIPTION
This should close #371.
After running
```bash
$fpm new TESTIT --app
$fpm build --compiler ifort --verbose
$fpm build --compiler ifort --verbose --release
```
you now get

```bash
$fpm build --compiler ifort --verbose --release
 <INFO>BUILD_NAME:release
 <INFO>COMPILER:  ifort
 <INFO>COMPILER OPTIONS:   -fp-model precise -pc 64 -align all
                           -error-limit 1 -reentrancy threaded -nogen-interfaces -assume byterecl
                           -module build/ifort_release/TESTIT -I build/ifort_release/TESTIT
$fpm build --compiler ifort --verbose --release
 <INFO>BUILD_NAME:debug
 <INFO>COMPILER:  ifort
 <INFO>COMPILER OPTIONS:   -warn all -check:all:noarg_temp_created
                           -error-limit 1 -O0 -g -assume byterecl -traceback  -module
                           build/ifort_debug/TESTIT -I build/ifort_debug/TESTIT
```

