### PR TITLE
check name used for package, executable, test, or example

### DIFF
--- a/src/fpm.f90
+++ b/src/fpm.f90
@@ -256,19 +256,19 @@ integer :: i
 call get_package_data(package, "fpm.toml", error, apply_defaults=.true.)
 if (allocated(error)) then
     print '(a)', error%message
-    error stop 1
+    stop 1
 end if
 
 call build_model(model, settings, package, error)
 if (allocated(error)) then
     print '(a)', error%message
-    error stop 1
+    stop 1
 end if
 
 call targets_from_sources(targets,model,error)
 if (allocated(error)) then
     print '(a)', error%message
-    error stop 1
+    stop 1
 end if
 
 if(settings%list)then
@@ -305,19 +305,19 @@ subroutine cmd_run(settings,test)
     call get_package_data(package, "fpm.toml", error, apply_defaults=.true.)
     if (allocated(error)) then
         print '(a)', error%message
-        error stop 1
+        stop 1
     end if
 
     call build_model(model, settings%fpm_build_settings, package, error)
     if (allocated(error)) then
         print '(a)', error%message
-        error stop 1
+        stop 1
     end if
 
     call targets_from_sources(targets,model,error)
     if (allocated(error)) then
         print '(a)', error%message
-        error stop 1
+        stop 1
     end if
 
     if (test) then

--- a/src/fpm/cmd/install.f90
+++ b/src/fpm/cmd/install.f90
@@ -169,7 +169,7 @@ contains
     type(error_t), intent(in), optional :: error
     if (present(error)) then
       print '("[Error]", 1x, a)', error%message
-      error stop 1
+      stop 1
     end if
   end subroutine handle_error
 

--- a/src/fpm/cmd/install.f90
+++ b/src/fpm/cmd/install.f90
@@ -3,7 +3,7 @@ module fpm_cmd_install
   use fpm, only : build_model
   use fpm_backend, only : build_package
   use fpm_command_line, only : fpm_install_settings
-  use fpm_error, only : error_t, fatal_error
+  use fpm_error, only : error_t, fatal_error, fpm_stop
   use fpm_filesystem, only : join_path, list_files
   use fpm_installer, only : installer_t, new_installer
   use fpm_manifest, only : package_config_t, get_package_data
@@ -168,8 +168,7 @@ contains
   subroutine handle_error(error)
     type(error_t), intent(in), optional :: error
     if (present(error)) then
-      print '("[Error]", 1x, a)', error%message
-      stop 1
+      call fpm_stop(1,error%message)
     end if
   end subroutine handle_error
 

--- a/src/fpm/cmd/new.f90
+++ b/src/fpm/cmd/new.f90
@@ -55,9 +55,9 @@ module fpm_cmd_new
 
 use fpm_command_line, only : fpm_new_settings
 use fpm_environment, only : run, OS_LINUX, OS_MACOS, OS_WINDOWS
-use fpm_filesystem, only : join_path, exists, basename, mkdir, is_dir, to_fortran_name
+use fpm_filesystem, only : join_path, exists, basename, mkdir, is_dir
 use fpm_filesystem, only : fileopen, fileclose, filewrite, warnwrite
-use fpm_strings, only : join
+use fpm_strings, only : join, to_fortran_name
 use,intrinsic :: iso_fortran_env, only : stderr=>error_unit
 implicit none
 private

--- a/src/fpm/cmd/new.f90
+++ b/src/fpm/cmd/new.f90
@@ -58,6 +58,7 @@ use fpm_environment, only : run, OS_LINUX, OS_MACOS, OS_WINDOWS
 use fpm_filesystem, only : join_path, exists, basename, mkdir, is_dir
 use fpm_filesystem, only : fileopen, fileclose, filewrite, warnwrite
 use fpm_strings, only : join, to_fortran_name
+use fpm_error, only : fpm_stop
 use,intrinsic :: iso_fortran_env, only : stderr=>error_unit
 implicit none
 private
@@ -606,7 +607,7 @@ character(len=*),intent(in) :: filename
     ! continue building of manifest
     ! ...
     call new_package(package, table, error=error)
-    if (allocated(error)) stop 3
+    if (allocated(error)) call fpm_stop( 3,'')
     if(settings%verbose)then
        call table%accept(ser)
     endif

--- a/src/fpm/cmd/update.f90
+++ b/src/fpm/cmd/update.f90
@@ -61,7 +61,7 @@ contains
     type(error_t), intent(in), optional :: error
     if (present(error)) then
       print '(a)', error%message
-      error stop 1
+      stop 1
     end if
   end subroutine handle_error
 

--- a/src/fpm/cmd/update.f90
+++ b/src/fpm/cmd/update.f90
@@ -1,7 +1,7 @@
 module fpm_cmd_update
   use fpm_command_line, only : fpm_update_settings
   use fpm_dependency, only : dependency_tree_t, new_dependency_tree
-  use fpm_error, only : error_t
+  use fpm_error, only : error_t, fpm_stop
   use fpm_filesystem, only : exists, mkdir, join_path, delete_file
   use fpm_manifest, only : package_config_t, get_package_data
   implicit none
@@ -60,8 +60,7 @@ contains
     !> Potential error
     type(error_t), intent(in), optional :: error
     if (present(error)) then
-      print '(a)', error%message
-      stop 1
+      call fpm_stop(1, error%message)
     end if
   end subroutine handle_error
 

--- a/src/fpm/error.f90
+++ b/src/fpm/error.f90
@@ -1,11 +1,13 @@
 !> Implementation of basic error handling.
 module fpm_error
+    use fpm_strings, only : is_fortran_name, to_fortran_name
     implicit none
     private
 
     public :: error_t
     public :: fatal_error, syntax_error, file_not_found_error
     public :: file_parse_error
+    public :: bad_name_error
 
 
     !> Data type defining an error
