### PR TITLE
Bump version for new release

### DIFF
--- a/fpm.toml
+++ b/fpm.toml
@@ -1,5 +1,5 @@
 name = "fpm"
-version = "0.2.0"
+version = "0.3.0"
 license = "MIT"
 author = "fpm maintainers"
 maintainer = ""

--- a/src/fpm_command_line.f90
+++ b/src/fpm_command_line.f90
@@ -138,7 +138,7 @@ contains
             case default     ; os_type =  "OS Type:     UNKNOWN"
         end select
         version_text = [character(len=80) :: &
-         &  'Version:     0.2.0, alpha',                           &
+         &  'Version:     0.3.0, alpha',                           &
          &  'Program:     fpm(1)',                                     &
          &  'Description: A Fortran package manager and build system', &
          &  'Home Page:   https://github.com/fortran-lang/fpm',        &


### PR DESCRIPTION
Based on #399, I've bumped the version to `0.3.0`. See below for draft release notes.

---

__Changes:__

- Add check for duplicate module names (not allowed) (#412)

- Add support for detecting FreeBSD (#468)

- Exit more gracefully with useful error messages for `build`,`run`,`test` (#491)

__New features:__

- Add `external-modules` manifest field to allow using installed library modules (#438)

- Add `-C`/`--directory` flag to change working directory (#483)

- Add automatic discovery of manifest files in parent directories (#483)

- Add simple support for invoking plugins from fpm (#484)

- Add support for specifying command line inputs via response files

- Add support for reading package version from file (#500)

__Fixes:__

- Fix default flags for Intel fortran on Windows (#431)

- Remove `-coarray=single` flag from default Intel flags (#437)

- Allow using the `lib` archiver in Windows (#442)

- Invoke matching c compiler when compiling c code (#433)

- Fix spurious output when checking for archiver (#489)

- Fix to module statement parsing (#490)

- Fix for specifying compiler flags containing an equals(=) sign (#497)

