### PR TITLE
quiet mode for #502

### DIFF
--- a/fpm.toml
+++ b/fpm.toml
@@ -14,6 +14,10 @@ rev = "2f5eaba864ff630ba0c3791126a3f811b6e437f3"
 git = "https://github.com/urbanjost/M_CLI2.git"
 rev = "ea6bbffc1c2fb0885e994d37ccf0029c99b19f24"
 
+[dependencies.M_escape]
+git = "https://github.com/urbanjost/M_escape.git"
+rev = "27973d212fcad5f19ba5115eaa1e5c7f4c193f30"
+
 [[test]]
 name = "cli-test"
 source-dir = "test/cli_test"

--- a/src/fpm.f90
+++ b/src/fpm.f90
@@ -4,7 +4,7 @@ use fpm_backend, only: build_package
 use fpm_command_line, only: fpm_build_settings, fpm_new_settings, &
                       fpm_run_settings, fpm_install_settings, fpm_test_settings
 use fpm_dependency, only : new_dependency_tree
-use fpm_environment, only: run, get_env
+use fpm_environment, only: run, get_env, fpm_stop
 use fpm_filesystem, only: is_dir, join_path, number_of_rows, list_files, exists, basename
 use fpm_model, only: fpm_model_t, srcfile_t, show_model, &
                     FPM_SCOPE_UNKNOWN, FPM_SCOPE_LIB, FPM_SCOPE_DEP, &
@@ -196,7 +196,7 @@ subroutine build_model(model, settings, package, error)
     ! Check for duplicate modules
     call check_modules_for_duplicates(model, duplicates_found)
     if (duplicates_found) then
-      error stop 'Error: One or more duplicate module names found.'
+      call fpm_stop(stopmsg='Error: One or more duplicate module names found.')
     end if
 end subroutine build_model
 
@@ -256,19 +256,19 @@ integer :: i
 call get_package_data(package, "fpm.toml", error, apply_defaults=.true.)
 if (allocated(error)) then
     print '(a)', error%message
-    error stop 1
+    call fpm_stop(1)
 end if
 
 call build_model(model, settings, package, error)
 if (allocated(error)) then
     print '(a)', error%message
-    error stop 1
+    call fpm_stop(1)
 end if
 
 call targets_from_sources(targets,model,error)
 if (allocated(error)) then
     print '(a)', error%message
-    error stop 1
+    call fpm_stop(1)
 end if
 
 if(settings%list)then
@@ -305,19 +305,19 @@ subroutine cmd_run(settings,test)
     call get_package_data(package, "fpm.toml", error, apply_defaults=.true.)
     if (allocated(error)) then
         print '(a)', error%message
-        error stop 1
+        call fpm_stop(1)
     end if
 
     call build_model(model, settings%fpm_build_settings, package, error)
     if (allocated(error)) then
         print '(a)', error%message
-        error stop 1
+        call fpm_stop(1)
     end if
 
     call targets_from_sources(targets,model,error)
     if (allocated(error)) then
         print '(a)', error%message
-        error stop 1
+        call fpm_stop(1)
     end if
 
     if (test) then

--- a/src/fpm.f90
+++ b/src/fpm.f90
@@ -1,6 +1,5 @@
 module fpm
 use M_escape, only : esc
-use fpm_global, only : config
 use fpm_strings, only: string_t, operator(.in.), glob, join, string_cat
 use fpm_backend, only: build_package
 use fpm_command_line, only: fpm_build_settings, fpm_new_settings, &
@@ -187,12 +186,12 @@ subroutine build_model(model, settings, package, error)
     end do
     if (allocated(error)) return
 
-    if (config%verbose) then
-        write(*,*)esc('<y><bo><E>  info:'),'          BUILD_NAME: ',settings%build_name
-        write(*,*)esc('<y><bo><E>  info:'),'            COMPILER: ',settings%compiler
-        write(*,*)esc('<y><bo><E>  info:'),'          C COMPILER: ',model%c_compiler
-        write(*,*)esc('<y><bo><E>  info:'),'    COMPILER OPTIONS: ', model%fortran_compile_flags
-        write(*,*)esc('<y><bo><E>  info:'),' INCLUDE DIRECTORIES: [', string_cat(model%include_dirs,','),']'
+    if (settings%verbose) then
+        write(*,'(*(g0,1x))')esc('<y><bo><E>  info:<g>          BUILD_NAME:'),settings%build_name
+        write(*,'(*(g0,1x))')esc('<y><bo><E>  info:<g>            COMPILER:'),settings%compiler
+        write(*,'(*(g0,1x))')esc('<y><bo><E>  info:<g>          C COMPILER:'),model%c_compiler
+        write(*,'(*(g0,1x))')esc('<y><bo><E>  info:<g>    COMPILER OPTIONS:'), model%fortran_compile_flags
+        write(*,'(*(g0,1x))')esc('<y><bo><E>  info:<g> INCLUDE DIRECTORIES:'),'[', string_cat(model%include_dirs,','),']'
      end if
 
     ! Check for duplicate modules
@@ -399,7 +398,7 @@ subroutine cmd_run(settings,test)
               end do
               write(stderr,'(A)') 'not found.'
               write(stderr,*)
-           else if(config%verbose)then
+           else if(settings%verbose)then
               write(stderr,'(A)',advance="yes")esc('<y><bo>  info:')//' when more than one executable is available'
               write(stderr,'(A)',advance="yes")'       program names must be specified.'
            endif
@@ -426,9 +425,9 @@ subroutine cmd_run(settings,test)
             if (exists(executables(i)%s)) then
                 if(settings%runner .ne. ' ')then
                     call run(settings%runner//' '//executables(i)%s//" "//settings%args, &
-                             echo=config%verbose, exitstat=stat(i))
+                             echo=settings%verbose, exitstat=stat(i))
                 else
