### PR TITLE
Bump version for new release

### DIFF
--- a/fpm/fpm.toml
+++ b/fpm/fpm.toml
@@ -1,5 +1,5 @@
 name = "fpm"
-version = "0.1.4"
+version = "0.2.0"
 license = "MIT"
 author = "fpm maintainers"
 maintainer = ""

--- a/fpm/src/fpm_command_line.f90
+++ b/fpm/src/fpm_command_line.f90
@@ -133,7 +133,7 @@ contains
             case default     ; os_type =  "OS Type:     UNKNOWN"
         end select
         version_text = [character(len=80) :: &
-         &  'Version:     0.1.4, alpha',                           &
+         &  'Version:     0.2.0, alpha',                           &
          &  'Program:     fpm(1)',                                     &
          &  'Description: A Fortran package manager and build system', &
          &  'Home Page:   https://github.com/fortran-lang/fpm',        &


### PR DESCRIPTION
PR to bump version to 0.2.0.

I'll create the new release on github once merged. See below for proposed change log entry, feel free to edit.

---

__Changes:__

- Replace deprecated flags in gfortran debug profile (#386)

- `--release` flag is replaced by `--profile release` (#390)

- Programs can use modules defined in relative subdirectories (#409)

__New features:__

- Add support for specifying an include directory (#377)

- Implement `--flag` command line option (#390)

__Fixes:__

- Fix problems when building with local paths (#327,#390)

- Fix for executable link libraries when auto discovery is enabled (#398)

- Fix fpm_strings::join for null inputs (#404)