### PR TITLE
proposal to close #525 by generating build/.gitignore

### DIFF
--- a/src/fpm.f90
+++ b/src/fpm.f90
@@ -5,7 +5,7 @@ use fpm_command_line, only: fpm_build_settings, fpm_new_settings, &
                       fpm_run_settings, fpm_install_settings, fpm_test_settings
 use fpm_dependency, only : new_dependency_tree
 use fpm_environment, only: run, get_env
-use fpm_filesystem, only: is_dir, join_path, number_of_rows, list_files, exists, basename
+use fpm_filesystem, only: is_dir, join_path, number_of_rows, list_files, exists, basename, filewrite, mkdir
 use fpm_model, only: fpm_model_t, srcfile_t, show_model, &
                     FPM_SCOPE_UNKNOWN, FPM_SCOPE_LIB, FPM_SCOPE_DEP, &
                     FPM_SCOPE_APP, FPM_SCOPE_EXAMPLE, FPM_SCOPE_TEST
@@ -57,6 +57,11 @@ subroutine build_model(model, settings, package, error)
     call new_dependency_tree(model%deps, cache=join_path("build", "cache.toml"))
     call model%deps%add(package, error)
     if (allocated(error)) return
+
+    ! build/ directory should now exist
+    if (.not.exists("build/.gitignore")) then
+      call filewrite(join_path("build", ".gitignore"),["*"])
+    end if
 
     if(settings%compiler.eq.'')then
         model%fortran_compiler = 'gfortran'

--- a/src/fpm/cmd/new.f90
+++ b/src/fpm/cmd/new.f90
@@ -98,9 +98,6 @@ character(len=:,kind=tfc),allocatable :: littlefile(:)
     ! like realpath() or getcwd().
     bname=basename(settings%name)
 
