### PR TITLE
correct for equal sign in flag options to fix #495

### DIFF
--- a/fpm.toml
+++ b/fpm.toml
@@ -12,7 +12,7 @@ rev = "2f5eaba864ff630ba0c3791126a3f811b6e437f3"
 
 [dependencies.M_CLI2]
 git = "https://github.com/urbanjost/M_CLI2.git"
-rev = "1f3b922ce35f105d1a51869bed9a1013b5b552b6"
+rev = "ea6bbffc1c2fb0885e994d37ccf0029c99b19f24"
 
 [[test]]
 name = "cli-test"

--- a/src/fpm_environment.f90
+++ b/src/fpm_environment.f90
@@ -215,8 +215,6 @@ contains
                     write(stderr,'(*(g0,1x))')'<ERROR>*get_command_arguments_stack* error obtaining argument ',i
                     exit
                 elseif(ilength.gt.0)then
-                    !TODO! should escape or double quotes depending on system
-                    !TODO! on some systems might have to do more to requote
                     if(index(arg//' ','-').ne.1)then
                         args=args//quote//arg//quote//' '
                     elseif(index(arg,' ').ne.0)then

--- a/src/fpm_environment.f90
+++ b/src/fpm_environment.f90
@@ -215,7 +215,11 @@ contains
                     write(stderr,'(*(g0,1x))')'<ERROR>*get_command_arguments_stack* error obtaining argument ',i
                     exit
                 elseif(ilength.gt.0)then
+                    !TODO! should escape or double quotes depending on system
+                    !TODO! on some systems might have to do more to requote
                     if(index(arg//' ','-').ne.1)then
+                        args=args//quote//arg//quote//' '
+                    elseif(index(arg,' ').ne.0)then
                         args=args//quote//arg//quote//' '
                     else
                         args=args//arg//' '

--- a/test/cli_test/cli_test.f90
+++ b/test/cli_test/cli_test.f90
@@ -53,7 +53,7 @@ character(len=*),parameter           :: tests(*)= [ character(len=256) :: &
 'CMD="run proj1 p2 project3 --profile debug",                      NAME="proj1","p2","project3",profile="debug",', &
 'CMD="run proj1 p2 project3 --profile release",                    NAME="proj1","p2","project3",profile="release",', &
 'CMD="run proj1 p2 project3 --profile release -- arg1 -x ""and a long one""", &
-   &NAME="proj1","p2","project3",profile="release",ARGS="""arg1"" -x ""and a long one""",                         ', &
+   &NAME="proj1","p2","project3",profile="release",ARGS="""arg1"" ""-x"" ""and a long one""",                         ', &
 
 'CMD="test",                                                                                              ', &
 'CMD="test my_project",                                            NAME="my_project",                     ', &
@@ -61,7 +61,7 @@ character(len=*),parameter           :: tests(*)= [ character(len=256) :: &
 'CMD="test proj1 p2 project3 --profile debug",                     NAME="proj1","p2","project3",profile="debug",', &
 'CMD="test proj1 p2 project3 --profile release",                   NAME="proj1","p2","project3",profile="release",', &
 'CMD="test proj1 p2 project3 --profile release -- arg1 -x ""and a long one""", &
-   &NAME="proj1","p2","project3",profile="release" ARGS="""arg1"" -x ""and a long one""",                         ', &
+   &NAME="proj1","p2","project3",profile="release" ARGS="""arg1"" ""-x"" ""and a long one""",                         ', &
 
 'CMD="build",                                                      NAME= profile="",ARGS="",', &
 'CMD="build --profile release",                                            NAME= profile="release",ARGS="",', &


### PR DESCRIPTION
Correction to allow for = in --flag option and also allow --keyword=value syntax on options

```text
   fpm run --flag -fsanitize=address
```
