### PR TITLE
feat(install.sh): use wget if curl is missing

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -58,6 +58,7 @@ if command -v curl > /dev/null 2>&1; then
   fetch_flag="-LJ"
 elif command -v wget > /dev/null 2>&1; then
   fetch=wget
+  fetch_flag="-O -"
 else
   echo "No download mechanism found.  Tried curl and wget."
   exit 1

--- a/install.sh
+++ b/install.sh
@@ -54,17 +54,15 @@ fi
 mkdir -p $BOOTSTRAP_DIR
 
 if command -v curl > /dev/null 2>&1; then
-  fetch=curl
-  fetch_flag="-LJ"
+    FETCH="curl -L"
 elif command -v wget > /dev/null 2>&1; then
-  fetch=wget
-  fetch_flag="-O -"
+    FETCH="wget -O -"
 else
-  echo "No download mechanism found.  Tried curl and wget."
-  exit 1
+    echo "No download mechanism found. Install curl or wget first."
+    exit 1
 fi
 
-$fetch ${fetch_flag:-} $SOURCE_URL > $BOOTSTRAP_DIR/fpm.f90
+$FETCH $SOURCE_URL > $BOOTSTRAP_DIR/fpm.f90
 
 $FC $FFLAGS -J $BOOTSTRAP_DIR $BOOTSTRAP_DIR/fpm.f90 -o $BOOTSTRAP_DIR/fpm
 

--- a/install.sh
+++ b/install.sh
@@ -52,7 +52,19 @@ if [ -z ${FFLAGS+x} ]; then
 fi
 
 mkdir -p $BOOTSTRAP_DIR
-curl -LJ $SOURCE_URL > $BOOTSTRAP_DIR/fpm.f90
+
+if command -v curl > /dev/null 2>&1; then
+  fetch=curl
+  fetch_flag="-LJ"
+elif command -v wget > /dev/null 2>&1; then
+  fetch=wget
+else
+  echo "No download mechanism found.  Tried curl and wget."
+  exit 1
+fi
+
+$fetch ${fetch_flag:-} $SOURCE_URL > $BOOTSTRAP_DIR/fpm.f90
+
 $FC $FFLAGS -J $BOOTSTRAP_DIR $BOOTSTRAP_DIR/fpm.f90 -o $BOOTSTRAP_DIR/fpm
 
 $BOOTSTRAP_DIR/fpm install --compiler "$FC" --flag "$FFLAGS" --prefix "$PREFIX"

--- a/install.sh
+++ b/install.sh
@@ -42,7 +42,8 @@ done
 
 set -u # error on use of undefined variable
 
-SOURCE_URL="https://github.com/fortran-lang/fpm/releases/download/v0.2.0/fpm-0.2.0.f90"
+SOURCE="fpm-0.2.0.f90"
+SOURCE_URL="https://github.com/fortran-lang/fpm/releases/download/v0.2.0/$SOURCE"
 BOOTSTRAP_DIR="build/bootstrap"
 if [ -z ${FC+x} ]; then
     FC="gfortran"
@@ -51,11 +52,9 @@ if [ -z ${FFLAGS+x} ]; then
     FFLAGS="-g -fbacktrace -O3"
 fi
 
-mkdir -p $BOOTSTRAP_DIR
-
 if command -v curl > /dev/null 2>&1; then
   fetch=curl
-  fetch_flag="-LJ"
+  fetch_flag="-LO"
 elif command -v wget > /dev/null 2>&1; then
   fetch=wget
 else
@@ -63,7 +62,10 @@ else
   exit 1
 fi
 
-$fetch ${fetch_flag:-} $SOURCE_URL > $BOOTSTRAP_DIR/fpm.f90
+$fetch ${fetch_flag:-} $SOURCE_URL
+
+mkdir -p $BOOTSTRAP_DIR
+mv $SOURCE $BOOTSTRAP_DIR/fpm.f90
 
 $FC $FFLAGS -J $BOOTSTRAP_DIR $BOOTSTRAP_DIR/fpm.f90 -o $BOOTSTRAP_DIR/fpm
 

--- a/install.sh
+++ b/install.sh
@@ -42,8 +42,7 @@ done
 
 set -u # error on use of undefined variable
 
-SOURCE="fpm-0.2.0.f90"
-SOURCE_URL="https://github.com/fortran-lang/fpm/releases/download/v0.2.0/$SOURCE"
+SOURCE_URL="https://github.com/fortran-lang/fpm/releases/download/v0.2.0/fpm-0.2.0.f90"
 BOOTSTRAP_DIR="build/bootstrap"
 if [ -z ${FC+x} ]; then
     FC="gfortran"
@@ -52,9 +51,11 @@ if [ -z ${FFLAGS+x} ]; then
     FFLAGS="-g -fbacktrace -O3"
 fi
 
+mkdir -p $BOOTSTRAP_DIR
+
 if command -v curl > /dev/null 2>&1; then
   fetch=curl
-  fetch_flag="-LO"
+  fetch_flag="-LJ"
 elif command -v wget > /dev/null 2>&1; then
   fetch=wget
 else
@@ -62,10 +63,7 @@ else
   exit 1
 fi
 
-$fetch ${fetch_flag:-} $SOURCE_URL
-
-mkdir -p $BOOTSTRAP_DIR
-mv $SOURCE $BOOTSTRAP_DIR/fpm.f90
+$fetch ${fetch_flag:-} $SOURCE_URL > $BOOTSTRAP_DIR/fpm.f90
 
 $FC $FFLAGS -J $BOOTSTRAP_DIR $BOOTSTRAP_DIR/fpm.f90 -o $BOOTSTRAP_DIR/fpm
 


### PR DESCRIPTION
Current behavior
-----------------
The `install.sh` installation script fails if `curl` is not present.  

Behavior enabled by this PR
----------------------------
Use `wget` when `curl` is missing. 

Use Case
----------
The Lubuntu lightweight Ubuntu distribution has `wget` by default but not `curl`.