### PR TITLE
still call "git init" even if fpm.toml exists in backfill

### DIFF
--- a/src/fpm/cmd/new.f90
+++ b/src/fpm/cmd/new.f90
@@ -99,7 +99,7 @@ character(len=:,kind=tfc),allocatable :: littlefile(:)
     bname=basename(settings%name)
 
     ! create NAME/.gitignore file
-        call warnwrite(join_path(settings%name, '.gitignore'), ['build/*'])
+    call warnwrite(join_path(settings%name, '.gitignore'), ['build/*'])
 
     littlefile=[character(len=80) :: '# '//bname, 'My cool new project!']
 

--- a/src/fpm/cmd/new.f90
+++ b/src/fpm/cmd/new.f90
@@ -98,6 +98,9 @@ character(len=:,kind=tfc),allocatable :: littlefile(:)
     ! like realpath() or getcwd().
     bname=basename(settings%name)
 
+    ! create NAME/.gitignore file
+        call warnwrite(join_path(settings%name, '.gitignore'), ['build/*'])
+
     littlefile=[character(len=80) :: '# '//bname, 'My cool new project!']
 
     ! create NAME/README.md

--- a/src/fpm/cmd/new.f90
+++ b/src/fpm/cmd/new.f90
@@ -98,9 +98,6 @@ character(len=:,kind=tfc),allocatable :: littlefile(:)
     ! like realpath() or getcwd().
     bname=basename(settings%name)
 
-    ! create NAME/.gitignore file
-    call warnwrite(join_path(settings%name, '.gitignore'), ['build/*'])
-
     littlefile=[character(len=80) :: '# '//bname, 'My cool new project!']
 
     ! create NAME/README.md
@@ -592,6 +589,11 @@ character(len=*),intent(in) :: filename
    integer                     :: lun
    character(len=8)            :: date
 
+    if(exists(filename))then
+       write(stderr,'(*(g0,1x))')'<INFO>  ',filename,&
+       & 'already exists. Not overwriting'
+       return
+    endif
     !> get date to put into metadata in manifest file "fpm.toml"
     call date_and_time(DATE=date)
     table = toml_table()


### PR DESCRIPTION
closes #535 by exiting the routine to create a default fpm.toml manifest if fpm.toml exists

A backfill should not fail with an error, but should just create a more complete `fpm` package, possibly producing <INFO> messages along the way depending on what actions are taken.

If a backfill that would have created a plain basic fpm.toml file is invoked and the fpm.toml file already exists, the command stops
and therefore does not complete the remaining steps  (which is basically currently just a "git init"), so if the package does not already have git initialized it remains so, which is unintended. This change produces an <INFO> message instead of a failure, allowing the `new` subcommand to continue and to complete the remaining intended actions when the above scenario occurs.