### PR TITLE
Bump fpm to version 0.2.0

### DIFF
--- a/fpm/fpm.toml
+++ b/fpm/fpm.toml
@@ -1,5 +1,5 @@
 name = "fpm"
-version = "0.1.4"
+version = "0.2.0"
 license = "MIT"
 author = "fpm maintainers"
 maintainer = ""

--- a/fpm/src/fpm_command_line.f90
+++ b/fpm/src/fpm_command_line.f90
@@ -133,7 +133,7 @@ contains
             case default     ; os_type =  "OS Type:     UNKNOWN"
         end select
         version_text = [character(len=80) :: &
-         &  'Version:     0.1.4, alpha',                           &
+         &  'Version:     0.2.0, alpha',                           &
          &  'Program:     fpm(1)',                                     &
          &  'Description: A Fortran package manager and build system', &
          &  'Home Page:   https://github.com/fortran-lang/fpm',        &


### PR DESCRIPTION
Release notes:

```markdown
**Changes**
- Add omp_lib to intrinsic modules list (https://github.com/fortran-lang/fpm/pull/413)
- Give Programs Access to Code in subdirectories (https://github.com/fortran-lang/fpm/pull/409)

**New Features**
- Add explicit include-dir key to manifest (https://github.com/fortran-lang/fpm/pull/377)
- Replace deprecated flags in debug_fortran option (https://github.com/fortran-lang/fpm/pull/386)
- Implement --flag option for Fortran fpm (https://github.com/fortran-lang/fpm/pull/390, https://github.com/fortran-lang/fpm/pull/407)

**Fixes**
- Minor fix: for setting executable link libraries (https://github.com/fortran-lang/fpm/pull/398)
- Correct join for null input (https://github.com/fortran-lang/fpm/pull/404)
```