### PR TITLE
Minor fix: for setting executable link libraries.

### DIFF
--- a/example_packages/link_executable/fpm.toml
+++ b/example_packages/link_executable/fpm.toml
@@ -1,5 +1,4 @@
 name = "link_executable"
-build.auto-executables = false
 
 [[executable]]
 name = "gomp_test"

--- a/fpm/src/fpm_sources.f90
+++ b/fpm/src/fpm_sources.f90
@@ -161,7 +161,7 @@ subroutine add_executable_sources(sources,executables,scope,auto_discover,error)
                 
                 sources(j)%exe_name = executables(i)%name
                 if (allocated(executables(i)%link)) then
-                    exe_source%link_libraries = executables(i)%link
+                    sources(j)%link_libraries = executables(i)%link
                 end if
                 cycle exe_loop
 


### PR DESCRIPTION
Executable link libraries were not working when auto discovery was enabled due to minor copy-paste typo.