### PR TITLE
Redirect output when searching for archiver

### DIFF
--- a/src/fpm.f90
+++ b/src/fpm.f90
@@ -4,12 +4,13 @@ use fpm_backend, only: build_package
 use fpm_command_line, only: fpm_build_settings, fpm_new_settings, &
                       fpm_run_settings, fpm_install_settings, fpm_test_settings
 use fpm_dependency, only : new_dependency_tree
-use fpm_environment, only: run, get_env, get_archiver
+use fpm_environment, only: run, get_env
 use fpm_filesystem, only: is_dir, join_path, number_of_rows, list_files, exists, basename
 use fpm_model, only: fpm_model_t, srcfile_t, show_model, &
                     FPM_SCOPE_UNKNOWN, FPM_SCOPE_LIB, FPM_SCOPE_DEP, &
                     FPM_SCOPE_APP, FPM_SCOPE_EXAMPLE, FPM_SCOPE_TEST
-use fpm_compiler, only: get_module_flags, is_unknown_compiler, get_default_c_compiler
+use fpm_compiler, only: get_module_flags, is_unknown_compiler, get_default_c_compiler, &
+                        get_archiver
 
 
 use fpm_sources, only: add_executable_sources, add_sources_from_dir

--- a/src/fpm_compiler.f90
+++ b/src/fpm_compiler.f90
@@ -475,7 +475,7 @@ function get_archiver() result(archiver)
     if (os_type /= OS_WINDOWS .and. os_type /= OS_UNKNOWN) then
         archiver = "ar -rs "
     else
-        call execute_command_line("ar --version > "//get_temp_filename(), &
+        call execute_command_line("ar --version > "//get_temp_filename()//" 2>&1", &
             & exitstat=estat)
         if (estat /= 0) then
             archiver = "lib /OUT:"

--- a/src/fpm_environment.f90
+++ b/src/fpm_environment.f90
@@ -12,7 +12,6 @@ module fpm_environment
     public :: os_is_unix
     public :: run
     public :: get_env
-    public :: get_archiver
     public :: get_command_arguments_quoted
     public :: separator
 
@@ -195,26 +194,6 @@ contains
         if(VALUE.eq.''.and.present(DEFAULT))VALUE=DEFAULT
      end function get_env
 
-    function get_archiver() result(archiver)
-        character(:), allocatable :: archiver
-
-        associate(os_type => get_os_type())
-            if (os_type /= OS_WINDOWS .and. os_type /= OS_UNKNOWN) then
-                archiver = "ar -rs "
-            else
-                block
-                    integer :: estat
-
-                    call execute_command_line("ar --version", exitstat=estat)
-                    if (estat /= 0) then
-                        archiver = "lib /OUT:"
-                    else
-                        archiver = "ar -rs "
-                    end if
-                end block
-            end if
-        end associate
-    end function
     function get_command_arguments_quoted() result(args)
     character(len=:),allocatable :: args
     character(len=:),allocatable :: arg


### PR DESCRIPTION
Requires some shuffling of routines to avoid dependency cycles.

Fixes https://github.com/fortran-lang/fpm/issues/456