### PR TITLE
Replace deprecated flags in debug_fortran option

### DIFF
--- a/fpm/src/fpm_compiler.f90
+++ b/fpm/src/fpm_compiler.f90
@@ -108,8 +108,8 @@ integer :: i
        & -Wimplicit-interface&
        & -fPIC -fmax-errors=1&
        & -g&
-       & -fbounds-check&
-       & -fcheck-array-temporaries&
+       & -fcheck=bounds&
+       & -fcheck=array-temps&
        & -fbacktrace&
        & -fcoarray=single&
        &'


### PR DESCRIPTION
The options ```-fbounds-check``` and ```-fcheck-array-temporaries```, used as flags in ```case(debug_fortran)```, are described [here](https://gcc.gnu.org/onlinedocs/gfortran/Code-Gen-Options.html#Code-Gen-Options) as deprecated aliases for -fcheck=bounds and -fcheck=array-temps, respectively.

The option ```-fcheck=<all|bounds|array-temps>``` was added in the [gfortran 4.5 release](https://gcc.gnu.org/wiki/GFortran/News).