### PR TITLE
Refactor: use objects to represent compilers and archiver

### DIFF
--- a/src/fpm.f90
+++ b/src/fpm.f90
@@ -10,7 +10,7 @@ use fpm_model, only: fpm_model_t, srcfile_t, show_model, &
                     FPM_SCOPE_UNKNOWN, FPM_SCOPE_LIB, FPM_SCOPE_DEP, &
                     FPM_SCOPE_APP, FPM_SCOPE_EXAMPLE, FPM_SCOPE_TEST
 use fpm_compiler, only: get_module_flags, is_unknown_compiler, get_default_c_compiler, &
-    & archiver_t, compiler_t
+    archiver_t, compiler_t
 
 
 use fpm_sources, only: add_executable_sources, add_sources_from_dir
@@ -79,7 +79,7 @@ subroutine build_model(model, settings, package, error)
         & join_path(model%output_directory,model%package_name), &
         & fortran_compiler_flags)
     model%compiler = compiler_t(fortran_compiler, settings%flag // fortran_compiler_flags)
-    model%c_compiler = compiler_t(c_compiler, settings%flag // fortran_compiler_flags)
+    model%c_compiler = compiler_t(c_compiler, settings%flag)
     model%archiver = archiver_t()
 
     allocate(model%packages(model%deps%ndep))

--- a/src/fpm_backend.f90
+++ b/src/fpm_backend.f90
@@ -238,20 +238,18 @@ subroutine build_target(model,target)
     select case(target%target_type)
 
     case (FPM_TARGET_OBJECT)
-        call run(model%fortran_compiler//" -c " // target%source%file_name // target%compile_flags &
-              // " -o " // target%output_file)
+        call model%compiler%compile(target%output_file, target%source%file_name, &
+            target%compile_flags)
 
     case (FPM_TARGET_C_OBJECT)
-        call run(model%c_compiler//" -c " // target%source%file_name // target%compile_flags &
-                // " -o " // target%output_file)
+        call model%c_compiler%compile(target%output_file, target%source%file_name, &
+            target%compile_flags)
 
     case (FPM_TARGET_EXECUTABLE)
-        
-        call run(model%fortran_compiler// " " // target%compile_flags &
-              //" "//target%link_flags// " -o " // target%output_file)
+        call model%compiler%link(target%output_file, target%link_flags, target%compile_flags)
 
     case (FPM_TARGET_ARCHIVE)
-        call run("ar -rs " // target%output_file // " " // string_cat(target%link_objects," "))
+        call model%archiver%archive(target%output_file, target%link_objects)
 
     end select
 

--- a/src/fpm_model.f90
+++ b/src/fpm_model.f90
@@ -19,6 +19,7 @@
 !>
 module fpm_model
 use iso_fortran_env, only: int64
+use fpm_compiler, only : archiver_t, compiler_t
 use fpm_strings, only: string_t, str
 use fpm_dependency, only: dependency_tree_t
 implicit none
@@ -114,15 +115,6 @@ type :: fpm_model_t
     !> Array of packages (including the root package)
     type(package_t), allocatable :: packages(:)
 
-    !> Command line name to invoke fortran compiler
-    character(:), allocatable :: fortran_compiler
-
-    !> Command line name to invoke c compiler
-    character(:), allocatable :: c_compiler
-
-    !> Command line flags passed to fortran for compilation
-    character(:), allocatable :: fortran_compile_flags
-
     !> Base directory for build
     character(:), allocatable :: output_directory
 
@@ -137,6 +129,15 @@ type :: fpm_model_t
 
     !> Project dependencies
     type(dependency_tree_t) :: deps
+
+    !> Compiler command
+    type(compiler_t) :: compiler
+
+    !> Compiler command
+    type(compiler_t) :: c_compiler
+
+    !> Archiver command
+    type(archiver_t) :: archiver
 
 end type fpm_model_t
 
@@ -270,9 +271,9 @@ function info_model(model) result(s)
     end do
     s = s // "]"
     !    character(:), allocatable :: fortran_compiler
-    s = s // ', fortran_compiler="' // model%fortran_compiler // '"'
+    s = s // ', fortran_compiler="' // model%compiler%prog // '"'
     !    character(:), allocatable :: fortran_compile_flags
-    s = s // ', fortran_compile_flags="' // model%fortran_compile_flags // '"'
+    s = s // ', fortran_compile_flags="' // model%compiler%flags // '"'
     !    character(:), allocatable :: output_directory
     s = s // ', output_directory="' // model%output_directory // '"'
     !    type(string_t), allocatable :: link_libraries(:)

--- a/src/fpm_targets.f90
+++ b/src/fpm_targets.f90
@@ -480,9 +480,9 @@ subroutine resolve_target_linking(targets, model)
         associate(target => targets(i)%ptr)
 
             if (target%target_type /= FPM_TARGET_C_OBJECT) then
-                target%compile_flags = model%fortran_compile_flags//" "//global_include_flags
+                target%compile_flags = model%compiler%flags//" "//global_include_flags
             else
-                target%compile_flags = global_include_flags
+                target%compile_flags = model%c_compiler%flags//" "//global_include_flags
             end if
 
             allocate(target%link_objects(0))


### PR DESCRIPTION
This patch doesn't change any functionality, but just shuffles things around.

- Fortran and C compiler are represented by thin `compiler_t` object
- archiver is represented by thin `archiver_t` object
- allows easier abstraction by moving from `type(archiver_t)` to `class(archiver_t), allocatable` later

Relevant for https://github.com/fortran-lang/fpm/pull/442, https://github.com/fortran-lang/fpm/pull/449