-    ! create NAME/.gitignore file
-    call warnwrite(join_path(settings%name, '.gitignore'), ['build/*'])
-
     littlefile=[character(len=80) :: '# '//bname, 'My cool new project!']
 
     ! create NAME/README.md

--- a/src/fpm/cmd/new.f90
+++ b/src/fpm/cmd/new.f90
@@ -100,44 +100,6 @@ character(len=:,kind=tfc),allocatable :: littlefile(:)
 
     littlefile=[character(len=80) :: '# '//bname, 'My cool new project!']
 
-    if(settings%with_full)then
-        ! create NAME/.gitignore file
-        call warnwrite(join_path(settings%name, '.gitignore'), [character(len=80):: &
-         &'# to ignore build/ only in the top level',&
-         &'/build*/',&
-         &'',&
-         &'# GitHub default for Fortran projects',&
-         &'# Prerequisites',&
-         &'*.d',&
-         &'# Compiled Object files',&
-         &'*.slo',&
-         &'*.lo',&
-         &'*.o',&
-         &'*.obj',&
-         &'# Precompiled Headers',&
-         &'*.gch',&
-         &'*.pch',&
-         &'# Compiled Dynamic libraries',&
-         &'*.so',&
-         &'*.dylib',&
-         &'*.dll',&
-         &'# Fortran module files',&
-         &'*.mod',&
-         &'*.smod',&
-         &'# Compiled Static libraries',&
-         &'*.lai',&
-         &'*.la',&
-         &'*.a',&
-         &'*.lib',&
-         &'# Executables',&
-         &'*.exe',&
-         &'*.out',&
-         &'*.app',&
-         &'#'])
-    else
-        call warnwrite(join_path(settings%name, '.gitignore'), ['/build/*'])
-    endif
-
     ! create NAME/README.md
     call warnwrite(join_path(settings%name, 'README.md'), littlefile)
 

--- a/src/fpm/cmd/new.f90
+++ b/src/fpm/cmd/new.f90
@@ -100,6 +100,44 @@ character(len=:,kind=tfc),allocatable :: littlefile(:)
 
     littlefile=[character(len=80) :: '# '//bname, 'My cool new project!']
 
+    if(settings%with_full)then
+        ! create NAME/.gitignore file
+        call warnwrite(join_path(settings%name, '.gitignore'), [character(len=80):: &
+         &'# to ignore build/ only in the top level',&
+         &'/build*/',&
+         &'',&
+         &'# GitHub default for Fortran projects',&
+         &'# Prerequisites',&
+         &'*.d',&
+         &'# Compiled Object files',&
+         &'*.slo',&
+         &'*.lo',&
+         &'*.o',&
+         &'*.obj',&
+         &'# Precompiled Headers',&
+         &'*.gch',&
+         &'*.pch',&
+         &'# Compiled Dynamic libraries',&
+         &'*.so',&
+         &'*.dylib',&
+         &'*.dll',&
+         &'# Fortran module files',&
+         &'*.mod',&
+         &'*.smod',&
+         &'# Compiled Static libraries',&
+         &'*.lai',&
+         &'*.la',&
+         &'*.a',&
+         &'*.lib',&
+         &'# Executables',&
+         &'*.exe',&
+         &'*.out',&
+         &'*.app',&
+         &'#'])
+    else
+        call warnwrite(join_path(settings%name, '.gitignore'), ['/build/*'])
+    endif
+
     ! create NAME/README.md
     call warnwrite(join_path(settings%name, 'README.md'), littlefile)
 

--- a/src/fpm/cmd/update.f90
+++ b/src/fpm/cmd/update.f90
@@ -2,7 +2,7 @@ module fpm_cmd_update
   use fpm_command_line, only : fpm_update_settings
   use fpm_dependency, only : dependency_tree_t, new_dependency_tree
   use fpm_error, only : error_t, fpm_stop
-  use fpm_filesystem, only : exists, mkdir, join_path, delete_file
+  use fpm_filesystem, only : exists, mkdir, join_path, delete_file, filewrite
   use fpm_manifest, only : package_config_t, get_package_data
   implicit none
   private
@@ -26,6 +26,7 @@ contains
 
     if (.not.exists("build")) then
       call mkdir("build")
+      call filewrite(join_path("build", ".gitignore"),["*"])
     end if
 
     cache = join_path("build", "cache.toml")

--- a/src/fpm_command_line.f90
+++ b/src/fpm_command_line.f90
@@ -936,14 +936,11 @@ contains
     '   o runs the command "git init" in that directory                     ', &
     '   o populates the directory with the default project directories      ', &
     '   o adds sample Fortran source files                                  ', &
-    '   o adds a ".gitignore" file for ignoring the build/ directory        ', &
-    '     (where fpm-generated output will be placed)                       ', &
     '                                                                       ', &
     ' The default file structure (that will be automatically scanned) is    ', &
     '                                                                       ', &
     '     NAME/                                                             ', &
     '       fpm.toml                                                        ', &
-    '       .gitignore                                                      ', &
     '       src/                                                            ', &
     '           NAME.f90                                                    ', &
     '       app/                                                            ', &
@@ -1004,8 +1001,8 @@ contains
     '              depend extensively on non-default build options.         ', &
     '                                                                       ', &
     ' --bare       A minimal manifest file ("fpm.toml") is created and      ', &
-    '              a ".gitignore" and "README.md" file is created but no    ', &
-    '              directories or sample Fortran is generated.              ', &
+    '              "README.md" file is created but no directories or        ', &
+    '              sample Fortran are generated.                            ', &
     '                                                                       ', &
     ' --help       print this help and exit                                 ', &
     ' --version    print program version information and exit               ', &


### PR DESCRIPTION
Seems like #525 is reasonable; it does put a few lines that are git(1)specific into fpm, but is does not make it dependent on the .gitignore file (that is, someone not using git(1) is not affected); and is more reliable at ensuring build/ is ignored which is very dominantly the case.  Any up or down votes on this simple change?