### PR TITLE
Response files with ar on Windows

### DIFF
--- a/src/fpm_backend.f90
+++ b/src/fpm_backend.f90
@@ -27,13 +27,13 @@
 !>
 module fpm_backend
 
-use fpm_environment, only: run
-use fpm_filesystem, only: dirname, join_path, exists, mkdir
+use fpm_environment, only: run, get_os_type, OS_WINDOWS
+use fpm_filesystem, only: dirname, join_path, exists, mkdir, unix_path
 use fpm_model, only: fpm_model_t
 use fpm_targets, only: build_target_t, build_target_ptr, &
                      FPM_TARGET_OBJECT, FPM_TARGET_ARCHIVE, FPM_TARGET_EXECUTABLE
                      
-use fpm_strings, only: string_t
+use fpm_strings, only: string_cat, string_t
 
 implicit none
 
@@ -247,8 +247,16 @@ subroutine build_target(model,target)
               //" "//target%link_flags// " -o " // target%output_file)
 
     case (FPM_TARGET_ARCHIVE)
-        call write_response_file(target%output_file//".resp" ,target%link_objects)
-        call run("ar -rs " // target%output_file // " @" // target%output_file//".resp")
+
+        select case (get_os_type())
+        case (OS_WINDOWS)
+            call write_response_file(target%output_file//".resp" ,target%link_objects)
+            call run("ar -rs " // target%output_file // " @" // target%output_file//".resp")
+
+        case default
+            call run("ar -rs " // target%output_file // " " // string_cat(target%link_objects," "))
+
+        end select
 
     end select
 
@@ -270,7 +278,7 @@ subroutine write_response_file(name, argv)
     integer :: iarg, io
     open(file=name, newunit=io)
     do iarg = 1, size(argv)
-        write(io, '(a)') argv(iarg)%s
+        write(io, '(a)') unix_path(argv(iarg)%s)
     end do
     close(io)
 end subroutine write_response_file


### PR DESCRIPTION
@awvwgk, response files seem to work on Windows if the objects paths are written in unix style.

Fixes #427.