### PR TITLE
Allow fpm to change the working directory

### DIFF
--- a/app/main.f90
+++ b/app/main.f90
@@ -1,4 +1,5 @@
 program main
+use, intrinsic :: iso_fortran_env, only : error_unit, output_unit
 use fpm_command_line, only: &
         fpm_cmd_settings, &
         fpm_new_settings, &
@@ -8,16 +9,56 @@ use fpm_command_line, only: &
         fpm_install_settings, &
         fpm_update_settings, &
         get_command_line_settings
+use fpm_error, only: error_t
+use fpm_filesystem, only: exists, parent_dir, join_path
 use fpm, only: cmd_build, cmd_run
 use fpm_cmd_install, only: cmd_install
 use fpm_cmd_new, only: cmd_new
 use fpm_cmd_update, only : cmd_update
+use fpm_os,  only: change_directory, get_current_directory
 
 implicit none
 
 class(fpm_cmd_settings), allocatable :: cmd_settings
+type(error_t), allocatable :: error
+character(len=:), allocatable :: pwd_start, pwd_working, working_dir, project_root
 
 call get_command_line_settings(cmd_settings)
+
+call get_current_directory(pwd_start, error)
+call handle_error(error)
+
+call get_working_dir(cmd_settings, working_dir)
+if (allocated(working_dir)) then
+    ! Change working directory if requested
+    if (len_trim(working_dir) > 0) then
+        call change_directory(working_dir, error)
+        call handle_error(error)
+
+        call get_current_directory(pwd_working, error)
+        call handle_error(error)
+        write(output_unit, '(*(a))') "fpm: Entering directory '"//pwd_working//"'"
+    else
+        pwd_working = pwd_start
+    end if
+else
+    pwd_working = pwd_start
+end if
+
+if (.not.has_manifest(pwd_working)) then
+    project_root = pwd_working
+    do while(.not.has_manifest(project_root))
+        working_dir = parent_dir(project_root)
+        if (len(working_dir) == 0) exit
+        project_root = working_dir
+    end do
+
+    if (has_manifest(project_root)) then
+        call change_directory(project_root, error)
+        call handle_error(error)
+        write(output_unit, '(*(a))') "fpm: Entering directory '"//project_root//"'"
+    end if
+end if
 
 select type(settings=>cmd_settings)
 type is (fpm_new_settings)
@@ -33,5 +74,41 @@ type is (fpm_install_settings)
 type is (fpm_update_settings)
     call cmd_update(settings)
 end select
+
+if (allocated(project_root)) then
+    write(output_unit, '(*(a))') "fpm: Leaving directory '"//project_root//"'"
+end if
+
+if (pwd_start /= pwd_working) then
+    write(output_unit, '(*(a))') "fpm: Leaving directory '"//pwd_working//"'"
+end if
+
+contains
+
+    function has_manifest(dir)
+        character(len=*), intent(in) :: dir
+        logical :: has_manifest
+
+        character(len=:), allocatable :: manifest
+
+        has_manifest = exists(join_path(dir, "fpm.toml"))
+    end function has_manifest
+
+    subroutine handle_error(error)
+        type(error_t), optional, intent(in) :: error
+        if (present(error)) then
+            write(error_unit, '("[Error]", 1x, a)') error%message
+            stop 1
+        end if
+    end subroutine handle_error
+
+    !> Save access to working directory in settings, in case setting have not been allocated
+    subroutine get_working_dir(settings, working_dir)
+        class(fpm_cmd_settings), optional, intent(in) :: settings
+        character(len=:), allocatable, intent(out) :: working_dir
+        if (present(settings)) then
+            working_dir = settings%working_dir
+        end if
+    end subroutine get_working_dir
 
 end program main

