### PR TITLE
Draft: initial implementation of implicit_none

### DIFF
--- a/src/fpm.f90
+++ b/src/fpm.f90
@@ -49,6 +49,7 @@ subroutine build_model(model, settings, package, error)
     type(string_t) :: include_dir
 
     model%package_name = package%name
+    model%implicit_none = package%implicit_none
 
     allocate(model%include_dirs(0))
     allocate(model%link_libraries(0))

--- a/src/fpm/manifest.f90
+++ b/src/fpm/manifest.f90
@@ -178,8 +178,6 @@ contains
             return
         end if
 
-        package%implicit_none = .false.
-
     end subroutine package_defaults
 
 

--- a/src/fpm/manifest.f90
+++ b/src/fpm/manifest.f90
@@ -178,6 +178,8 @@ contains
             return
         end if
 
+        package%implicit_none = .false.
+
     end subroutine package_defaults
 
 

--- a/src/fpm/manifest/package.f90
+++ b/src/fpm/manifest/package.f90
@@ -61,6 +61,8 @@ module fpm_manifest_package
         !> Name of the package
         character(len=:), allocatable :: name
 
+        logical :: implicit_none
+
         !> Package version
         type(version_t) :: version
 

--- a/src/fpm/manifest/package.f90
+++ b/src/fpm/manifest/package.f90
@@ -134,8 +134,7 @@ contains
            return
         end if
 
-        self%implicit_none = .false.
-        call get_value(table, "implicit_none", self%implicit_none)
+        call get_value(table, "implicit_none", self%implicit_none, .false.)
 
         if (len(self%name) <= 0) then
             call syntax_error(error, "Package name must be a non-empty string")

--- a/src/fpm/manifest/package.f90
+++ b/src/fpm/manifest/package.f90
@@ -134,6 +134,9 @@ contains
            return
         end if
 
+        self%implicit_none = .false.
+        call get_value(table, "implicit_none", self%implicit_none)
+
         if (len(self%name) <= 0) then
             call syntax_error(error, "Package name must be a non-empty string")
             return
@@ -302,7 +305,7 @@ contains
             case("version", "license", "author", "maintainer", "copyright", &
                     & "description", "keywords", "categories", "homepage", "build", &
                     & "dependencies", "dev-dependencies", "test", "executable", &
-                    & "example", "library", "install")
+                    & "example", "library", "install", "implicit_none")
                 continue
 
             end select

--- a/src/fpm_backend.f90
+++ b/src/fpm_backend.f90
@@ -257,7 +257,7 @@ subroutine build_target(model,target,stat)
     integer, intent(out) :: stat
 
     integer :: ilib, fh
-    character(:), allocatable :: link_flags
+    character(:), allocatable :: link_flags, implicit_flag
 
     if (.not.exists(dirname(target%output_file))) then
         call mkdir(dirname(target%output_file))
@@ -266,7 +266,12 @@ subroutine build_target(model,target,stat)
     select case(target%target_type)
 
     case (FPM_TARGET_OBJECT)
-        call run(model%fortran_compiler//" -c " // target%source%file_name // target%compile_flags &
+        if (model%implicit_none) then
+            implicit_flag = " -fimplicit-none"
+        else
+            implicit_flag = ""
+        end if
+        call run(model%fortran_compiler//" -c " // target%source%file_name // target%compile_flags // implicit_flag &
               // " -o " // target%output_file, echo=.true., exitstat=stat)
 
     case (FPM_TARGET_C_OBJECT)

--- a/src/fpm_model.f90
+++ b/src/fpm_model.f90
@@ -111,6 +111,9 @@ type :: fpm_model_t
     !> Name of root package
     character(:), allocatable :: package_name
 
+    !> Should "implicit none" be enforced by the compiler
+    logical :: implicit_none
+
     !> Array of packages (including the root package)
     type(package_t), allocatable :: packages(:)
 
@@ -259,12 +262,20 @@ end function info_srcfile_short
 
 function info_model(model) result(s)
     type(fpm_model_t), intent(in) :: model
-    character(:), allocatable :: s
+    character(:), allocatable :: s, tmp
     integer :: i
     !type :: fpm_model_t
     s = "fpm_model_t("
     !    character(:), allocatable :: package_name
     s = s // 'package_name="' // model%package_name // '"'
+
+    if (model%implicit_none) then
+        tmp = ".true."
+    else
+        tmp = ".false."
+    end if
+    s = s // ', implicit_none=' // tmp
+
     !    type(srcfile_t), allocatable :: sources(:)
     s = s // ", packages=["
     do i = 1, size(model%packages)


### PR DESCRIPTION
@epagone and I worked on this and implemented the following.

This adds `implicit_none` flag to `fpm.toml`, if it is not specified, it will be `.false.` by default.

Then it is propagated to the model, at the top level (for now). Then in the backend we read this flag from the model and insert `-fimplicit-none` into the command line flag (so it only works for gfortran for now).

TODO:

* [ ] It should be integrated with the rest of the compiler options / profiles (currently we add it in `fpm_backend.f90` which is probably too late, it should be already part of `target%compile_flags`)
* [ ] Generate the correct flag for each compiler
* [ ] Add a test for this
* [ ] This should be set on per package basis and even allow to override per file basis
* [ ] Design question: should this flag by part of the model as is done in this PR (perhaps on per package/per file basis) or should it be collected directly from `fpm.toml` and put into compiler flags / profiles and never expose it explicitly in the model?
* [ ] Turn this on by default