### PR TITLE
Fix to allow compiling C with Intel CC

### DIFF
--- a/src/fpm.f90
+++ b/src/fpm.f90
@@ -9,7 +9,7 @@ use fpm_filesystem, only: is_dir, join_path, number_of_rows, list_files, exists,
 use fpm_model, only: fpm_model_t, srcfile_t, show_model, &
                     FPM_SCOPE_UNKNOWN, FPM_SCOPE_LIB, FPM_SCOPE_DEP, &
                     FPM_SCOPE_APP, FPM_SCOPE_EXAMPLE, FPM_SCOPE_TEST
-use fpm_compiler, only: get_module_flags, is_unknown_compiler
+use fpm_compiler, only: get_module_flags, is_unknown_compiler, get_default_c_compiler
 
 
 use fpm_sources, only: add_executable_sources, add_sources_from_dir
@@ -61,6 +61,8 @@ subroutine build_model(model, settings, package, error)
     else
         model%fortran_compiler = settings%compiler
     endif
+
+    call get_default_c_compiler(model%fortran_compiler, model%c_compiler)
 
     if (is_unknown_compiler(model%fortran_compiler)) then
         write(*, '(*(a:,1x))') &
@@ -178,6 +180,7 @@ subroutine build_model(model, settings, package, error)
     if (settings%verbose) then
         write(*,*)'<INFO> BUILD_NAME: ',settings%build_name
         write(*,*)'<INFO> COMPILER:  ',settings%compiler
+        write(*,*)'<INFO> C COMPILER:  ',model%c_compiler
         write(*,*)'<INFO> COMPILER OPTIONS:  ', model%fortran_compile_flags 
         write(*,*)'<INFO> INCLUDE DIRECTORIES:  [', string_cat(model%include_dirs,','),']' 
      end if

--- a/src/fpm.f90
+++ b/src/fpm.f90
@@ -4,7 +4,7 @@ use fpm_backend, only: build_package
 use fpm_command_line, only: fpm_build_settings, fpm_new_settings, &
                       fpm_run_settings, fpm_install_settings, fpm_test_settings
 use fpm_dependency, only : new_dependency_tree
-use fpm_environment, only: run
+use fpm_environment, only: run, get_env
 use fpm_filesystem, only: is_dir, join_path, number_of_rows, list_files, exists, basename
 use fpm_model, only: fpm_model_t, srcfile_t, show_model, &
                     FPM_SCOPE_UNKNOWN, FPM_SCOPE_LIB, FPM_SCOPE_DEP, &
@@ -63,6 +63,7 @@ subroutine build_model(model, settings, package, error)
     endif
 
     call get_default_c_compiler(model%fortran_compiler, model%c_compiler)
+    model%c_compiler = get_env('FPM_C_COMPILER',model%c_compiler)
 
     if (is_unknown_compiler(model%fortran_compiler)) then
         write(*, '(*(a:,1x))') &

--- a/src/fpm_backend.f90
+++ b/src/fpm_backend.f90
@@ -242,7 +242,7 @@ subroutine build_target(model,target)
               // " -o " // target%output_file)
 
     case (FPM_TARGET_C_OBJECT)
