### PR TITLE
Add Conda install instructions to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ _e.g._ `$ chmod u+x fpm-v0.1.0-linux-x86_64`
 
 #### Conda
 
-If you haven't yet, first enable the conda-forge channel:
+Fpm is available on conda-forge, to add conda-forge to your channels use:
 
 ```
 conda config --add channels conda-forge
@@ -41,8 +41,8 @@ conda create -n fpm fpm
 conda activate fpm
 ```
 
-Conda can be installed from [miniconda](https://docs.conda.io/en/latest/miniconda.html)
-or from [miniforge](https://github.com/conda-forge/miniforge/releases).
+The conda package manager can be installed from [miniforge](https://github.com/conda-forge/miniforge/releases)
+or from [miniconda](https://docs.conda.io/en/latest/miniconda.html).
 
 #### Github Actions
 
@@ -118,4 +118,3 @@ with itself and run the tests with:
 $ cd fpm
 $ fpm test
 ```
-

--- a/README.md
+++ b/README.md
@@ -17,14 +17,35 @@ To report a bug report or suggest a feature, please read our
 
 ## Getting started
 
-### Binary download
+### Setting up fpm
+
+#### Binary download
 `x86-64` binaries are available [to download](https://github.com/fortran-lang/fpm/releases) for Windows, MacOS and Linux.
 
 __Note:__ On Linux and MacOS, you will need to enable executable permission before you can use the binary.
 
 _e.g._ `$ chmod u+x fpm-v0.1.0-linux-x86_64`
 
-__Github actions:__ to setup *fpm* within Github actions for automated testing, you can use the [fortran-lang/setup-fpm](https://github.com/marketplace/actions/setup-fpm) action.
+#### Conda
+
+If you haven't yet, first enable the conda-forge channel:
+
+```
+conda config --add channels conda-forge
+```
+
+Fpm can be installed with:
+
+```
+conda create -n fpm fpm
+conda activate fpm
+```
+
+#### Github Actions
+
+To setup *fpm* within Github actions for automated testing, you can use the [fortran-lang/setup-fpm](https://github.com/marketplace/actions/setup-fpm) action.
+
+#### Bootstraping on other platforms
 
 For other platforms and architectures have a look at the [bootstrapping instructions](#bootstrapping-instructions).
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ conda create -n fpm fpm
 conda activate fpm
 ```
 
+Conda can be installed from [miniconda](https://docs.conda.io/en/latest/miniconda.html)
+or from [miniforge](https://github.com/conda-forge/miniforge/releases).
+
 #### Github Actions
 
 To setup *fpm* within Github actions for automated testing, you can use the [fortran-lang/setup-fpm](https://github.com/marketplace/actions/setup-fpm) action.


### PR DESCRIPTION
This adds the Conda install instructions from [Sebastian's Discourse post](https://fortran-lang.discourse.group/t/fortran-package-manager-on-conda-forge/850) to the README. I also slightly adjusted the sections formatting.

I'm not a Conda user so I haven't tested this. Please double check.