### PR TITLE
Minor edits to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ To build *fpm* without a prior *fpm* version a single source file version is ava
 at each release.
 
 To build manually using the single source distribution, run the following code (from within the current directory)
+
 ```
 mkdir _tmp
 curl -LJ https://github.com/fortran-lang/fpm/releases/download/v0.2.0/fpm-0.2.0.f90 > _tmp/fpm.f90


### PR DESCRIPTION
Slight edit to the bootstrapping instructions to make clear that the code-snippet must be run from within the fpm directory to work. 

Otherwise it fails, because the code cannot find the fpm.toml file. 

While perhaps obvious, this confused me on my first attempt to use fpm.