-        call run(model%c_compiler//" -c " // target%source%file_name  &
+        call run(model%c_compiler//" -c " // target%source%file_name // target%compile_flags &
                 // " -o " // target%output_file)
 
     case (FPM_TARGET_EXECUTABLE)

--- a/src/fpm_backend.f90
+++ b/src/fpm_backend.f90
@@ -30,8 +30,8 @@ module fpm_backend
 use fpm_environment, only: run
 use fpm_filesystem, only: dirname, join_path, exists, mkdir
 use fpm_model, only: fpm_model_t
-use fpm_targets, only: build_target_t, build_target_ptr, &
-                     FPM_TARGET_OBJECT, FPM_TARGET_ARCHIVE, FPM_TARGET_EXECUTABLE
+use fpm_targets, only: build_target_t, build_target_ptr, FPM_TARGET_OBJECT, &
+                       FPM_TARGET_C_OBJECT, FPM_TARGET_ARCHIVE, FPM_TARGET_EXECUTABLE
                      
 use fpm_strings, only: string_cat
 
@@ -240,6 +240,10 @@ subroutine build_target(model,target)
     case (FPM_TARGET_OBJECT)
         call run(model%fortran_compiler//" -c " // target%source%file_name // target%compile_flags &
               // " -o " // target%output_file)
+
+    case (FPM_TARGET_C_OBJECT)
+        call run(model%c_compiler//" -c " // target%source%file_name  &
+                // " -o " // target%output_file)
 
     case (FPM_TARGET_EXECUTABLE)
         

--- a/src/fpm_compiler.f90
+++ b/src/fpm_compiler.f90
@@ -345,10 +345,10 @@ subroutine get_default_c_compiler(f_compiler, c_compiler)
 
     select case(id)
 
-    case(id_intel_classic)
+    case(id_intel_classic_nix, id_intel_classic_mac, id_intel_classic_windows, id_intel_classic_unknown)
         c_compiler = 'icc'
 
-    case(id_intel_llvm)
+    case(id_intel_llvm_nix,id_intel_llvm_windows, id_intel_llvm_unknown)
         c_compiler = 'icx'
 
     case(id_flang)

--- a/src/fpm_compiler.f90
+++ b/src/fpm_compiler.f90
@@ -336,6 +336,33 @@ subroutine get_module_flags(compiler, modpath, flags)
 
 end subroutine get_module_flags
 
+subroutine get_default_c_compiler(f_compiler, c_compiler)
+    character(len=*), intent(in) :: f_compiler
+    character(len=:), allocatable, intent(out) :: c_compiler
+    integer(compiler_enum) :: id
+
+    id = get_compiler_id(f_compiler)
+
+    select case(id)
+    case default
+        c_compiler = 'gcc'
+
+    case(id_intel_classic)
+        c_compiler = 'icc'
+
+    case(id_intel_llvm)
+        c_compiler = 'icx'
+
+    case(id_flang)
+        c_compiler='clang'
+
+    case(id_ibmxl)
+        c_compiler='xlc'
+
+    end select
+
+end subroutine get_default_c_compiler
+
 function get_compiler_id(compiler) result(id)
     character(len=*), intent(in) :: compiler
     integer(kind=compiler_enum) :: id

--- a/src/fpm_compiler.f90
+++ b/src/fpm_compiler.f90
@@ -344,8 +344,6 @@ subroutine get_default_c_compiler(f_compiler, c_compiler)
     id = get_compiler_id(f_compiler)
 
     select case(id)
-    case default
-        c_compiler = 'gcc'
 
     case(id_intel_classic)
         c_compiler = 'icc'
@@ -359,6 +357,9 @@ subroutine get_default_c_compiler(f_compiler, c_compiler)
     case(id_ibmxl)
         c_compiler='xlc'
 
+    case default
+        ! Fall-back to using Fortran compiler
+        c_compiler = f_compiler
     end select
 
 end subroutine get_default_c_compiler

--- a/src/fpm_model.f90
+++ b/src/fpm_model.f90
@@ -117,6 +117,9 @@ type :: fpm_model_t
     !> Command line name to invoke fortran compiler
     character(:), allocatable :: fortran_compiler
 
+    !> Command line name to invoke c compiler
+    character(:), allocatable :: c_compiler
+
     !> Command line flags passed to fortran for compilation
     character(:), allocatable :: fortran_compile_flags
 

--- a/src/fpm_targets.f90
+++ b/src/fpm_targets.f90
@@ -35,7 +35,8 @@ implicit none
 private
 
 public FPM_TARGET_UNKNOWN, FPM_TARGET_EXECUTABLE, &
-       FPM_TARGET_ARCHIVE, FPM_TARGET_OBJECT
+       FPM_TARGET_ARCHIVE, FPM_TARGET_OBJECT, &
+       FPM_TARGET_C_OBJECT
 public build_target_t, build_target_ptr
 public targets_from_sources, resolve_module_dependencies
 public resolve_target_linking, add_target, add_dependency
@@ -50,7 +51,8 @@ integer, parameter :: FPM_TARGET_EXECUTABLE = 1
 integer, parameter :: FPM_TARGET_ARCHIVE = 2
 !> Target type is compiled object
 integer, parameter :: FPM_TARGET_OBJECT = 3
-
+!> Target type is c compiled object
+integer, parameter :: FPM_TARGET_C_OBJECT = 4
 
 !> Wrapper type for constructing arrays of `[[build_target_t]]` pointers
 type build_target_ptr
@@ -194,7 +196,8 @@ subroutine build_target_list(targets,model)
                 case (FPM_UNIT_MODULE,FPM_UNIT_SUBMODULE,FPM_UNIT_SUBPROGRAM,FPM_UNIT_CSOURCE)
 
                     call add_target(targets,source = sources(i), &
-                                type = FPM_TARGET_OBJECT,&
+                                type = merge(FPM_TARGET_C_OBJECT,FPM_TARGET_OBJECT,&
+                                               sources(i)%unit_type==FPM_UNIT_CSOURCE), &
                                 output_file = get_object_name(sources(i)))
 
                     if (with_lib .and. sources(i)%unit_scope == FPM_SCOPE_LIB) then


### PR DESCRIPTION
- Minimal set of changes to invoke a separate C compiler instead of passing C code to the Fortran compiler
- Allows compiling packages with C code using Intel compiler collection, Fixes #426 
- C compiler is chosen automatically based on the Fortran compiler selection
  - Companion compiler chosen if known, otherwise fall-back to invoking the Fortran compiler for C as done currently
  - C compiler can alternatively be specified explicitly using environment variable `FPM_C_COMPILER`

| Compiler ID | FC | CC |
| -------------- | -- |  -- |
| `gcc` | `gfortran` | `gcc` |
| `intel_classic` | `ifort` | `icc` |
| `intel_llvm` | `ifx` | `icx` |
| `intel_flang` | `flang` | `clang` |
| `ibmxl` | `xlf` | `xlc` |

__Not addressed in this PR:__ specifying C compiler flags