### PR TITLE
Use default instead of master to reference the repository HEAD

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,8 +8,7 @@ help address your problem, evaluate changes, and guide you through your pull
 requests.
 
 By contributing to *fpm*, you certify that you own or are allowed to share the
-content of your contribution under the
-[fpm license](https://github.com/fortran-lang/fpm/blob/master/LICENSE).
+content of your contribution under the [fpm license](LICENSE).
 
 * [Style](#style)
 * [Reporting a bug](#reporting-a-bug)
@@ -35,7 +34,7 @@ Before opening a bug report:
 1. Check if the issue has already been reported
    ([issues](https://github.com/fortran-lang/fpm/issues)).
 2. Check if it is still an issue or it has been fixed?
-   Try to reproduce it with the latest version from the master branch.
+   Try to reproduce it with the latest version from the default branch.
 3. Isolate the problem and create a minimal test case.
 
 A good bug report should include all information needed to reproduce the bug.

--- a/manifest-reference.md
+++ b/manifest-reference.md
@@ -403,7 +403,7 @@ To use a specific upstream branch declare the *branch* name with
 
 ```toml
 [dependencies]
-toml-f = { git = "https://github.com/toml-f/toml-f", branch = "master" }
+toml-f = { git = "https://github.com/toml-f/toml-f", branch = "main" }
 ```
 
 Alternatively, reference tags by using the *tag* entry

--- a/src/fpm/cmd/new.f90
+++ b/src/fpm/cmd/new.f90
@@ -347,7 +347,7 @@ character(len=:,kind=tfc),allocatable :: littlefile(:)
         &'  # git repository.                                                             ',&
         &'  #                                                                             ',&
         &'  # You can be specific about which version of a dependency you would           ',&
-        &'  # like. By default the latest master master branch is used. You can           ',&
+        &'  # like. By default the latest default branch is used. You can           ',&
         &'  # optionally specify a branch, a tag or a commit value.                       ',&
         &'  #                                                                             ',&
         &'  # So here are several alternates for specifying a remote dependency (you      ',&


### PR DESCRIPTION
See #421 for details.