### PR TITLE
feat(install.sh): sudo {mkdir|cp} if necessary

### DIFF
--- a/src/fpm/installer.f90
+++ b/src/fpm/installer.f90
@@ -238,7 +238,17 @@ contains
       end if
     end if
 
-    call self%run(self%copy//' "'//source//'" "'//install_dest//'"', error)
+
+    block
+      integer write_permission_stat
+
+      call execute_command_line("test -w " // install_dest, exitstat=write_permission_stat)
+      associate(sudo_if_needed => merge("     ","sudo ", write_permission_stat==0))
+        call self%run(sudo_if_needed // self%copy//' "'//source//'" "'//install_dest//'"', error)
+      end associate
+    end block
+
+
     if (allocated(error)) return
 
   end subroutine install

--- a/src/fpm_filesystem.f90
+++ b/src/fpm_filesystem.f90
@@ -285,8 +285,12 @@ subroutine mkdir(dir)
     select case (get_os_type())
         case (OS_UNKNOWN, OS_LINUX, OS_MACOS, OS_CYGWIN, OS_SOLARIS, OS_FREEBSD)
             call execute_command_line('mkdir -p ' // dir, exitstat=stat)
-            write (*, '(" + ",2a)') 'mkdir -p ' // dir
-
+            if (stat/=0) then
+              call execute_command_line('sudo mkdir -p ' // dir, exitstat=stat)
+              write (*, '(" + ",2a)') 'sudo mkdir -p ' // dir
+            else  
+              write (*, '(" + ",2a)') 'mkdir -p ' // dir
+            end if
         case (OS_WINDOWS)
             call execute_command_line("mkdir " // windows_path(dir), exitstat=stat)
             write (*, '(" + ",2a)') 'mkdir ' // windows_path(dir)


### PR DESCRIPTION
This commit causes `fpm` to invoke `mkdir` and/or `cp` using `sudo` if
the user lacks write permissions to the installation destination on Unix-like 
systems. Invoking `sudo` potentially prompts the user for a
password.