### PR TITLE
Update version for release 0.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ non-Fortran related package manager.
 
 __Note:__ On Linux and MacOS, you will need to enable executable permission before you can use the binary.
 
-_e.g._ `$ chmod u+x fpm-0.3.0-linux-x86_64`
+_e.g._ `$ chmod u+x fpm-0.4.0-linux-x86_64`
 
 #### Conda
 

--- a/fpm.toml
+++ b/fpm.toml
@@ -1,5 +1,5 @@
 name = "fpm"
-version = "0.3.0"
+version = "0.4.0"
 license = "MIT"
 author = "fpm maintainers"
 maintainer = ""

--- a/src/fpm_command_line.f90
+++ b/src/fpm_command_line.f90
@@ -137,7 +137,7 @@ contains
             case default     ; os_type =  "OS Type:     UNKNOWN"
         end select
         version_text = [character(len=80) :: &
-         &  'Version:     0.3.0, alpha',                               &
+         &  'Version:     0.4.0, alpha',                               &
          &  'Program:     fpm(1)',                                     &
          &  'Description: A Fortran package manager and build system', &
          &  'Home Page:   https://github.com/fortran-lang/fpm',        &


### PR DESCRIPTION
Release is tested here: https://github.com/awvwgk/fortran-package-manager/releases/tag/v0.4.0

---

Release notes:

**Changes**

- bootstrap script is now based on 0.3.0 (https://github.com/fortran-lang/fpm/pull/504)
- executable, example and test names are checked to contain only alphanumeric characters (https://github.com/fortran-lang/fpm/pull/511)
- optimize file listing (https://github.com/fortran-lang/fpm/pull/507)

**New Features**

- generate `build/.gitignore` to avoid disallow committing build artifacts (https://github.com/fortran-lang/fpm/pull/528)
- allow *extra* section in package manifest (https://github.com/fortran-lang/fpm/pull/533)
- support MPI wrappers and LFortran compiler (https://github.com/fortran-lang/fpm/pull/527)

**Fixes**

- initialize executable names before comparison (https://github.com/fortran-lang/fpm/pull/516)
- don't access unallocated variables in fpm-run (https://github.com/fortran-lang/fpm/pull/517)
- cleanup help texts and remove unallocated variables (https://github.com/fortran-lang/fpm/pull/522)
- fix compilation errors for building fpm with `ifort` (https://github.com/fortran-lang/fpm/pull/523)
- always call git init in case of backfilling with fpm-new (https://github.com/fortran-lang/fpm/pull/536)
- use correct symbols on MacOS/ARM64 (https://github.com/fortran-lang/fpm/pull/548)

---

For conda-forge we have to rewrite the build script first, because the bootstrapping process can no longer be done in a single step but requires a two-stage procedure now. I have an idea how to do this smoothly even when cross-compiling, but I haven't tried it yet.

For LFortran's CI you have to download the Windows binary from the GitHub release because we still can't fpm build with conda-forge's toolchain on Windows. For MacOS and Linux conda-forge of course should work just fine.