@@ -44,6 +46,30 @@ contains
         error%message = message
 
     end subroutine syntax_error
+
+    function bad_name_error(error, label,name)
+
+        !> Instance of the error data
+        type(error_t), allocatable, intent(out) :: error
+
+        !> Error message label to add to message
+        character(len=*), intent(in) :: label
+
+        !> name value to check
+        character(len=*), intent(in) :: name
+
+        logical :: bad_name_error
+
+        if(.not.is_fortran_name(to_fortran_name(name)))then
+           bad_name_error=.true.
+           allocate(error)
+           error%message = 'manifest file syntax error: '//label//' name must be composed only of &
+           &alphanumerics, "-" and "_"  and start with a letter ::'//name
+        else
+          bad_name_error=.false.
+        endif
+
+    end function bad_name_error
 
 
     !> Error created when a file is missing or not found
@@ -87,9 +113,9 @@ contains
 
         allocate(error)
         error%message = 'Parse error: '//message//new_line('a')
-        
+
         error%message = error%message//file_name
-        
+
         if (present(line_num)) then
 
             write(temp_string,'(I0)') line_num
@@ -120,9 +146,9 @@ contains
 
                     error%message = error%message//new_line('a')
                     error%message = error%message//'   | '//repeat(' ',line_col-1)//'^'
-                
+
                 end if
-                
+
             end if
 
         end if

--- a/src/fpm/error.f90
+++ b/src/fpm/error.f90
@@ -1,5 +1,6 @@
 !> Implementation of basic error handling.
 module fpm_error
+    use,intrinsic :: iso_fortran_env, only : stdin=>input_unit, stdout=>output_unit, stderr=>error_unit
     use fpm_strings, only : is_fortran_name, to_fortran_name
     implicit none
     private
@@ -8,6 +9,7 @@ module fpm_error
     public :: fatal_error, syntax_error, file_not_found_error
     public :: file_parse_error
     public :: bad_name_error
+    public :: fpm_stop
 
 
     !> Data type defining an error
@@ -155,5 +157,23 @@ contains
 
     end subroutine file_parse_error
 
+    subroutine fpm_stop(value,message)
+    ! TODO: if verbose mode, call ERROR STOP instead of STOP
+    ! TODO: if M_escape is used, add color
+    ! to work with older compilers might need a case statement for values
+
+        !> value to use on STOP
+        integer, intent(in) :: value
+        !> Error message
+        character(len=*), intent(in) :: message
+        if(message.ne.'')then
+           if(value.gt.0)then
+              write(stderr,'("<ERROR>",a)')trim(message)
+           else
+              write(stderr,'("<INFO> ",a)')trim(message)
+           endif
+        endif
+        stop value
+    end subroutine fpm_stop
 
 end module fpm_error

--- a/src/fpm/error.f90
+++ b/src/fpm/error.f90
@@ -16,15 +16,7 @@ module fpm_error
 
     end type error_t
 
-
-    !> Alias syntax errors to fatal errors for now
-    interface syntax_error
-        module procedure :: fatal_error
-    end interface syntax_error
-
-
 contains
-
 
     !> Generic fatal runtime error
     subroutine fatal_error(error, message)
@@ -39,6 +31,19 @@ contains
         error%message = message
 
     end subroutine fatal_error
+
+    subroutine syntax_error(error, message)
+
+        !> Instance of the error data
+        type(error_t), allocatable, intent(out) :: error
+
+        !> Error message
+        character(len=*), intent(in) :: message
+
+        allocate(error)
+        error%message = message
+
+    end subroutine syntax_error
 
 
     !> Error created when a file is missing or not found

--- a/src/fpm/manifest/example.f90
+++ b/src/fpm/manifest/example.f90
@@ -19,6 +19,7 @@ module fpm_manifest_example
     use fpm_manifest_executable, only : executable_config_t
     use fpm_error, only : error_t, syntax_error
     use fpm_toml, only : toml_table, toml_key, toml_stat, get_value
+    use fpm_strings, only : to_fortran_name, is_fortran_name
     implicit none
     private
 
@@ -61,6 +62,11 @@ contains
            call syntax_error(error, "Could not retrieve example name")
            return
         end if
