### PR TITLE
Fix compilation error in ifort

### DIFF
--- a/src/fpm/manifest/build.f90
+++ b/src/fpm/manifest/build.f90
@@ -12,7 +12,7 @@
 module fpm_manifest_build
     use fpm_error, only : error_t, syntax_error, fatal_error
     use fpm_strings, only : string_t
-    use fpm_toml, only : toml_table, toml_key, toml_stat, get_value
+    use fpm_toml, only : toml_table, toml_key, toml_stat, get_value, get_list
     implicit none
     private
 
@@ -87,10 +87,10 @@ contains
         end if
 
 
-        call get_value(table, "link", self%link, error)
+        call get_list(table, "link", self%link, error)
         if (allocated(error)) return
 
-        call get_value(table, "external-modules", self%external_modules, error)
+        call get_list(table, "external-modules", self%external_modules, error)
         if (allocated(error)) return
 
     end subroutine new_build_config

--- a/src/fpm/manifest/example.f90
+++ b/src/fpm/manifest/example.f90
@@ -18,7 +18,7 @@ module fpm_manifest_example
     use fpm_manifest_dependency, only : dependency_config_t, new_dependencies
     use fpm_manifest_executable, only : executable_config_t
     use fpm_error, only : error_t, syntax_error, bad_name_error
-    use fpm_toml, only : toml_table, toml_key, toml_stat, get_value
+    use fpm_toml, only : toml_table, toml_key, toml_stat, get_value, get_list
     implicit none
     private
 
@@ -73,7 +73,7 @@ contains
             if (allocated(error)) return
         end if
 
-        call get_value(table, "link", self%link, error)
+        call get_list(table, "link", self%link, error)
         if (allocated(error)) return
 
     end subroutine new_example

--- a/src/fpm/manifest/executable.f90
+++ b/src/fpm/manifest/executable.f90
@@ -14,7 +14,7 @@ module fpm_manifest_executable
     use fpm_manifest_dependency, only : dependency_config_t, new_dependencies
     use fpm_error, only : error_t, syntax_error, bad_name_error
     use fpm_strings, only : string_t 
-    use fpm_toml, only : toml_table, toml_key, toml_stat, get_value
+    use fpm_toml, only : toml_table, toml_key, toml_stat, get_value, get_list
     implicit none
     private
 
@@ -84,7 +84,7 @@ contains
             if (allocated(error)) return
         end if
 
-        call get_value(table, "link", self%link, error)
+        call get_list(table, "link", self%link, error)
         if (allocated(error)) return
 
     end subroutine new_executable

--- a/src/fpm/manifest/library.f90
+++ b/src/fpm/manifest/library.f90
@@ -11,7 +11,7 @@
 module fpm_manifest_library
     use fpm_error, only : error_t, syntax_error
     use fpm_strings, only: string_t, string_cat
-    use fpm_toml, only : toml_table, toml_key, toml_stat, get_value
+    use fpm_toml, only : toml_table, toml_key, toml_stat, get_value, get_list
     implicit none
     private
 
@@ -59,7 +59,7 @@ contains
         call get_value(table, "source-dir", self%source_dir, "src")
         call get_value(table, "build-script", self%build_script)
 
-        call get_value(table, "include-dir", self%include_dir, error)
+        call get_list(table, "include-dir", self%include_dir, error)
         if (allocated(error)) return
 
         ! Set default value of include-dir if not found in manifest

--- a/src/fpm/manifest/test.f90
+++ b/src/fpm/manifest/test.f90
@@ -18,7 +18,7 @@ module fpm_manifest_test
     use fpm_manifest_dependency, only : dependency_config_t, new_dependencies
     use fpm_manifest_executable, only : executable_config_t
     use fpm_error, only : error_t, syntax_error, bad_name_error
-    use fpm_toml, only : toml_table, toml_key, toml_stat, get_value
+    use fpm_toml, only : toml_table, toml_key, toml_stat, get_value, get_list
     implicit none
     private
 
@@ -73,7 +73,7 @@ contains
             if (allocated(error)) return
         end if
 
-        call get_value(table, "link", self%link, error)
+        call get_list(table, "link", self%link, error)
         if (allocated(error)) return
 
     end subroutine new_test

--- a/src/fpm/toml.f90
+++ b/src/fpm/toml.f90
@@ -22,14 +22,9 @@ module fpm_toml
     private
 
     public :: read_package_file
-    public :: toml_table, toml_array, toml_key, toml_stat, get_value, set_value
+    public :: toml_table, toml_array, toml_key, toml_stat, get_value, set_value, get_list
     public :: new_table, add_table, add_array, len
     public :: toml_error, toml_serializer, toml_parse
-
-
-    interface get_value
-        module procedure :: get_child_value_string_list
-    end interface get_value
 
 
 contains
@@ -71,7 +66,7 @@ contains
     end subroutine read_package_file
 
 
-    subroutine get_child_value_string_list(table, key, list, error)
+    subroutine get_list(table, key, list, error)
 
         !> Instance of the TOML data structure
         type(toml_table), intent(inout) :: table
@@ -114,7 +109,7 @@ contains
             end if
         end if
 
-    end subroutine get_child_value_string_list
+    end subroutine get_list
 
 
 end module fpm_toml


### PR DESCRIPTION
Intel Fortran (`ifort`) is choking on the TOML proxy module in fpm, due to overloading the `get_value` interface in the proxy with an fpm specific data type. For some reason this alters the signature of the `toml_table` data type and causes a compilation error.