--- a/ci/run_tests.sh
+++ b/ci/run_tests.sh
@@ -13,86 +13,70 @@ fi
 pushd example_packages/
 rm -rf ./*/build
 
-pushd hello_world
-"$fpm" build
-"$fpm" run --target hello_world
-"$fpm" run
-popd
+dir=hello_world
+"$fpm" -C $dir build
+"$fpm" -C $dir run --target hello_world
+"$fpm" -C $dir run
 
-pushd hello_fpm
-"$fpm" build
-"$fpm" run --target hello_fpm
-popd
+dir=hello_fpm
+"$fpm" -C $dir build
+"$fpm" -C $dir run --target hello_fpm
 
-pushd circular_test
-"$fpm" build
-popd
+dir=circular_test
+"$fpm" -C $dir build
 
-pushd circular_example
-"$fpm" build
-popd
+dir=circular_example
+"$fpm" -C $dir build
 
-pushd hello_complex
-"$fpm" build
-"$fpm" test
-"$fpm" run --target say_Hello
-"$fpm" run --target say_goodbye
-"$fpm" test --target greet_test
-"$fpm" test --target farewell_test
-popd
+dir=hello_complex
+"$fpm" -C $dir build
+"$fpm" -C $dir test
+"$fpm" -C $dir run --target say_Hello
+"$fpm" -C $dir run --target say_goodbye
+"$fpm" -C $dir test --target greet_test
+"$fpm" -C $dir test --target farewell_test
 
-pushd hello_complex_2
-"$fpm" build
-"$fpm" run --target say_hello_world
-"$fpm" run --target say_goodbye
-"$fpm" test --target greet_test
-"$fpm" test --target farewell_test
-popd
+dir=hello_complex_2
+"$fpm" -C $dir build
+"$fpm" -C $dir run --target say_hello_world
+"$fpm" -C $dir run --target say_goodbye
+"$fpm" -C $dir test --target greet_test
+"$fpm" -C $dir test --target farewell_test
 
-pushd with_examples
-"$fpm" build
-"$fpm" run --example --target demo-prog
-"$fpm" run --target demo-prog
-popd
+dir=with_examples
+"$fpm" -C $dir build
+"$fpm" -C $dir run --example --target demo-prog
+"$fpm" -C $dir run --target demo-prog
 
-pushd auto_discovery_off
-"$fpm" build
-"$fpm" run --target auto_discovery_off
-"$fpm" test --target my_test
-test ! -x ./build/gfortran_*/app/unused
-test ! -x ./build/gfortran_*/test/unused_test
-popd
+dir=auto_discovery_off
+"$fpm" -C $dir build
+"$fpm" -C $dir run --target auto_discovery_off
+"$fpm" -C $dir test --target my_test
+test ! -x $dir/build/gfortran_*/app/unused
+test ! -x $dir/build/gfortran_*/test/unused_test
 
-pushd with_c
-"$fpm" build
-"$fpm" run --target with_c
-popd
+dir=with_c
+"$fpm" -C $dir build
+"$fpm" -C $dir run --target with_c
 
-pushd submodules
-"$fpm" build
-popd
+"$fpm" -C $dir build
 
-pushd program_with_module
-"$fpm" build
-"$fpm" run --target Program_with_module
-popd
+dir=program_with_module
+"$fpm" -C $dir build
+"$fpm" -C $dir run --target Program_with_module
 
-pushd link_executable
-"$fpm" build
-"$fpm" run --target gomp_test
-popd
+dir=link_executable
+"$fpm" -C $dir build
+"$fpm" -C $dir run --target gomp_test
 
-pushd fortran_includes
-"$fpm" build
-popd
+dir=fortran_includes
+"$fpm" -C $dir build
 
-pushd c_includes
-"$fpm" build
-popd
+dir=c_includes
+"$fpm" -C $dir build
 
-pushd c_header_only
-"$fpm" build
-popd
+dir=c_header_only
+"$fpm" -C $dir build
 
 # Cleanup
 rm -rf ./*/build

--- a/ci/run_tests.sh
+++ b/ci/run_tests.sh
@@ -16,67 +16,82 @@ rm -rf ./*/build
 dir=hello_world
 "$fpm" -C $dir build
 "$fpm" -C $dir run --target hello_world
-"$fpm" -C $dir run
+"$fpm" -C $dir/app run
 