+        if(.not.is_fortran_name(to_fortran_name(self%name)))then
+           call syntax_error(error, 'manifest file syntax error: example name must be composed only of &
+           &alphanumerics, "-" and "_"  and start with a letter')
+           return
+        endif
         call get_value(table, "source-dir", self%source_dir, "example")
         call get_value(table, "main", self%main, "main.f90")
 

--- a/src/fpm/manifest/example.f90
+++ b/src/fpm/manifest/example.f90
@@ -64,7 +64,7 @@ contains
         end if
         if(.not.is_fortran_name(to_fortran_name(self%name)))then
            call syntax_error(error, 'manifest file syntax error: example name must be composed only of &
-           &alphanumerics, "-" and "_"  and start with a letter')
+           &alphanumerics, "-" and "_"  and start with a letter::'//self%name)
            return
         endif
         call get_value(table, "source-dir", self%source_dir, "example")

--- a/src/fpm/manifest/example.f90
+++ b/src/fpm/manifest/example.f90
@@ -17,9 +17,8 @@
 module fpm_manifest_example
     use fpm_manifest_dependency, only : dependency_config_t, new_dependencies
     use fpm_manifest_executable, only : executable_config_t
-    use fpm_error, only : error_t, syntax_error
+    use fpm_error, only : error_t, syntax_error, bad_name_error
     use fpm_toml, only : toml_table, toml_key, toml_stat, get_value
-    use fpm_strings, only : to_fortran_name, is_fortran_name
     implicit none
     private
 
@@ -62,9 +61,7 @@ contains
            call syntax_error(error, "Could not retrieve example name")
            return
         end if
-        if(.not.is_fortran_name(to_fortran_name(self%name)))then
-           call syntax_error(error, 'manifest file syntax error: example name must be composed only of &
-           &alphanumerics, "-" and "_"  and start with a letter::'//self%name)
+        if (bad_name_error(error,'example',self%name))then
            return
         endif
         call get_value(table, "source-dir", self%source_dir, "example")

--- a/src/fpm/manifest/executable.f90
+++ b/src/fpm/manifest/executable.f90
@@ -74,7 +74,7 @@ contains
         end if
         if(.not.is_fortran_name(to_fortran_name(self%name)))then
            call syntax_error(error, 'manifest file syntax error: executable name must be composed only of &
-           &alphanumerics, "-" and "_"  and start with a letter')
+           &alphanumerics, "-" and "_"  and start with a letter::'//self%name)
            return
         endif
         call get_value(table, "source-dir", self%source_dir, "app")

--- a/src/fpm/manifest/executable.f90
+++ b/src/fpm/manifest/executable.f90
@@ -13,7 +13,7 @@
 module fpm_manifest_executable
     use fpm_manifest_dependency, only : dependency_config_t, new_dependencies
     use fpm_error, only : error_t, syntax_error
-    use fpm_strings, only : string_t
+    use fpm_strings, only : string_t, is_fortran_name, to_fortran_name
     use fpm_toml, only : toml_table, toml_key, toml_stat, get_value
     implicit none
     private
@@ -72,6 +72,11 @@ contains
            call syntax_error(error, "Could not retrieve executable name")
            return
         end if
+        if(.not.is_fortran_name(to_fortran_name(self%name)))then
+           call syntax_error(error, 'manifest file syntax error: executable name must be composed only of &
+           &alphanumerics, "-" and "_"  and start with a letter')
+           return
+        endif
         call get_value(table, "source-dir", self%source_dir, "app")
         call get_value(table, "main", self%main, "main.f90")
 

--- a/src/fpm/manifest/executable.f90
+++ b/src/fpm/manifest/executable.f90
@@ -12,8 +12,8 @@
 !>```
 module fpm_manifest_executable
     use fpm_manifest_dependency, only : dependency_config_t, new_dependencies
-    use fpm_error, only : error_t, syntax_error
-    use fpm_strings, only : string_t, is_fortran_name, to_fortran_name
+    use fpm_error, only : error_t, syntax_error, bad_name_error
+    use fpm_strings, only : string_t 
     use fpm_toml, only : toml_table, toml_key, toml_stat, get_value
     implicit none
     private
@@ -72,9 +72,7 @@ contains
            call syntax_error(error, "Could not retrieve executable name")
            return
         end if
-        if(.not.is_fortran_name(to_fortran_name(self%name)))then
-           call syntax_error(error, 'manifest file syntax error: executable name must be composed only of &
-           &alphanumerics, "-" and "_"  and start with a letter::'//self%name)
+        if (bad_name_error(error,'executable',self%name))then
            return
         endif
         call get_value(table, "source-dir", self%source_dir, "app")

--- a/src/fpm/manifest/package.f90
+++ b/src/fpm/manifest/package.f90
@@ -39,10 +39,9 @@ module fpm_manifest_package
     use fpm_manifest_install, only: install_config_t, new_install_config
     use fpm_manifest_test, only : test_config_t, new_test
     use fpm_filesystem, only : exists, getline, join_path
-    use fpm_error, only : error_t, fatal_error, syntax_error
+    use fpm_error, only : error_t, fatal_error, syntax_error, bad_name_error
     use fpm_toml, only : toml_table, toml_array, toml_key, toml_stat, get_value, &
         & len
-    use fpm_strings, only : is_fortran_name, to_fortran_name
     use fpm_versioning, only : version_t, new_version
     implicit none
     private
@@ -132,9 +131,7 @@ contains
            call syntax_error(error, "Could not retrieve package name")
            return
         end if
-        if(.not.is_fortran_name(to_fortran_name(self%name)))then
-           call syntax_error(error, 'manifest file syntax error: package name must be composed only of &
-           &alphanumerics, "-" and "_"  and start with a letter::'//self%name)
+        if (bad_name_error(error,'package',self%name))then
            return
         endif
 

--- a/src/fpm/manifest/package.f90
+++ b/src/fpm/manifest/package.f90
@@ -134,7 +134,7 @@ contains
         end if
         if(.not.is_fortran_name(to_fortran_name(self%name)))then
            call syntax_error(error, 'manifest file syntax error: package name must be composed only of &
-           &alphanumerics, "-" and "_"  and start with a letter')
+           &alphanumerics, "-" and "_"  and start with a letter::'//self%name)
            return
         endif
 

--- a/src/fpm/manifest/package.f90
+++ b/src/fpm/manifest/package.f90
@@ -42,6 +42,7 @@ module fpm_manifest_package
     use fpm_error, only : error_t, fatal_error, syntax_error
     use fpm_toml, only : toml_table, toml_array, toml_key, toml_stat, get_value, &
         & len
+    use fpm_strings, only : is_fortran_name, to_fortran_name
     use fpm_versioning, only : version_t, new_version
     implicit none
     private
@@ -131,6 +132,11 @@ contains
            call syntax_error(error, "Could not retrieve package name")
            return
         end if
+        if(.not.is_fortran_name(to_fortran_name(self%name)))then
+           call syntax_error(error, 'manifest file syntax error: package name must be composed only of &
+           &alphanumerics, "-" and "_"  and start with a letter')
+           return
+        endif
 
         if (len(self%name) <= 0) then
             call syntax_error(error, "Package name must be a non-empty string")

--- a/src/fpm/manifest/test.f90
+++ b/src/fpm/manifest/test.f90
@@ -19,6 +19,7 @@ module fpm_manifest_test
     use fpm_manifest_executable, only : executable_config_t
     use fpm_error, only : error_t, syntax_error
     use fpm_toml, only : toml_table, toml_key, toml_stat, get_value
+    use fpm_strings, only : to_fortran_name, is_fortran_name
     implicit none
     private
 
@@ -61,6 +62,11 @@ contains
            call syntax_error(error, "Could not retrieve test name")
            return
         end if
+        if(.not.is_fortran_name(to_fortran_name(self%name)))then
+           call syntax_error(error, 'manifest file syntax error: test name must be composed only of &
+           &alphanumerics, "-" and "_"  and start with a letter')
+           return
+        endif
         call get_value(table, "source-dir", self%source_dir, "test")
         call get_value(table, "main", self%main, "main.f90")
 

--- a/src/fpm/manifest/test.f90
+++ b/src/fpm/manifest/test.f90
@@ -17,9 +17,8 @@
 module fpm_manifest_test
     use fpm_manifest_dependency, only : dependency_config_t, new_dependencies
     use fpm_manifest_executable, only : executable_config_t
-    use fpm_error, only : error_t, syntax_error
+    use fpm_error, only : error_t, syntax_error, bad_name_error
     use fpm_toml, only : toml_table, toml_key, toml_stat, get_value
-    use fpm_strings, only : to_fortran_name, is_fortran_name
     implicit none
     private
 
@@ -62,9 +61,7 @@ contains
            call syntax_error(error, "Could not retrieve test name")
            return
         end if
-        if(.not.is_fortran_name(to_fortran_name(self%name)))then
-           call syntax_error(error, 'manifest file syntax error: test name must be composed only of &
-           &alphanumerics, "-" and "_"  and start with a letter ::'//self%name)
+        if (bad_name_error(error,'test',self%name))then
            return
         endif
         call get_value(table, "source-dir", self%source_dir, "test")

--- a/src/fpm/manifest/test.f90
+++ b/src/fpm/manifest/test.f90
@@ -64,7 +64,7 @@ contains
         end if
         if(.not.is_fortran_name(to_fortran_name(self%name)))then
            call syntax_error(error, 'manifest file syntax error: test name must be composed only of &
-           &alphanumerics, "-" and "_"  and start with a letter')
+           &alphanumerics, "-" and "_"  and start with a letter ::'//self%name)
            return
         endif
         call get_value(table, "source-dir", self%source_dir, "test")

--- a/src/fpm_backend.f90
+++ b/src/fpm_backend.f90
@@ -27,6 +27,8 @@
 !>
 module fpm_backend
 
+use,intrinsic :: iso_fortran_env, only : stdin=>input_unit, stdout=>output_unit, stderr=>error_unit
+use fpm_error, only : fpm_stop
 use fpm_environment, only: run, get_os_type, OS_WINDOWS
 use fpm_filesystem, only: basename, dirname, join_path, exists, mkdir, unix_path
 use fpm_model, only: fpm_model_t
@@ -98,10 +100,10 @@ subroutine build_package(targets,model)
         if (build_failed) then
             do j=1,size(stat)
                 if (stat(j) /= 0) then
-                    write(*,*) '<ERROR> Compilation failed for object "',basename(queue(j)%ptr%output_file),'"'
+                    write(stderr,'(*(g0:,1x))') '<ERROR> Compilation failed for object "',basename(queue(j)%ptr%output_file),'"'
                 end if
             end do
-            stop 1
+            call fpm_stop(1,'stopping due to failed compilation')
         end if
 
     end do
@@ -135,8 +137,7 @@ recursive subroutine sort_target(target)
     ! Check for a circular dependency
     ! (If target has been touched but not processed)
     if (target%touched) then
-        write(*,*) '(!) Circular dependency found with: ',target%output_file
-        stop
+        call fpm_stop(1,'(!) Circular dependency found with: '//target%output_file)
     else
         target%touched = .true.  ! Set touched flag
     end if

--- a/src/fpm_command_line.f90
+++ b/src/fpm_command_line.f90
@@ -138,7 +138,8 @@ contains
             case default     ; os_type =  "OS Type:     UNKNOWN"
         end select
         version_text = [character(len=80) :: &
-         &  'Version:     0.3.0, alpha',                           &
+         &  'Version:     0.3.0, alpha',                               &
+         &  'PR:          511',                                        &
          &  'Program:     fpm(1)',                                     &
          &  'Description: A Fortran package manager and build system', &
          &  'Home Page:   https://github.com/fortran-lang/fpm',        &

--- a/src/fpm_command_line.f90
+++ b/src/fpm_command_line.f90
@@ -28,8 +28,8 @@ use fpm_environment,  only : get_os_type, get_env, &
                              OS_CYGWIN, OS_SOLARIS, OS_FREEBSD, OS_OPENBSD
 use M_CLI2,           only : set_args, lget, sget, unnamed, remaining, specified
 use M_CLI2,           only : get_subcommand, CLI_RESPONSE_FILE
-use fpm_strings,      only : lower, split, fnv_1a
-use fpm_filesystem,   only : basename, canon_path, to_fortran_name, which
+use fpm_strings,      only : lower, split, fnv_1a, to_fortran_name, is_fortran_name
+use fpm_filesystem,   only : basename, canon_path, which
 use fpm_environment,  only : run, get_command_arguments_quoted
 use fpm_compiler, only : get_default_compile_flags
 use,intrinsic :: iso_fortran_env, only : stdin=>input_unit, &
@@ -516,27 +516,6 @@ contains
     end subroutine printhelp
 
     end subroutine get_command_line_settings
-
-    function is_fortran_name(line) result (lout)
-    ! determine if a string is a valid Fortran name ignoring trailing spaces
-    ! (but not leading spaces)
-    character(len=*),parameter   :: int='0123456789'
-    character(len=*),parameter   :: lower='abcdefghijklmnopqrstuvwxyz'
-    character(len=*),parameter   :: upper='ABCDEFGHIJKLMNOPQRSTUVWXYZ'
-    character(len=*),parameter   :: allowed=upper//lower//int//'_'
-    character(len=*),intent(in)  :: line
-    character(len=:),allocatable :: name
-    logical                      :: lout
-        name=trim(line)
-        if(len(name).ne.0)then
-            lout = .true.                                  &
-             & .and. verify(name(1:1), lower//upper) == 0  &
-             & .and. verify(name,allowed) == 0             &
-             & .and. len(name) <= 63
-        else
-            lout = .false.
-        endif
-    end function is_fortran_name
 
     subroutine set_help()
    help_list_nodash=[character(len=80) :: &

--- a/src/fpm_environment.f90
+++ b/src/fpm_environment.f90
@@ -6,6 +6,7 @@ module fpm_environment
     use,intrinsic :: iso_fortran_env, only : stdin=>input_unit,   &
                                            & stdout=>output_unit, &
                                            & stderr=>error_unit
+    use fpm_error, only : fpm_stop
     implicit none
     private
     public :: get_os_type
@@ -157,8 +158,7 @@ contains
             exitstat = stat
         else
             if (stat /= 0) then
-                print *, 'Command failed'
-                stop 1
+                call fpm_stop(1,'*run*:Command failed')
             end if
         end if
 

--- a/src/fpm_environment.f90
+++ b/src/fpm_environment.f90
@@ -158,7 +158,7 @@ contains
         else
             if (stat /= 0) then
                 print *, 'Command failed'
-                stop 
+                stop 1
             end if
         end if
 

--- a/src/fpm_environment.f90
+++ b/src/fpm_environment.f90
@@ -158,7 +158,7 @@ contains
         else
             if (stat /= 0) then
                 print *, 'Command failed'
-                error stop
+                stop 
             end if
         end if
 

--- a/src/fpm_filesystem.f90
+++ b/src/fpm_filesystem.f90
@@ -10,7 +10,7 @@ use,intrinsic :: iso_fortran_env, only : stdin=>input_unit, stdout=>output_unit,
     implicit none
     private
     public :: basename, canon_path, dirname, is_dir, join_path, number_of_rows, read_lines, list_files, env_variable, &
-            mkdir, exists, get_temp_filename, windows_path, unix_path, getline, delete_file, to_fortran_name
+            mkdir, exists, get_temp_filename, windows_path, unix_path, getline, delete_file
     public :: fileopen, fileclose, filewrite, warnwrite, parent_dir
     public :: which
 
@@ -306,8 +306,7 @@ subroutine mkdir(dir)
     end select
 
     if (stat /= 0) then
-        print *, 'execute_command_line() failed'
-        error stop
+        stop 'execute_command_line() failed'
     end if
 end subroutine mkdir
 
@@ -344,8 +343,7 @@ recursive subroutine list_files(dir, files, recurse)
     end select
 
     if (stat /= 0) then
-        print *, 'execute_command_line() failed'
-        error stop
+        stop 'execute_command_line() failed'
     end if
 
     open (newunit=fh, file=temp_file, status='old')
@@ -611,16 +609,6 @@ character(len=256)                    :: message
     call fileclose(lun)
 
 end subroutine filewrite
-
-!> Returns string with special characters replaced with an underscore.
-!! For now, only a hyphen is treated as a special character, but this can be
-!! expanded to other characters if needed.
-pure function to_fortran_name(string) result(res)
-    character(*), intent(in) :: string
-    character(len(string)) :: res
-    character, parameter :: SPECIAL_CHARACTERS(*) = ['-']
-    res = replace(string, SPECIAL_CHARACTERS, '_')
-end function to_fortran_name
 
 function which(command) result(pathname)
 !>

--- a/src/fpm_source_parsing.f90
+++ b/src/fpm_source_parsing.f90
@@ -16,7 +16,7 @@
 !>
 module fpm_source_parsing
 use fpm_error, only: error_t, file_parse_error, fatal_error
-use fpm_strings, only: string_t, string_cat, len_trim, split, lower, str_ends_with, fnv_1a
+use fpm_strings, only: string_t, string_cat, len_trim, split, lower, str_ends_with, fnv_1a, is_fortran_name
 use fpm_model, only: srcfile_t, &
                     FPM_UNIT_UNKNOWN, FPM_UNIT_PROGRAM, FPM_UNIT_MODULE, &
                     FPM_UNIT_SUBMODULE, FPM_UNIT_SUBPROGRAM, &
@@ -146,7 +146,7 @@ function parse_f_source(f_filename,error) result(f_source)
 
                 end if
 
-                if (.not.validate_name(mod_name)) then
+                if (.not.is_fortran_name(mod_name)) then
                     cycle
                 end if
 
@@ -215,7 +215,7 @@ function parse_f_source(f_filename,error) result(f_source)
                     cycle
                 end if
 
-                if (.not.validate_name(mod_name)) then
+                if (.not.is_fortran_name(mod_name)) then
                     call file_parse_error(error,f_filename, &
                           'empty or invalid name for module',i, &
                           file_lines(i)%s, index(file_lines(i)%s,mod_name))
@@ -242,7 +242,7 @@ function parse_f_source(f_filename,error) result(f_source)
                           file_lines(i)%s)
                     return
                 end if
-                if (.not.validate_name(mod_name)) then
+                if (.not.is_fortran_name(mod_name)) then
                     call file_parse_error(error,f_filename, &
                           'empty or invalid name for submodule',i, &
                           file_lines(i)%s, index(file_lines(i)%s,mod_name))
@@ -271,7 +271,7 @@ function parse_f_source(f_filename,error) result(f_source)
 
                     end if
 
-                    if (.not.validate_name(temp_string)) then
+                    if (.not.is_fortran_name(temp_string)) then
                         call file_parse_error(error,f_filename, &
                           'empty or invalid name for submodule parent',i, &
                           file_lines(i)%s, index(file_lines(i)%s,temp_string))
@@ -320,44 +320,6 @@ function parse_f_source(f_filename,error) result(f_source)
         end if
 
     end do
-
-    contains
-
-    function validate_name(name) result(valid)
-        character(*), intent(in) :: name
-        logical :: valid
-
-        integer :: i
-
-        if (len_trim(name) < 1) then
-            valid = .false.
-            return
-        end if
-
-        if (lower(name(1:1)) < 'a' .or. &
-            lower(name(1:1)) > 'z') then
-
-            valid = .false.
-            return
-        end if
-
-        do i=1,len(name)
-
-            if (.not.( &
-                (name(i:i) >= '0' .and. name(i:i) <= '9').or. &
-                (lower(name(i:i)) >= 'a' .and. lower(name(i:i)) <= 'z').or. &
-                name(i:i) == '_') ) then
-
-                valid = .false.
-                return
-            end if
-
-        end do
-
-        valid = .true.
-        return
-
-    end function validate_name
 
 end function parse_f_source
 

--- a/src/fpm_source_parsing.f90
+++ b/src/fpm_source_parsing.f90
@@ -78,7 +78,7 @@ function parse_f_source(f_filename,error) result(f_source)
 
     integer :: stat
     integer :: fh, n_use, n_include, n_mod, i, j, ic, pass
-    type(string_t), allocatable :: file_lines(:)
+    type(string_t), allocatable :: file_lines(:), file_lines_lower(:)
     character(:), allocatable :: temp_string, mod_name, string_parts(:)
 
     f_source%file_name = f_filename
@@ -87,8 +87,15 @@ function parse_f_source(f_filename,error) result(f_source)
     file_lines = read_lines(fh)
     close(fh)
 
-    ! Ignore empty files, returned as FPM_UNIT_UNKNOW
-    if (len_trim(file_lines) < 1) return
+    ! for efficiency in parsing make a lowercase left-adjusted copy of the file
+    ! Need a copy because INCLUDE (and #include) file arguments are case-sensitive
+    file_lines_lower=file_lines
+    do i=1,size(file_lines_lower)
+       file_lines_lower(i)%s=adjustl(lower(file_lines_lower(i)%s))
+    enddo
+
+    ! Ignore empty files, returned as FPM_UNIT_UNKNOWN
+    if (len_trim(file_lines_lower) < 1) return
 
     f_source%digest = fnv_1a(file_lines)
 
@@ -96,31 +103,31 @@ function parse_f_source(f_filename,error) result(f_source)
         n_use = 0
         n_include = 0
         n_mod = 0
-        file_loop: do i=1,size(file_lines)
+        file_loop: do i=1,size(file_lines_lower)
 
             ! Skip lines that are continued: not statements
             if (i > 1) then
-                ic = index(file_lines(i-1)%s,'!')
+                ic = index(file_lines_lower(i-1)%s,'!')
                 if (ic < 1) then
-                    ic = len(file_lines(i-1)%s)
+                    ic = len(file_lines_lower(i-1)%s)
                 end if
-                temp_string = trim(file_lines(i-1)%s(1:ic))
+                temp_string = trim(file_lines_lower(i-1)%s(1:ic))
                 if (len(temp_string) > 0 .and. index(temp_string,'&') == len(temp_string)) then
                     cycle
                 end if
             end if
 
             ! Process 'USE' statements
-            if (index(adjustl(lower(file_lines(i)%s)),'use ') == 1 .or. &
-                index(adjustl(lower(file_lines(i)%s)),'use::') == 1) then
+            if (index(file_lines_lower(i)%s,'use ') == 1 .or. &
+                index(file_lines_lower(i)%s,'use::') == 1) then
 
-                if (index(file_lines(i)%s,'::') > 0) then
+                if (index(file_lines_lower(i)%s,'::') > 0) then
 
-                    temp_string = split_n(file_lines(i)%s,delims=':',n=2,stat=stat)
+                    temp_string = split_n(file_lines_lower(i)%s,delims=':',n=2,stat=stat)
                     if (stat /= 0) then
                         call file_parse_error(error,f_filename, &
                                 'unable to find used module name',i, &
-                                file_lines(i)%s,index(file_lines(i)%s,'::'))
+                                file_lines_lower(i)%s,index(file_lines_lower(i)%s,'::'))
                         return
                     end if
 
@@ -128,21 +135,19 @@ function parse_f_source(f_filename,error) result(f_source)
                     if (stat /= 0) then
                         call file_parse_error(error,f_filename, &
                                  'unable to find used module name',i, &
-                                 file_lines(i)%s)
+                                 file_lines_lower(i)%s)
                         return
                     end if
-                    mod_name = lower(mod_name)
 
                 else
 
-                    mod_name = split_n(file_lines(i)%s,n=2,delims=' ,',stat=stat)
+                    mod_name = split_n(file_lines_lower(i)%s,n=2,delims=' ,',stat=stat)
                     if (stat /= 0) then
                         call file_parse_error(error,f_filename, &
                                 'unable to find used module name',i, &
-                                file_lines(i)%s)
+                                file_lines_lower(i)%s)
                         return
                     end if
-                    mod_name = lower(mod_name)
 
                 end if
 
@@ -166,12 +171,11 @@ function parse_f_source(f_filename,error) result(f_source)
             end if
 
             ! Process 'INCLUDE' statements
-            ic = index(adjustl(lower(file_lines(i)%s)),'include')
+            ic = index(file_lines_lower(i)%s,'include')
             if ( ic == 1 ) then
                 ic = index(lower(file_lines(i)%s),'include')
                 if (index(adjustl(file_lines(i)%s(ic+7:)),'"') == 1 .or. &
                     index(adjustl(file_lines(i)%s(ic+7:)),"'") == 1 ) then
-
 
                     n_include = n_include + 1
 
@@ -189,14 +193,14 @@ function parse_f_source(f_filename,error) result(f_source)
             end if
 
             ! Extract name of module if is module
-            if (index(adjustl(lower(file_lines(i)%s)),'module ') == 1) then
+            if (index(file_lines_lower(i)%s,'module ') == 1) then
 
                 ! Remove any trailing comments
-                ic = index(file_lines(i)%s,'!')-1
+                ic = index(file_lines_lower(i)%s,'!')-1
                 if (ic < 1) then
-                    ic = len(file_lines(i)%s)
+                    ic = len(file_lines_lower(i)%s)
                 end if
-                temp_string = trim(file_lines(i)%s(1:ic))
+                temp_string = trim(file_lines_lower(i)%s(1:ic))
 
                 ! R1405 module-stmt := "MODULE" module-name
                 ! module-stmt has two space-delimited parts only
@@ -206,7 +210,7 @@ function parse_f_source(f_filename,error) result(f_source)
                     cycle
                 end if
 
-                mod_name = lower(trim(adjustl(string_parts(2))))
+                mod_name = trim(adjustl(string_parts(2)))
                 if (scan(mod_name,'=(&')>0 ) then
                     ! Ignore these cases:
                     ! module <something>&
@@ -218,7 +222,7 @@ function parse_f_source(f_filename,error) result(f_source)
                 if (.not.is_fortran_name(mod_name)) then
                     call file_parse_error(error,f_filename, &
                           'empty or invalid name for module',i, &
-                          file_lines(i)%s, index(file_lines(i)%s,mod_name))
+                          file_lines_lower(i)%s, index(file_lines_lower(i)%s,mod_name))
                     return
                 end if
 
@@ -233,29 +237,29 @@ function parse_f_source(f_filename,error) result(f_source)
             end if
 
             ! Extract name of submodule if is submodule
-            if (index(adjustl(lower(file_lines(i)%s)),'submodule') == 1) then
+            if (index(file_lines_lower(i)%s,'submodule') == 1) then
 
-                mod_name = split_n(file_lines(i)%s,n=3,delims='()',stat=stat)
+                mod_name = split_n(file_lines_lower(i)%s,n=3,delims='()',stat=stat)
                 if (stat /= 0) then
                     call file_parse_error(error,f_filename, &
                           'unable to get submodule name',i, &
-                          file_lines(i)%s)
+                          file_lines_lower(i)%s)
                     return
                 end if
                 if (.not.is_fortran_name(mod_name)) then
                     call file_parse_error(error,f_filename, &
                           'empty or invalid name for submodule',i, &
-                          file_lines(i)%s, index(file_lines(i)%s,mod_name))
+                          file_lines_lower(i)%s, index(file_lines_lower(i)%s,mod_name))
                     return
                 end if
 
                 n_mod = n_mod + 1
 
-                temp_string = split_n(file_lines(i)%s,n=2,delims='()',stat=stat)
+                temp_string = split_n(file_lines_lower(i)%s,n=2,delims='()',stat=stat)
                 if (stat /= 0) then
                     call file_parse_error(error,f_filename, &
                           'unable to get submodule ancestry',i, &
-                          file_lines(i)%s)
+                          file_lines_lower(i)%s)
                     return
                 end if
 
@@ -274,13 +278,13 @@ function parse_f_source(f_filename,error) result(f_source)
                     if (.not.is_fortran_name(temp_string)) then
                         call file_parse_error(error,f_filename, &
                           'empty or invalid name for submodule parent',i, &
-                          file_lines(i)%s, index(file_lines(i)%s,temp_string))
+                          file_lines_lower(i)%s, index(file_lines_lower(i)%s,temp_string))
                         return
                     end if
 
-                    f_source%modules_used(n_use)%s = lower(temp_string)
+                    f_source%modules_used(n_use)%s = temp_string
 
-                    f_source%modules_provided(n_mod)%s = lower(mod_name)
+                    f_source%modules_provided(n_mod)%s = mod_name
 
                 end if
 
@@ -288,9 +292,9 @@ function parse_f_source(f_filename,error) result(f_source)
 
             ! Detect if contains a program
             !  (no modules allowed after program def)
-            if (index(adjustl(lower(file_lines(i)%s)),'program ') == 1) then
+            if (index(file_lines_lower(i)%s,'program ') == 1) then
 
-                temp_string = lower(split_n(file_lines(i)%s,n=2,delims=' ',stat=stat))
+                temp_string = split_n(file_lines_lower(i)%s,n=2,delims=' ',stat=stat)
                 if (stat == 0) then
 
                     if (scan(temp_string,'=(')>0 ) then
@@ -357,7 +361,7 @@ function parse_c_source(c_filename,error) result(c_source)
     file_lines = read_lines(fh)
     close(fh)
 
-    ! Ignore empty files, returned as FPM_UNIT_UNKNOW
+    ! Ignore empty files, returned as FPM_UNIT_UNKNOWN
     if (len_trim(file_lines) < 1) then
         c_source%unit_type = FPM_UNIT_UNKNOWN
         return

--- a/src/fpm_strings.f90
+++ b/src/fpm_strings.f90
@@ -20,6 +20,8 @@
 !! - [[STRING_ARRAY_CONTAINS]]  Check if array of **TYPE(STRING_T)** matches a particular **CHARACTER** string
 !! - **OPERATOR(.IN.)**  Check if array of **TYPE(STRING_T)** matches a particular **CHARACTER** string
 !! - [[GLOB]]  function compares text strings, one of which can have wildcards ('*' or '?').
+!! - [[IS_FORTRAN_NAME]]  determine whether a string is an acceptable Fortran entity name
+!! - [[TO_FORTRAN_NAME]]  replace allowed special but unusuable characters in names with underscore
 !!### Miscellaneous
 !! - [[LEN_TRIM]]  Determine total trimmed length of **STRING_T** array
 !! - [[FNV_1A]]  Hash a **CHARACTER(*)** string of default kind or a **TYPE(STRING_T)** array
@@ -33,6 +35,7 @@ implicit none
 
 private
 public :: f_string, lower, split, str_ends_with, string_t
+public :: to_fortran_name, is_fortran_name
 public :: string_array_contains, string_cat, len_trim, operator(.in.), fnv_1a
 public :: replace, resize, str, join, glob
 
@@ -920,5 +923,36 @@ else
     s = ".false."
 end if
 end function
+
+!> Returns string with special characters replaced with an underscore.
+!! For now, only a hyphen is treated as a special character, but this can be
+!! expanded to other characters if needed.
+pure function to_fortran_name(string) result(res)
+    character(*), intent(in) :: string
+    character(len(string)) :: res
+    character, parameter :: SPECIAL_CHARACTERS(*) = ['-']
+    res = replace(string, SPECIAL_CHARACTERS, '_')
+end function to_fortran_name
+
+function is_fortran_name(line) result (lout)
+! determine if a string is a valid Fortran name ignoring trailing spaces
+! (but not leading spaces)
+    character(len=*),parameter   :: int='0123456789'
+    character(len=*),parameter   :: lower='abcdefghijklmnopqrstuvwxyz'
+    character(len=*),parameter   :: upper='ABCDEFGHIJKLMNOPQRSTUVWXYZ'
+    character(len=*),parameter   :: allowed=upper//lower//int//'_'
+    character(len=*),intent(in)  :: line
+    character(len=:),allocatable :: name
+    logical                      :: lout
+        name=trim(line)
+        if(len(name).ne.0)then
+            lout = .true.                                  &
+             & .and. verify(name(1:1), lower//upper) == 0  &
+             & .and. verify(name,allowed) == 0             &
+             & .and. len(name) <= 63
+        else
+            lout = .false.
+        endif
+    end function is_fortran_name
 
 end module fpm_strings

--- a/src/fpm_targets.f90
+++ b/src/fpm_targets.f90
@@ -25,7 +25,7 @@
 !>
 module fpm_targets
 use iso_fortran_env, only: int64
-use fpm_error, only: error_t, fatal_error
+use fpm_error, only: error_t, fatal_error, fpm_stop
 use fpm_model
 use fpm_environment, only: get_os_type, OS_WINDOWS
 use fpm_filesystem, only: dirname, join_path, canon_path
@@ -298,7 +298,7 @@ subroutine add_target(targets,type,output_file,source,link_libraries)
             write(*,*) 'Error while building target list: duplicate output object "',&
                         output_file,'"'
             if (present(source)) write(*,*) ' Source file: "',source%file_name,'"'
-            stop 1
+            call fpm_stop(1,' ')
 
         end if
 

--- a/src/fpm_targets.f90
+++ b/src/fpm_targets.f90
@@ -341,7 +341,7 @@ end subroutine add_dependency
 !>
 !> - Executable sources (`FPM_SCOPE_APP`,`FPM_SCOPE_TEST`) may use
 !>   library modules (including dependencies) as well as any modules
-!>   corresponding to source files in the same directory or a 
+!>   corresponding to source files in the same directory or a
 !>   subdirectory of the executable source file.
 !>
 !> @warning If a module used by a source file cannot be resolved to

--- a/test/fpm_test/test_manifest.f90
+++ b/test/fpm_test/test_manifest.f90
@@ -85,13 +85,13 @@ contains
             & '[dependencies.fpm]', &
             & 'git = "https://github.com/fortran-lang/fpm"', &
             & '[[executable]]', &
-            & 'name = "example-#1" # comment', &
+            & 'name = "example-1" # comment', &
             & 'source-dir = "prog"', &
             & '[dependencies]', &
             & 'toml-f.git = "git@github.com:toml-f/toml-f.git"', &
             & '"toml..f" = { path = ".." }', &
             & '[["executable"]]', &
-            & 'name = "example-#2"', &
+            & 'name = "example-2"', &
             & 'source-dir = "prog"', &
             & '[executable.dependencies]', &
             & '[''library'']', &

--- a/test/fpm_test/test_toml.f90
+++ b/test/fpm_test/test_toml.f90
@@ -41,13 +41,13 @@ contains
             & '[dependencies.fpm]', &
             & 'git = "https://github.com/fortran-lang/fpm"', &
             & '[[executable]]', &
-            & 'name = "example-#1" # comment', &
+            & 'name = "example-1" # comment', &
             & 'source-dir = "prog"', &
             & '[dependencies]', &
             & 'toml-f.git = "git@github.com:toml-f/toml-f.git"', &
             & '"toml..f" = { path = ".." }', &
             & '[["executable"]]', &
-            & 'name = "example-#2"', &
+            & 'name = "example-2"', &
             & 'source-dir = "prog"', &
             & '[executable.dependencies]', &
             & '[''library'']', &


### PR DESCRIPTION
fpm manifest files can contain names that produce errors or complicate keeping the package portable. The names are used as parts of file names and even module names but are not tested for spaces, slashes, and other special characters. Although there may be interest in allowing Unicode names or other syntax in the future, fpm will generally produce errors internally if anything other than ASCII alphanumeric characters are used for names, plus a hythen and underscore; and names should start with a letter.  

This adds such a check and also replaces ERROR STOP calls with STOP calls, which is generally distracting and usually not useful; although it has been useful during early development of fpm for developers.

This should prevent the problems described in #503, although adding such a note to the documentation would be appropriate as well. Closes #331  "feature" also.