### PR TITLE
Allow to find include files / modules in CPATH environment variable

### DIFF
--- a/src/fpm_environment.f90
+++ b/src/fpm_environment.f90
@@ -121,7 +121,7 @@ contains
         else
             build_os = get_os_type()
         end if
-        unix = os /= OS_WINDOWS
+        unix = build_os /= OS_WINDOWS
     end function os_is_unix
 
     !> echo command string and pass it to the system for execution


### PR DESCRIPTION
This should make it easier for GFortran based builds to find modules in non-standard locations