-dir=hello_fpm
-"$fpm" -C $dir build
-"$fpm" -C $dir run --target hello_fpm
+pushd hello_fpm
+"$fpm" build
+"$fpm" run --target hello_fpm
+popd
 
-dir=circular_test
-"$fpm" -C $dir build
+pushd circular_test
+"$fpm" build
+popd
 
-dir=circular_example
-"$fpm" -C $dir build
+pushd circular_example
+"$fpm" build
+popd
 
-dir=hello_complex
-"$fpm" -C $dir build
-"$fpm" -C $dir test
-"$fpm" -C $dir run --target say_Hello
-"$fpm" -C $dir run --target say_goodbye
-"$fpm" -C $dir test --target greet_test
-"$fpm" -C $dir test --target farewell_test
+pushd hello_complex
+"$fpm" build
+"$fpm" test
+"$fpm" run --target say_Hello
+"$fpm" run --target say_goodbye
+"$fpm" test --target greet_test
+"$fpm" test --target farewell_test
+popd
 
-dir=hello_complex_2
-"$fpm" -C $dir build
-"$fpm" -C $dir run --target say_hello_world
-"$fpm" -C $dir run --target say_goodbye
-"$fpm" -C $dir test --target greet_test
-"$fpm" -C $dir test --target farewell_test
+pushd hello_complex_2
+"$fpm" build
+"$fpm" run --target say_hello_world
+"$fpm" run --target say_goodbye
+"$fpm" test --target greet_test
+"$fpm" test --target farewell_test
+popd
 
-dir=with_examples
-"$fpm" -C $dir build
-"$fpm" -C $dir run --example --target demo-prog
-"$fpm" -C $dir run --target demo-prog
+pushd with_examples
+"$fpm" build
+"$fpm" run --example --target demo-prog
+"$fpm" run --target demo-prog
+popd
 
-dir=auto_discovery_off
-"$fpm" -C $dir build
-"$fpm" -C $dir run --target auto_discovery_off
-"$fpm" -C $dir test --target my_test
-test ! -x $dir/build/gfortran_*/app/unused
-test ! -x $dir/build/gfortran_*/test/unused_test
+pushd auto_discovery_off
+"$fpm" build
+"$fpm" run --target auto_discovery_off
+"$fpm" test --target my_test
+test ! -x ./build/gfortran_*/app/unused
+test ! -x ./build/gfortran_*/test/unused_test
+popd
 
-dir=with_c
-"$fpm" -C $dir build
-"$fpm" -C $dir run --target with_c
+pushd with_c
+"$fpm" build
+"$fpm" run --target with_c
+popd
 
-"$fpm" -C $dir build
+pushd submodules
+"$fpm" build
+popd
 
-dir=program_with_module
-"$fpm" -C $dir build
-"$fpm" -C $dir run --target Program_with_module
+pushd program_with_module
+"$fpm" build
+"$fpm" run --target Program_with_module
+popd
 
-dir=link_executable
-"$fpm" -C $dir build
-"$fpm" -C $dir run --target gomp_test
+pushd link_executable
+"$fpm" build
+"$fpm" run --target gomp_test
+popd
 
-dir=fortran_includes
-"$fpm" -C $dir build
+pushd fortran_includes
+"$fpm" build
+popd
 
-dir=c_includes
-"$fpm" -C $dir build
+pushd c_includes
+"$fpm" build
+popd
 