-                    call run(executables(i)%s//" "//settings%args,echo=config%verbose, &
+                    call run(executables(i)%s//" "//settings%args,echo=settings%verbose, &
                              exitstat=stat(i))
                 endif
             else

--- a/src/fpm.f90
+++ b/src/fpm.f90
@@ -1,4 +1,6 @@
 module fpm
+use M_escape, only : esc
+use fpm_global, only : config
 use fpm_strings, only: string_t, operator(.in.), glob, join, string_cat
 use fpm_backend, only: build_package
 use fpm_command_line, only: fpm_build_settings, fpm_new_settings, &
@@ -185,12 +187,12 @@ subroutine build_model(model, settings, package, error)
     end do
     if (allocated(error)) return
 
-    if (settings%verbose) then
-        write(*,*)'<INFO> BUILD_NAME: ',settings%build_name
-        write(*,*)'<INFO> COMPILER:  ',settings%compiler
-        write(*,*)'<INFO> C COMPILER:  ',model%c_compiler
-        write(*,*)'<INFO> COMPILER OPTIONS:  ', model%fortran_compile_flags
-        write(*,*)'<INFO> INCLUDE DIRECTORIES:  [', string_cat(model%include_dirs,','),']'
+    if (config%verbose) then
+        write(*,*)esc('<y><bo><E>  info:'),'          BUILD_NAME: ',settings%build_name
+        write(*,*)esc('<y><bo><E>  info:'),'            COMPILER: ',settings%compiler
+        write(*,*)esc('<y><bo><E>  info:'),'          C COMPILER: ',model%c_compiler
+        write(*,*)esc('<y><bo><E>  info:'),'    COMPILER OPTIONS: ', model%fortran_compile_flags
+        write(*,*)esc('<y><bo><E>  info:'),' INCLUDE DIRECTORIES: [', string_cat(model%include_dirs,','),']'
      end if
 
     ! Check for duplicate modules
@@ -391,15 +393,15 @@ subroutine cmd_run(settings,test)
         line=join(settings%name)
         if(line.ne.'.')then ! do not report these special strings
            if(any(.not.found))then
-              write(stderr,'(A)',advance="no")'fpm::run<ERROR> specified names '
+              write(stderr,'(A)',advance="no") esc('<r><bo>error:')//' specified names '
               do j=1,size(settings%name)
                   if (.not.found(j)) write(stderr,'(A)',advance="no") '"'//trim(settings%name(j))//'" '
               end do
               write(stderr,'(A)') 'not found.'
               write(stderr,*)
-           else if(settings%verbose)then
-              write(stderr,'(A)',advance="yes")'<INFO>when more than one executable is available'
-              write(stderr,'(A)',advance="yes")'      program names must be specified.'
+           else if(config%verbose)then
+              write(stderr,'(A)',advance="yes")esc('<y><bo>  info:')//' when more than one executable is available'
+              write(stderr,'(A)',advance="yes")'       program names must be specified.'
            endif
         endif
 
@@ -424,13 +426,13 @@ subroutine cmd_run(settings,test)
             if (exists(executables(i)%s)) then
                 if(settings%runner .ne. ' ')then
                     call run(settings%runner//' '//executables(i)%s//" "//settings%args, &
-                             echo=settings%verbose, exitstat=stat(i))
+                             echo=config%verbose, exitstat=stat(i))
                 else
-                    call run(executables(i)%s//" "//settings%args,echo=settings%verbose, &
+                    call run(executables(i)%s//" "//settings%args,echo=config%verbose, &
                              exitstat=stat(i))
                 endif
             else
-                write(stderr,*)'fpm::run<ERROR>',executables(i)%s,' not found'
+                write(stderr,*) esc('<r><bo>error:'),executables(i)%s,' not found'
                 stop 1
             end if
         end do
@@ -438,7 +440,7 @@ subroutine cmd_run(settings,test)
         if (any(stat /= 0)) then
             do i=1,size(stat)
                 if (stat(i) /= 0) then
-                    write(*,*) '<ERROR> Execution failed for "',basename(executables(i)%s),'"'
+                    write(*,*) esc('<r><bo>error:'),' Execution failed for "',basename(executables(i)%s),'"'
                 end if
             end do
             stop 1

--- a/src/fpm.f90
+++ b/src/fpm.f90
@@ -440,7 +440,7 @@ subroutine cmd_run(settings,test)
         if (any(stat /= 0)) then
             do i=1,size(stat)
                 if (stat(i) /= 0) then
-                    write(*,*) esc('<r><bo>error:'),' Execution failed for "',basename(executables(i)%s),'"'
+                    write(*,*) esc('<r><bo>error: Execution failed for "'),basename(executables(i)%s),'"'
                 end if
             end do
             stop 1

--- a/src/fpm/cmd/install.f90
+++ b/src/fpm/cmd/install.f90
@@ -1,6 +1,7 @@
 module fpm_cmd_install
   use, intrinsic :: iso_fortran_env, only : output_unit
   use fpm, only : build_model
+  use fpm_environment, only : fpm_stop
   use fpm_backend, only : build_package
   use fpm_command_line, only : fpm_install_settings
   use fpm_error, only : error_t, fatal_error
@@ -168,8 +169,7 @@ contains
   subroutine handle_error(error)
     type(error_t), intent(in), optional :: error
     if (present(error)) then
-      print '("[Error]", 1x, a)', error%message
-      error stop 1
+      call fpm_stop(1,"[Error] "//error%message)
     end if
   end subroutine handle_error
 

--- a/src/fpm/cmd/install.f90
+++ b/src/fpm/cmd/install.f90
@@ -1,6 +1,5 @@
 module fpm_cmd_install
   use, intrinsic :: iso_fortran_env, only : output_unit
-  use fpm_global, only : config
   use fpm, only : build_model
   use fpm_environment, only : fpm_stop
   use fpm_backend, only : build_package
@@ -60,7 +59,7 @@ contains
     call new_installer(installer, prefix=settings%prefix, &
       bindir=settings%bindir, libdir=settings%libdir, &
       includedir=settings%includedir, &
-      verbosity=merge(2, 1, config%verbose))
+      verbosity=merge(2, 1, settings%verbose))
 
     if (allocated(package%library) .and. package%install%library) then
       dir = join_path(model%output_directory, model%package_name)

--- a/src/fpm/cmd/install.f90
+++ b/src/fpm/cmd/install.f90
@@ -1,5 +1,6 @@
 module fpm_cmd_install
   use, intrinsic :: iso_fortran_env, only : output_unit
+  use fpm_global, only : config
   use fpm, only : build_model
   use fpm_environment, only : fpm_stop
   use fpm_backend, only : build_package
@@ -59,7 +60,7 @@ contains
     call new_installer(installer, prefix=settings%prefix, &
       bindir=settings%bindir, libdir=settings%libdir, &
       includedir=settings%includedir, &
-      verbosity=merge(2, 1, settings%verbose))
+      verbosity=merge(2, 1, config%verbose))
 
     if (allocated(package%library) .and. package%install%library) then
       dir = join_path(model%output_directory, model%package_name)