-dir=c_header_only
-"$fpm" -C $dir build
+pushd c_header_only
+"$fpm" build
+popd
 
 # Cleanup
 rm -rf ./*/build

--- a/src/fpm_filesystem.f90
+++ b/src/fpm_filesystem.f90
@@ -10,7 +10,7 @@ use,intrinsic :: iso_fortran_env, only : stdin=>input_unit, stdout=>output_unit,
     private
     public :: basename, canon_path, dirname, is_dir, join_path, number_of_rows, read_lines, list_files, env_variable, &
             mkdir, exists, get_temp_filename, windows_path, unix_path, getline, delete_file, to_fortran_name
-    public :: fileopen, fileclose, filewrite, warnwrite
+    public :: fileopen, fileclose, filewrite, warnwrite, parent_dir
 
     integer, parameter :: LINE_BUFFER_LEN = 1000
 
@@ -183,6 +183,15 @@ function dirname(path) result (dir)
     dir = path(1:scan(path,'/\',back=.true.))
 
 end function dirname
+
+!> Extract dirname from path
+function parent_dir(path) result (dir)
+    character(*), intent(in) :: path
+    character(:), allocatable :: dir
+
+    dir = path(1:scan(path,'/\',back=.true.)-1)
+
+end function parent_dir
 
 
 !> test if a name matches an existing directory path

--- a/src/fpm_os.F90
+++ b/src/fpm_os.F90
@@ -1,0 +1,79 @@
+module fpm_os
+    use, intrinsic :: iso_c_binding, only : c_char, c_int, c_null_char
+    use fpm_error, only : error_t, fatal_error
+    implicit none
+    private
+    public :: change_directory, get_current_directory
+
+#ifndef _WIN32
+    character(len=*), parameter :: pwd_env = "PWD"
+#else
+    character(len=*), parameter :: pwd_env = "CD"
+#endif
+
+    interface
+        function chdir(path) result(stat) &
+#ifndef _WIN32
+                bind(C, name="chdir")
+#else
+                bind(C, name="_chdir")
+#endif
+            import :: c_char, c_int
+            character(kind=c_char, len=1), intent(in) :: path(*)
+            integer(c_int) :: stat
+        end function chdir
+    end interface
+
+contains
+
+    subroutine change_directory(path, error)
+        character(len=*), intent(in) :: path
+        type(error_t), allocatable, intent(out) :: error
+
+        character(kind=c_char, len=1), allocatable :: cpath(:)
+        integer :: stat
+
+        allocate(cpath(len(path)+1))
+        call f_c_character(path, cpath, len(path)+1)
+
+        stat = chdir(cpath)
+
+        if (stat /= 0) then
+            call fatal_error(error, "Failed to change directory to '"//path//"'")
+        end if
+    end subroutine change_directory
+
+    subroutine f_c_character(rhs, lhs, len)
+        character(kind=c_char), intent(out) :: lhs(*)
+        character(len=*), intent(in) :: rhs
+        integer, intent(in) :: len
+        integer :: length
+        length = min(len-1, len_trim(rhs))
+
+        lhs(1:length) = transfer(rhs(1:length), lhs(1:length))
+        lhs(length+1:length+1) = c_null_char
+
+    end subroutine f_c_character
+
+    subroutine get_current_directory(path)
+        character(len=:), allocatable, intent(out) :: path
+
+        integer :: length, stat
+
+        call get_environment_variable(pwd_env, length=length, status=stat)
+        if (stat /= 0) return
+
+        allocate(character(len=length) :: path, stat=stat)
+        if (stat /= 0) return
+
+        if (length > 0) then
+            call get_environment_variable(pwd_env, path, status=stat)
+            if (stat /= 0) then
+                deallocate(path)
+                return
+            end if
+        end if
+
+    end subroutine get_current_directory
+
+end module fpm_os


### PR DESCRIPTION
This allow to use `fpm -C <PATH>` to change the working directory and enables the automatic discovery of a package manifest in the parent directories.

#### Explicitly changing of directories

*`-C, --directory PATH`: Change working directory to `PATH` before running any command.*

After checking out this pull request locally, you should be able to build the example package by:

```
fpm run -- build -C example_packages/hello_fpm
```

#### Automatic discovery of manifest files

With a directory changing mechanism we can also easily implement a mechanism to ”find” the package manifest in a parent directory. For this purpose fpm will retrieve the current working directory and check if a package manifest exists in any of the parent directories. By changing to this directory, all other commands can be used directly without modification.

You should be able to check this behavior with

```
fpm run -- build -C example_packages/hello_fpm/app
```

If you copy / install the fpm executable you can also check the automatic discovery without the `-C` / `--directory` option. It should work just the same.

*Please try to break this feature.*

---

#### Caveats

This introduces preprocessor usage into *fpm*, not sure if we are actually able to avoid it without using compiler extensions at this point.

Related #481, #172