--- a/src/fpm/cmd/new.f90
+++ b/src/fpm/cmd/new.f90
@@ -54,7 +54,6 @@ module fpm_cmd_new
 !> be the first go-to for a CLI utility).
 
 use M_escape, only : esc
-use fpm_global, only : config
 use fpm_command_line, only : fpm_new_settings
 use fpm_environment, only : run, OS_LINUX, OS_MACOS, OS_WINDOWS
 use fpm_filesystem, only : join_path, exists, basename, mkdir, is_dir, to_fortran_name
@@ -610,7 +609,7 @@ character(len=*),intent(in) :: filename
     ! ...
     call new_package(package, table, error=error)
     if (allocated(error)) stop 3
-    if(config%verbose)then
+    if(settings%verbose)then
        call table%accept(ser)
     endif
     ser%unit=lun
@@ -639,7 +638,7 @@ joined_string = join(input,right=nl)
 if (allocated(table)) deallocate(table)
 call toml_parse(table, joined_string)
 if (allocated(table)) then
-   if(config%verbose)then
+   if(settings%verbose)then
       ! If the TOML file is successfully parsed the table will be allocated and
       ! can be written to the standard output by passing the `toml_serializer`
       ! as visitor to the table.

--- a/src/fpm/cmd/new.f90
+++ b/src/fpm/cmd/new.f90
@@ -53,6 +53,8 @@ module fpm_cmd_new
 !> although some other command might provide that (and the help command should
 !> be the first go-to for a CLI utility).
 
+use M_escape, only : esc
+use fpm_global, only : config
 use fpm_command_line, only : fpm_new_settings
 use fpm_environment, only : run, OS_LINUX, OS_MACOS, OS_WINDOWS
 use fpm_filesystem, only : join_path, exists, basename, mkdir, is_dir, to_fortran_name
@@ -75,8 +77,8 @@ character(len=:,kind=tfc),allocatable :: littlefile(:)
     !> TOP DIRECTORY NAME PROCESSING
     !> see if requested new directory already exists and process appropriately
     if(exists(settings%name) .and. .not.settings%backfill )then
-        write(stderr,'(*(g0,1x))')&
-        & '<ERROR>',settings%name,'already exists.'
+        write(stderr,'(*(g0,1x))') esc('<r><bo>error:'), &
+        & settings%name,'already exists.'
         write(stderr,'(*(g0,1x))')&
         & '        perhaps you wanted to add --backfill ?'
         return
@@ -84,7 +86,8 @@ character(len=:,kind=tfc),allocatable :: littlefile(:)
         write(*,'(*(g0))')'backfilling ',settings%name
     elseif(exists(settings%name) )then
         write(stderr,'(*(g0,1x))')&
-        & '<ERROR>',settings%name,'already exists and is not a directory.'
+        & esc('<r><bo>error:'), &
+        & settings%name,'already exists and is not a directory.'
         return
     else
         ! make new directory
@@ -607,7 +610,7 @@ character(len=*),intent(in) :: filename
     ! ...
     call new_package(package, table, error=error)
     if (allocated(error)) stop 3
-    if(settings%verbose)then
+    if(config%verbose)then
        call table%accept(ser)
     endif
     ser%unit=lun
@@ -636,7 +639,7 @@ joined_string = join(input,right=nl)
 if (allocated(table)) deallocate(table)
 call toml_parse(table, joined_string)
 if (allocated(table)) then
-   if(settings%verbose)then
+   if(config%verbose)then
       ! If the TOML file is successfully parsed the table will be allocated and
       ! can be written to the standard output by passing the `toml_serializer`
       ! as visitor to the table.

--- a/src/fpm/cmd/update.f90
+++ b/src/fpm/cmd/update.f90
@@ -1,4 +1,5 @@
 module fpm_cmd_update
+  use fpm_global, only : config
   use fpm_environment, only : fpm_stop
   use fpm_command_line, only : fpm_update_settings
   use fpm_dependency, only : dependency_tree_t, new_dependency_tree
@@ -35,7 +36,7 @@ contains
     end if
 
     call new_dependency_tree(deps, cache=cache, &
-      verbosity=merge(2, 1, settings%verbose))
+      verbosity=merge(2, 1, config%verbose))
 
     call deps%add(package, error)
     call handle_error(error)

--- a/src/fpm/cmd/update.f90
+++ b/src/fpm/cmd/update.f90
@@ -1,5 +1,4 @@
 module fpm_cmd_update
-  use fpm_global, only : config
   use fpm_environment, only : fpm_stop
   use fpm_command_line, only : fpm_update_settings
   use fpm_dependency, only : dependency_tree_t, new_dependency_tree
@@ -36,7 +35,7 @@ contains
     end if
 
     call new_dependency_tree(deps, cache=cache, &
-      verbosity=merge(2, 1, config%verbose))
+      verbosity=merge(2, 1, settings%verbose))
 
     call deps%add(package, error)
     call handle_error(error)

--- a/src/fpm/cmd/update.f90
+++ b/src/fpm/cmd/update.f90
@@ -1,4 +1,5 @@
 module fpm_cmd_update
+  use fpm_environment, only : fpm_stop
   use fpm_command_line, only : fpm_update_settings
   use fpm_dependency, only : dependency_tree_t, new_dependency_tree
   use fpm_error, only : error_t
@@ -60,8 +61,7 @@ contains
     !> Potential error
     type(error_t), intent(in), optional :: error
     if (present(error)) then
-      print '(a)', error%message
-      error stop 1
+      call fpm_stop(stopcode=1,stopmsg=error%message)
     end if
   end subroutine handle_error
 

--- a/src/fpm_backend.f90
+++ b/src/fpm_backend.f90
@@ -278,7 +278,7 @@ subroutine build_target(model,target,stat)
 
     case (FPM_TARGET_EXECUTABLE)
 
-        write(*,('(a)')) esc('<E><bo><c>    load:')//' '//target%output_file
+        write(*,('(a)')) esc('<E><bo><c>    load:')//' '//basename(target%output_file)
         call run(model%fortran_compiler// " " // target%compile_flags &
               //" "//target%link_flags// " -o " // target%output_file, echo=.false., exitstat=stat)
 
@@ -287,12 +287,12 @@ subroutine build_target(model,target,stat)
         select case (get_os_type())
         case (OS_WINDOWS)
             call write_response_file(target%output_file//".resp" ,target%link_objects)
-            write(*,('(a)')) esc('<E><bo><y> archive:')//' '//target%output_file
+            write(*,('(a)')) esc('<E><bo><y> archive:')//' '//basename(target%output_file)
             call run(model%archiver // target%output_file // " @" // target%output_file//".resp", &
                      echo=.false., exitstat=stat)
 
         case default
-            write(*,('(a)')) esc('<E><bo><y> archive:')//' '//target%output_file
+            write(*,('(a)')) esc('<E><bo><y> archive:')//' '//basename(target%output_file)
             call run(model%archiver // target%output_file // " " // string_cat(target%link_objects," "), &
                      echo=.false., exitstat=stat)
 

--- a/src/fpm_backend.f90
+++ b/src/fpm_backend.f90
@@ -268,20 +268,20 @@ subroutine build_target(model,target,stat)
 
     case (FPM_TARGET_OBJECT)
         if(.not.CONFIG_VERBOSE) write(*,('(a)')) &
-                esc('<B><bo><w>'//model%fortran_compiler//':</B></w><bo>'//target%source%file_name)
+                esc('<B><bo><w>compile:')//target%source%file_name
         call run(model%fortran_compiler//" -c " // target%source%file_name // target%compile_flags &
               // " -o " // target%output_file, echo=CONFIG_VERBOSE, exitstat=stat)
 
     case (FPM_TARGET_C_OBJECT)
         if(.not.CONFIG_VERBOSE) write(*,('(a)')) &
-                esc('<B><bo><w>'//model%fortran_compiler//':</B></w><bo>'//target%source%file_name)
+                esc('<B><bo><w>compile:')//target%source%file_name
         call run(model%c_compiler//" -c " // target%source%file_name // target%compile_flags &
                 // " -o " // target%output_file, echo=CONFIG_VERBOSE, exitstat=stat)
 
     case (FPM_TARGET_EXECUTABLE)
 
         if(.not.CONFIG_VERBOSE) write(*,('(a)')) &
-                esc('<G><bo><w>'//model%fortran_compiler//':</B></w><bo>'//target%output_file)
+                esc('<G><bo><w>load   :')//target%output_file
         call run(model%fortran_compiler// " " // target%compile_flags &
               //" "//target%link_flags// " -o " // target%output_file, echo=CONFIG_VERBOSE, exitstat=stat)
 
@@ -291,13 +291,13 @@ subroutine build_target(model,target,stat)
         case (OS_WINDOWS)
             call write_response_file(target%output_file//".resp" ,target%link_objects)
             if(.not.CONFIG_VERBOSE) write(*,('(a)')) &
-                    esc('<G><bo><w>'//model%archiver//':</G></w><bo>'//target%output_file)
+                    esc('<G><bo><w>archive:')//target%output_file
             call run(model%archiver // target%output_file // " @" // target%output_file//".resp", &
                      echo=CONFIG_VERBOSE, exitstat=stat)
 
         case default
             if(.not.CONFIG_VERBOSE) write(*,('(a)')) &
-                    esc('<G><bo><w>'//model%archiver//':</G></w><bo>'//string_cat(target%link_objects," "))
+                    esc('<G><bo><w>archive:')//string_cat(target%link_objects," ")
             call run(model%archiver // target%output_file // " " // string_cat(target%link_objects," "), &
                      echo=CONFIG_VERBOSE, exitstat=stat)
 

--- a/src/fpm_backend.f90
+++ b/src/fpm_backend.f90
@@ -281,7 +281,7 @@ subroutine build_target(model,target,stat)
     case (FPM_TARGET_EXECUTABLE)
 
         if(.not.CONFIG_VERBOSE) write(*,('(a)')) &
-                esc('<G><bo><w>load   :')//target%output_file
+                esc('<W><bo><b>load   :')//target%output_file
         call run(model%fortran_compiler// " " // target%compile_flags &
               //" "//target%link_flags// " -o " // target%output_file, echo=CONFIG_VERBOSE, exitstat=stat)
 
@@ -291,13 +291,13 @@ subroutine build_target(model,target,stat)
         case (OS_WINDOWS)
             call write_response_file(target%output_file//".resp" ,target%link_objects)
             if(.not.CONFIG_VERBOSE) write(*,('(a)')) &
-                    esc('<G><bo><w>archive:')//target%output_file
+                    esc('<W><bo><b>archive:')//target%output_file
             call run(model%archiver // target%output_file // " @" // target%output_file//".resp", &
                      echo=CONFIG_VERBOSE, exitstat=stat)
 
         case default
             if(.not.CONFIG_VERBOSE) write(*,('(a)')) &
-                    esc('<G><bo><w>archive:')//string_cat(target%link_objects," ")
+                    esc('<W><bo><b>archive:')//string_cat(target%link_objects," ")
             call run(model%archiver // target%output_file // " " // string_cat(target%link_objects," "), &
                      echo=CONFIG_VERBOSE, exitstat=stat)
 

--- a/src/fpm_backend.f90
+++ b/src/fpm_backend.f90
@@ -27,7 +27,6 @@
 !>
 module fpm_backend
 
-use fpm_global, only : config
 use fpm_environment, only: run, get_os_type, OS_WINDOWS
 use fpm_filesystem, only: basename, dirname, join_path, exists, mkdir, unix_path
 use fpm_model, only: fpm_model_t
@@ -83,7 +82,7 @@ subroutine build_package(targets,model)
             ! Check if build already failed
             !$omp atomic read
             skip_current = build_failed
-            
+
             if (.not.skip_current) then
                 call build_target(model,queue(j)%ptr,stat(j))
             end if
@@ -268,34 +267,34 @@ subroutine build_target(model,target,stat)
     select case(target%target_type)
 
     case (FPM_TARGET_OBJECT)
-        if(.not.config%verbose) write(*,('(a)')) esc('<B><bo><w>compile:')//' '//target%source%file_name
+        write(*,('(a)')) esc('<E><bo><g> compile:')//' '//target%source%file_name
         call run(model%fortran_compiler//" -c " // target%source%file_name // target%compile_flags &
-              // " -o " // target%output_file, echo=config%verbose, exitstat=stat)
+              // " -o " // target%output_file, echo=.false., exitstat=stat)
 
     case (FPM_TARGET_C_OBJECT)
-        if(.not.config%verbose) write(*,('(a)')) esc('<B><bo><w>compile:')//' '//target%source%file_name
+        write(*,('(a)')) esc('<E><bo><g> compile:')//' '//target%source%file_name
         call run(model%c_compiler//" -c " // target%source%file_name // target%compile_flags &
-                // " -o " // target%output_file, echo=config%verbose, exitstat=stat)
+                // " -o " // target%output_file, echo=.false., exitstat=stat)
 
     case (FPM_TARGET_EXECUTABLE)
 
-        if(.not.config%verbose) write(*,('(a)')) esc('<W><bo><b>   load:')//' '//target%output_file
+        write(*,('(a)')) esc('<E><bo><c>    load:')//' '//target%output_file
         call run(model%fortran_compiler// " " // target%compile_flags &
-              //" "//target%link_flags// " -o " // target%output_file, echo=config%verbose, exitstat=stat)
+              //" "//target%link_flags// " -o " // target%output_file, echo=.false., exitstat=stat)
 
     case (FPM_TARGET_ARCHIVE)
 
         select case (get_os_type())
         case (OS_WINDOWS)
             call write_response_file(target%output_file//".resp" ,target%link_objects)
-            if(.not.config%verbose) write(*,('(a)')) esc('<W><bo><b>archive:')//' '//target%output_file
+            write(*,('(a)')) esc('<E><bo><y> archive:')//' '//target%output_file
             call run(model%archiver // target%output_file // " @" // target%output_file//".resp", &
-                     echo=config%verbose, exitstat=stat)
+                     echo=.false., exitstat=stat)
 
         case default
-            if(.not.config%verbose) write(*,('(a)')) esc('<W><bo><b>archive:')//' '//target%output_file
+            write(*,('(a)')) esc('<E><bo><y> archive:')//' '//target%output_file
             call run(model%archiver // target%output_file // " " // string_cat(target%link_objects," "), &
-                     echo=config%verbose, exitstat=stat)
+                     echo=.false., exitstat=stat)
 
         end select
 

--- a/src/fpm_backend.f90
+++ b/src/fpm_backend.f90
@@ -27,12 +27,13 @@
 !>
 module fpm_backend
 
-use fpm_environment, only: run, get_os_type, OS_WINDOWS
+use fpm_environment, only: run, get_os_type, OS_WINDOWS, CONFIG_VERBOSE
 use fpm_filesystem, only: basename, dirname, join_path, exists, mkdir, unix_path
 use fpm_model, only: fpm_model_t
 use fpm_targets, only: build_target_t, build_target_ptr, FPM_TARGET_OBJECT, &
                        FPM_TARGET_C_OBJECT, FPM_TARGET_ARCHIVE, FPM_TARGET_EXECUTABLE
 use fpm_strings, only: string_cat, string_t
+use M_escape, only : esc
 
 implicit none
 
@@ -266,29 +267,39 @@ subroutine build_target(model,target,stat)
     select case(target%target_type)
 
     case (FPM_TARGET_OBJECT)
+        if(.not.CONFIG_VERBOSE) write(*,('(a)')) &
+                esc('<B><bo><w>'//model%fortran_compiler//':</B></w><bo>'//target%source%file_name)
         call run(model%fortran_compiler//" -c " // target%source%file_name // target%compile_flags &
-              // " -o " // target%output_file, echo=.true., exitstat=stat)
+              // " -o " // target%output_file, echo=CONFIG_VERBOSE, exitstat=stat)
 
     case (FPM_TARGET_C_OBJECT)
+        if(.not.CONFIG_VERBOSE) write(*,('(a)')) &
+                esc('<B><bo><w>'//model%fortran_compiler//':</B></w><bo>'//target%source%file_name)
         call run(model%c_compiler//" -c " // target%source%file_name // target%compile_flags &
-                // " -o " // target%output_file, echo=.true., exitstat=stat)
+                // " -o " // target%output_file, echo=CONFIG_VERBOSE, exitstat=stat)
 
     case (FPM_TARGET_EXECUTABLE)
 
+        if(.not.CONFIG_VERBOSE) write(*,('(a)')) &
+                esc('<G><bo><w>'//model%fortran_compiler//':</B></w><bo>'//target%output_file)
         call run(model%fortran_compiler// " " // target%compile_flags &
-              //" "//target%link_flags// " -o " // target%output_file, echo=.true., exitstat=stat)
+              //" "//target%link_flags// " -o " // target%output_file, echo=CONFIG_VERBOSE, exitstat=stat)
 
     case (FPM_TARGET_ARCHIVE)
 
         select case (get_os_type())
         case (OS_WINDOWS)
             call write_response_file(target%output_file//".resp" ,target%link_objects)
+            if(.not.CONFIG_VERBOSE) write(*,('(a)')) &
+                    esc('<G><bo><w>'//model%archiver//':</G></w><bo>'//target%output_file)
             call run(model%archiver // target%output_file // " @" // target%output_file//".resp", &
-                     echo=.true., exitstat=stat)
+                     echo=CONFIG_VERBOSE, exitstat=stat)
 
         case default
+            if(.not.CONFIG_VERBOSE) write(*,('(a)')) &
+                    esc('<G><bo><w>'//model%archiver//':</G></w><bo>'//string_cat(target%link_objects," "))
             call run(model%archiver // target%output_file // " " // string_cat(target%link_objects," "), &
-                     echo=.true., exitstat=stat)
+                     echo=CONFIG_VERBOSE, exitstat=stat)
 
         end select
 

--- a/src/fpm_command_line.f90
+++ b/src/fpm_command_line.f90
@@ -127,7 +127,11 @@ contains
         character(len=10)             :: color_mode
 
         ! conventional GNU keywords for color are "auto", "never", "always" so map to M_escape
-        color_mode=get_env('FPM_COLOR','auto')
+        if(get_os_type().eq.OS_WINDOWS)then
+           color_mode=get_env('FPM_COLOR','plain')
+        else
+           color_mode=get_env('FPM_COLOR','color')
+        endif
         select case(color_mode)
         case('color','always'); color_mode='color'
         case('plain','never');  color_mode='plain'

--- a/src/fpm_command_line.f90
+++ b/src/fpm_command_line.f90
@@ -602,22 +602,36 @@ contains
    ' <bo>Note:</bo> color mode is controlled by the environment variable FPM_COLOR. The', &
    '       set of allowable values is {<g><bo>always,never,auto</bo></g><w>}. The default is "<g><bo>auto</bo></g><w>". ', &
    ' ']
-   help_list_dash = [character(len=90) :: &
+   help_list_dash = [character(len=256) :: &
    !'<clear>', &
-   '<b><bo>F</bo>ortran <bo>P</bo>ackage <bo>M</bo>anager:</b>', &
-   '                                                                                ', &
-   ' <bo><g>build</g></bo><w> [--compiler COMPILER_NAME] [--profile PROF] [--flag FFLAGS] [--list]          ', &
-   ' <bo><g>help</g></bo><w> [NAME(s)]                                                                 ', &
-   ' <bo><g>new</g></bo><w> NAME [[--lib|--src] [--app] [--test] [--example]]|                         ', &
-   '          </bo>[--full|--bare][--backfill]                                           ', &
-   ' <bo><g>update</g></bo><w> [NAME(s)] [--fetch-only] [--clean] [--verbose]                          ', &
-   ' <bo><g>list</g></bo><w> [--list]                                                                  ', &
-   ' <bo><g>run</g></bo><w>  [[--target] NAME(s) [--example] [--profile PROF] [--flag FFLAGS] [--all]       ', &
-   '      </bo>[--runner "CMD"] [--compiler COMPILER_NAME] [--list] [-- ARGS]            ', &
-   ' <bo><g>test</g></bo><w> [[--target] NAME(s)] [--profile PROF] [--flag FFLAGS] [--runner "CMD"]', &
-   '      </bo>[--list] [--compiler COMPILER_NAME] [-- ARGS]                                      ', &
-   ' <bo><g>install</g></bo><w> [--profile PROF] [--flag FFLAGS] [--no-rebuild] [--prefix PATH] ', &
-   '         </bo>[options]   ', &
+   '<b><bo>F</bo>ortran </bo>P</bo>ackage <bo>M</bo>anager:</b>', &
+   '                                                           ', &
+   ' <bo><g>build</g><w> [<g>--compiler</g> <m>COMPILER_NAME</m><w>] &
+   &[<g>--profile</g> <m>PROF</m><w>] [<g>--flag</g> <m>FFLAGS</m><w>] [<g>--list</g><w>]', &
+
+   ' <bo><g>help</g><w> [<r><un>NAME(s)</un></r><w>]                       ', &
+
+   ' <bo><g>new</g><w> <r><un>NAME</un></r><w> [[<g>--lib</g><w>|<g>--src</g><w>] [<g>--app</g><w>] &
+   &[<g>--test</g><w>] [<g>--example</g><w>]]|', &
+   ' <bo>         [<g>--full</g><w>|<g>--bare</g><w>][<g>--backfill</g><w>]', &
+
+   ' <bo><g>update</g><w> <w>[<r><un>NAME(s)</un></r><w>] [<g>--fetch-only</g><w>] [<g>--clean</g><w>] [<g>--verbose</g><w>]', &
+
+   ' <bo><g>list</g><w> [<g>--list</g><w>]', &
+
+   ' <bo><g>run</g><w>  [[<g>--target</g><w>] <r><un>NAME(s)</un></r> <w>[<g>--example</g><w>]&
+   &[<g>--profile</g><w> <m>PROF</m><w>] [<g>--flag</g><w> <m>FFLAGS</m><w>] [<g>--all</g><w>]', &
+   ' <bo>     [<g>--runner</g><w> <m>"CMD"</m><w>] [<g>--compiler</g><w> <m>COMPILER_NAME</m><w>] &
+   &[<g>--list</g><w>] [-- <m>ARGS</m><w>]', &
+
+   ' <bo><g>test</g><w> [[<g>--target</g><w>] <r><un>NAME(s)</un></r><w>] [<g>--profile</g><w> <m>PROF</m><w>] &
+   &[<g>--flag</g><w> <m>FFLAGS</m><w>] [<g>--runner</g><w> <m>"CMD"</m><w>]', &
+   ' <bo>     [<g>--list</g><w>] [<g>--compiler</g><w> <m>COMPILER_NAME</m><w>] [-- <m>ARGS</m><w>]', &
+
+   ' <bo><g>install</g><w> [<g>--profile</g><w> <m>PROF</m>] [<g>--flag</g><w> <m>FFLAGS</m>] &
+
+   &[<g>--no-rebuild</g><w>] [<g>--prefix</g><w> <m>PATH</m><w>] ', &
+   ' <bo>        <w>[<m>OPTIONS</m><w>]', &
    ' ']
     help_usage=[character(len=256) :: &
     '' ]

--- a/src/fpm_command_line.f90
+++ b/src/fpm_command_line.f90
@@ -128,9 +128,9 @@ contains
 
         ! conventional GNU keywords for color are "auto", "never", "always" so map to M_escape
         if(get_os_type().eq.OS_WINDOWS)then
-           color_mode=get_env('FPM_COLOR','plain')
-        else
            color_mode=get_env('FPM_COLOR','color')
+        else
+           color_mode=get_env('FPM_COLOR','auto')
         endif
         select case(color_mode)
         case('color','always'); color_mode='color'

--- a/src/fpm_command_line.f90
+++ b/src/fpm_command_line.f90
@@ -794,6 +794,11 @@ contains
     '   (currently) allow for continued lines or multiple specifications of ', &
     '   the same option.                                                    ', &
     '                                                                       ', &
+    'COLOR                                                                  ', &
+    '   Message color mode is controlled by the environment variable        ', &
+    '   FPM_COLOR. The allowable values are "always","never", or "auto".    ', &
+    '   The default is "auto".                                              ', &
+    '                                                                       ', &
     'EXAMPLES                                                               ', &
     '   sample commands:                                                    ', &
     '                                                                       ', &

--- a/src/fpm_command_line.f90
+++ b/src/fpm_command_line.f90
@@ -608,28 +608,27 @@ contains
    '                                                           ', &
    ' <bo><g>build</g><w> [<g>--compiler</g> <m>COMPILER_NAME</m><w>] &
    &[<g>--profile</g> <m>PROF</m><w>] [<g>--flag</g> <m>FFLAGS</m><w>] [<g>--list</g><w>]', &
-
+   '                                                           ', &
    ' <bo><g>help</g><w> [<r><un>NAME(s)</un></r><w>]                       ', &
-
+   '                                                           ', &
    ' <bo><g>new</g><w> <r><un>NAME</un></r><w> [[<g>--lib</g><w>|<g>--src</g><w>] [<g>--app</g><w>] &
    &[<g>--test</g><w>] [<g>--example</g><w>]]|', &
    ' <bo>         [<g>--full</g><w>|<g>--bare</g><w>][<g>--backfill</g><w>]', &
-
+   '                                                           ', &
    ' <bo><g>update</g><w> <w>[<r><un>NAME(s)</un></r><w>] [<g>--fetch-only</g><w>] [<g>--clean</g><w>] [<g>--verbose</g><w>]', &
-
+   '                                                           ', &
    ' <bo><g>list</g><w> [<g>--list</g><w>]', &
-
+   '                                                           ', &
    ' <bo><g>run</g><w>  [[<g>--target</g><w>] <r><un>NAME(s)</un></r> <w>[<g>--example</g><w>]&
    &[<g>--profile</g><w> <m>PROF</m><w>] [<g>--flag</g><w> <m>FFLAGS</m><w>] [<g>--all</g><w>]', &
    ' <bo>     [<g>--runner</g><w> <m>"CMD"</m><w>] [<g>--compiler</g><w> <m>COMPILER_NAME</m><w>] &
    &[<g>--list</g><w>] [-- <m>ARGS</m><w>]', &
-
+   '                                                           ', &
    ' <bo><g>test</g><w> [[<g>--target</g><w>] <r><un>NAME(s)</un></r><w>] [<g>--profile</g><w> <m>PROF</m><w>] &
    &[<g>--flag</g><w> <m>FFLAGS</m><w>] [<g>--runner</g><w> <m>"CMD"</m><w>]', &
    ' <bo>     [<g>--list</g><w>] [<g>--compiler</g><w> <m>COMPILER_NAME</m><w>] [-- <m>ARGS</m><w>]', &
-
+   '                                                           ', &
    ' <bo><g>install</g><w> [<g>--profile</g><w> <m>PROF</m>] [<g>--flag</g><w> <m>FFLAGS</m>] &
-
    &[<g>--no-rebuild</g><w>] [<g>--prefix</g><w> <m>PATH</m><w>] ', &
    ' <bo>        <w>[<m>OPTIONS</m><w>]', &
    ' ']

--- a/src/fpm_command_line.f90
+++ b/src/fpm_command_line.f90
@@ -128,7 +128,7 @@ contains
 
         ! conventional GNU keywords for color are "auto", "never", "always" so map to M_escape
         if(get_os_type().eq.OS_WINDOWS)then
-           color_mode=get_env('FPM_COLOR','color')
+           color_mode=get_env('FPM_COLOR','plain')
         else
            color_mode=get_env('FPM_COLOR','auto')
         endif

--- a/src/fpm_environment.f90
+++ b/src/fpm_environment.f90
@@ -6,7 +6,6 @@ module fpm_environment
     use,intrinsic :: iso_fortran_env, only : stdin=>input_unit,   &
                                            & stdout=>output_unit, &
                                            & stderr=>error_unit
-    use fpm_global, only : config
     use M_escape, only : esc
     implicit none
     private
@@ -167,20 +166,17 @@ contains
 
     end subroutine run
 
-    !> if verbose mode perform an ERROR STOP else perform a STOP
+    !> stop displaying optionally displaying potentially colored message
     subroutine fpm_stop(stopcode,stopmsg)
     implicit none
     integer,intent(in),optional          :: stopcode
     character(len=*),intent(in),optional :: stopmsg
     integer                              :: local_code
     integer                              :: ios
-       if(present(stopcode))then;local_code=stopcode;else;local_code=0;endif
+       local_code=0
+       if(present(stopcode))local_code=stopcode
        if(present(stopmsg)) write(stderr,'(a)',iostat=ios)esc('<r><bo>'//stopmsg)
-       if(config%verbose)then
-          error stop local_code
-       else
-          stop local_code
-       endif
+       stop local_code
     end subroutine fpm_stop
 
     !> get named environment variable value. It it is blank or

--- a/src/fpm_environment.f90
+++ b/src/fpm_environment.f90
@@ -6,6 +6,7 @@ module fpm_environment
     use,intrinsic :: iso_fortran_env, only : stdin=>input_unit,   &
                                            & stdout=>output_unit, &
                                            & stderr=>error_unit
+    use fpm_global, only : config
     use M_escape, only : esc
     implicit none
     private
@@ -25,8 +26,6 @@ module fpm_environment
     integer, parameter, public :: OS_SOLARIS = 5
     integer, parameter, public :: OS_FREEBSD = 6
     integer, parameter, public :: OS_OPENBSD = 7
-
-    logical,save,public :: CONFIG_VERBOSE=.true.
 
 contains
     !> Determine the OS type
@@ -177,7 +176,7 @@ contains
     integer                              :: ios
        if(present(stopcode))then;local_code=stopcode;else;local_code=0;endif
        if(present(stopmsg)) write(stderr,'(a)',iostat=ios)esc('<r><bo>'//stopmsg)
-       if(CONFIG_VERBOSE)then
+       if(config%verbose)then
           error stop local_code
        else
           stop local_code
@@ -232,14 +231,14 @@ contains
         do i=2,command_argument_count() ! look at all arguments after subcommand
             call get_command_argument(number=i,length=ilength,status=istatus)
             if(istatus /= 0) then
-                write(stderr,'(*(g0,1x))')'<ERROR>*get_command_arguments_stack* error obtaining argument ',i
+                write(stderr,'(*(g0,1x))')esc('<r><bo>error:'),'get_command_arguments_stack* error obtaining argument ',i
                 exit
             else
                 if(allocated(arg))deallocate(arg)
                 allocate(character(len=ilength) :: arg)
                 call get_command_argument(number=i,value=arg,length=ilength,status=istatus)
                 if(istatus /= 0) then
-                    write(stderr,'(*(g0,1x))')'<ERROR>*get_command_arguments_stack* error obtaining argument ',i
+                    write(stderr,'(*(g0,1x))') esc('<r><bo>error:'),'get_command_arguments_stack* error obtaining argument ',i
                     exit
                 elseif(ilength.gt.0)then
                     if(index(arg//' ','-').ne.1)then

--- a/src/fpm_filesystem.f90
+++ b/src/fpm_filesystem.f90
@@ -5,7 +5,7 @@ use,intrinsic :: iso_fortran_env, only : stdin=>input_unit, stdout=>output_unit,
     use fpm_environment, only: get_os_type, &
                                OS_UNKNOWN, OS_LINUX, OS_MACOS, OS_WINDOWS, &
                                OS_CYGWIN, OS_SOLARIS, OS_FREEBSD, OS_OPENBSD
-    use fpm_environment, only: separator, get_env
+    use fpm_environment, only: separator, get_env, fpm_stop
     use fpm_strings, only: f_string, replace, string_t, split
     implicit none
     private
@@ -306,8 +306,7 @@ subroutine mkdir(dir)
     end select
 
     if (stat /= 0) then
-        print *, 'execute_command_line() failed'
-        error stop
+        call fpm_stop(stopmsg='execute_command_line() failed')
     end if
 end subroutine mkdir
 
@@ -344,8 +343,7 @@ recursive subroutine list_files(dir, files, recurse)
     end select
 
     if (stat /= 0) then
-        print *, 'execute_command_line() failed'
-        error stop
+	call fpm_stop(stopmsg='execute_command_line() failed')
     end if
 
     open (newunit=fh, file=temp_file, status='old')

--- a/src/fpm_filesystem.f90
+++ b/src/fpm_filesystem.f90
@@ -2,6 +2,7 @@
 !!
 module fpm_filesystem
 use,intrinsic :: iso_fortran_env, only : stdin=>input_unit, stdout=>output_unit, stderr=>error_unit
+    use M_escape, only : esc
     use fpm_environment, only: get_os_type, &
                                OS_UNKNOWN, OS_LINUX, OS_MACOS, OS_WINDOWS, &
                                OS_CYGWIN, OS_SOLARIS, OS_FREEBSD, OS_OPENBSD
@@ -554,8 +555,7 @@ character(len=256)            :: message
         ios=0
     endif
     if(ios.ne.0)then
-        write(stderr,'(*(a:,1x))')&
-        & '<ERROR> *filewrite*:',filename,trim(message)
+        write(stderr,'(*(a:,1x))') esc('<r><bo>error:'),'*fileopen*:',filename,trim(message)
         lun=-1
         if(present(ier))then
            ier=ios
@@ -575,7 +575,7 @@ integer               :: ios
     if(lun.ne.-1)then
         close(unit=lun,iostat=ios,iomsg=message)
         if(ios.ne.0)then
-            write(stderr,'(*(a:,1x))')'<ERROR> *filewrite*:',trim(message)
+            write(stderr,'(*(a:,1x))') esc('<r><bo>error:'),'*fileclose*:',trim(message)
             if(present(ier))then
                ier=ios
             else
@@ -599,8 +599,7 @@ character(len=256)                    :: message
        do i=1,size(filedata)
            write(lun,'(a)',iostat=ios,iomsg=message)trim(filedata(i))
            if(ios.ne.0)then
-               write(stderr,'(*(a:,1x))')&
-               & '<ERROR> *filewrite*:',filename,trim(message)
+               write(stderr,'(*(a:,1x))') esc('<r><bo>error:'),'*filewrite*:',filename,trim(message)
                stop 4
            endif
        enddo

--- a/src/fpm_global.f90
+++ b/src/fpm_global.f90
@@ -1,0 +1,6 @@
+    module fpm_global
+    type modes
+       logical :: verbose=.true.
+    end type modes
+    type(modes),public :: config
+    end module fpm_global

--- a/src/fpm_global.f90
+++ b/src/fpm_global.f90
@@ -1,7 +1,6 @@
     module fpm_global
     type modes
        logical :: verbose=.true.
-       character(len=10) :: color_mode='color'
     end type modes
     type(modes),public :: config
     end module fpm_global

--- a/src/fpm_global.f90
+++ b/src/fpm_global.f90
@@ -1,6 +1,7 @@
     module fpm_global
     type modes
        logical :: verbose=.true.
+       character(len=10) :: color_mode='color'
     end type modes
     type(modes),public :: config
     end module fpm_global

--- a/test/fpm_test/main.f90
+++ b/test/fpm_test/main.f90
@@ -1,6 +1,7 @@
 !> Driver for unit testing
 program fpm_testing
     use, intrinsic :: iso_fortran_env, only : error_unit
+    use fpm_environment, only : fpm_stop
     use testsuite, only : run_testsuite, new_testsuite, testsuite_t, &
         & select_suite, run_selected
     use test_toml, only : collect_toml
@@ -42,7 +43,7 @@ program fpm_testing
                 write(error_unit, fmt) "Suite:", suite(is)%name
                 call run_selected(suite(is)%collect, test_name, error_unit, stat)
                 if (stat < 0) then
-                    error stop 1
+                    call fpm_stop(1)
                 end if
             else
                 write(error_unit, fmt) "Testing:", suite(is)%name
@@ -53,7 +54,7 @@ program fpm_testing
             do is = 1, size(suite)
                 write(error_unit, fmt) "-", suite(is)%name
             end do
-            error stop 1
+            call fpm_stop(1)
         end if
     else
         do is = 1, size(suite)
@@ -64,7 +65,7 @@ program fpm_testing
 
     if (stat > 0) then
        write(error_unit, '(i0, 1x, a)') stat, "test(s) failed!"
-       error stop 1
+       call fpm_stop(1)
     end if
 
 


### PR DESCRIPTION
Tries to address some of the issues in #502, parts of which have come up previously before. 


add a conditional routine fpm_stop that calls ERROR STOP if in
verbose mode but STOP otherwise.

add some color to the output. Set environment variable FPM_COLOR
to "plain" to turn it off. Note that the gfortran extension ISATTY()
is used to signal to turn off color when redirecting output.

Make build output quieter in normal mode and only echo commands being
executed when in verbose mode.