### PR TITLE
Allow setting, archiver, C compiler flags and linker flags from commandline

### DIFF
--- a/src/fpm.f90
+++ b/src/fpm.f90
@@ -39,7 +39,7 @@ subroutine build_model(model, settings, package, error)
 
     integer :: i, j
     type(package_config_t) :: dependency
-    character(len=:), allocatable :: manifest, lib_dir, flags
+    character(len=:), allocatable :: manifest, lib_dir, flags, cflags, ldflags
 
     logical :: duplicates_found = .false.
     type(string_t) :: include_dir
@@ -73,7 +73,10 @@ subroutine build_model(model, settings, package, error)
         end select
     end if
 
-    write(build_name, '(z16.16)') fnv_1a(flags)
+    cflags = trim(settings%cflag)
+    ldflags = trim(settings%ldflag)
+
+    write(build_name, '(z16.16)') fnv_1a(flags//cflags//ldflags)
 
     if (model%compiler%is_unknown()) then
         write(*, '(*(a:,1x))') &
@@ -195,6 +198,8 @@ subroutine build_model(model, settings, package, error)
         write(*,*)'<INFO> COMPILER:  ',model%compiler%fc
         write(*,*)'<INFO> C COMPILER:  ',model%compiler%cc
         write(*,*)'<INFO> COMPILER OPTIONS:  ', model%fortran_compile_flags
+        write(*,*)'<INFO> C COMPILER OPTIONS:  ', model%c_compile_flags
+        write(*,*)'<INFO> LINKER OPTIONS:  ', model%link_flags
         write(*,*)'<INFO> INCLUDE DIRECTORIES:  [', string_cat(model%include_dirs,','),']'
      end if
 

--- a/src/fpm.f90
+++ b/src/fpm.f90
@@ -60,8 +60,8 @@ subroutine build_model(model, settings, package, error)
       call filewrite(join_path("build", ".gitignore"),["*"])
     end if
 
-    call new_compiler(model%compiler, settings%compiler)
-    call new_archiver(model%archiver)
+    call new_compiler(model%compiler, settings%compiler, settings%c_compiler)
+    call new_archiver(model%archiver, settings%archiver)
 
     if (settings%flag == '') then
         flags = model%compiler%get_default_flags(settings%profile == "release")

--- a/src/fpm_command_line.f90
+++ b/src/fpm_command_line.f90
@@ -120,55 +120,46 @@ character(len=:), allocatable :: val_runner, val_compiler, val_flag, val_cflag, 
 
 character(len=80), parameter :: help_text_compiler(*) = [character(len=80) :: &
     ' --compiler NAME   Specify a compiler name. The default is "gfortran"',&
-    '                   unless set by the environment variable FPM_FC or FC.',&
+    '                   unless set by the environment variable FPM_FC.',&
     ' --c-compiler NAME Specify the C compiler name. By default automatic determined',&
-    '                   unless set by the environment variable FPM_CC or CC.',&
+    '                   unless set by the environment variable FPM_CC.',&
     ' --archiver NAME   Specify the archiver name. By default automatic determined',&
-    '                   unless set by the environment variable FPM_AR or AR.'&
+    '                   unless set by the environment variable FPM_AR.'&
     ]
 
 character(len=80), parameter :: help_text_flag(*) = [character(len=80) :: &
     ' --flag  FFLAGS    selects compile arguments for the build, the default',&
-    '                   value is set by the FFLAGS environment variable.', &
+    '                   value is set by the FPM_FFLAGS environment variable.', &
     '                   These are added to the profile options if --profile', &
     '                   is specified, else these options override the defaults.',&
     '                   Note object and .mod directory locations are always',&
     '                   built in.',&
     ' --c-flag CFLAGS   selects compile arguments specific for C source in the build.',&
-    '                   The default value is set by the CFLAGS environment variable.',&
+    '                   The default value is set by the FPM_CFLAGS environment variable.',&
     ' --link-flag LDFLAGS',&
     '                   select arguments passed to the linker for the build.',&
-    '                   The default value is set by the LDFLAGS environment variable.'&
+    '                   The default value is set by the FPM_LDFLAGS environment variable.'&
     ]
 
 
 character(len=80), parameter :: help_text_environment(*) = [character(len=80) :: &
     'ENVIRONMENT VARIABLES',&
-    ' FPM_FC, FC        sets the path to the Fortran compiler used for the build,', &
-    '                   FPM_FC will take preference over FC, if both are set,', &
+    ' FPM_FC            sets the path to the Fortran compiler used for the build,', &
     '                   will be overwritten by --compiler command line option', &
     '', &
-    ' FPM_FFLAGS, FFLAGS',&
-    '                   sets the arguments for the Fortran compiler', &
-    '                   FPM_FFLAGS will take preference over FFLAGS, if both are set,', &
+    ' FPM_FFLAGS        sets the arguments for the Fortran compiler', &
     '                   will be overwritten by --flag command line option', &
     '', &
-    ' FPM_CC, CC        sets the path to the C compiler used for the build,', &
-    '                   FPM_CC will take preference over CC, if both are set,', &
+    ' FPM_CC            sets the path to the C compiler used for the build,', &
     '                   will be overwritten by --c-compiler command line option', &
     '', &
-    ' FPM_CFLAGS, CFLAGS',&
-    '                   sets the arguments for the C compiler', &
-    '                   FPM_CFLAGS will take preference over CFLAGS, if both are set,', &
+    ' FPM_CFLAGS        sets the arguments for the C compiler', &
     '                   will be overwritten by --c-flag command line option', &
     '', &
-    ' FPM_AR, AR        sets the path to the archiver used for the build,', &
-    '                   FPM_AR will take preference over AR, if both are set,', &
+    ' FPM_AR            sets the path to the archiver used for the build,', &
     '                   will be overwritten by --archiver command line option', &
     '', &
-    ' FPM_LDFLAGS, LDFLAGS',&
-    '                   sets additional link arguments for creating executables', &
-    '                   FPM_LDFLAGS will take preference over LDFLAGS, if both are set,', &
+    ' FPM_LDFLAGS       sets additional link arguments for creating executables', &
     '                   will be overwritten by --link-flag command line option' &
     ]
 
@@ -1210,7 +1201,8 @@ contains
     end subroutine get_char_arg
 
 
-    !> Get an environment variable for fpm
+    !> Get an environment variable for fpm, this routine ensures that every variable
+    !> used by fpm is prefixed with FPM_.
     function get_fpm_env(env, default) result(val)
       character(len=*), intent(in) :: env
       character(len=*), intent(in) :: default
@@ -1218,7 +1210,7 @@ contains
 
       character(len=*), parameter :: fpm_prefix = "FPM_"
 
-      val = get_env(fpm_prefix//val, get_env(env, default))
+      val = get_env(fpm_prefix//val, default)
     end function get_fpm_env
 
 end module fpm_command_line

--- a/src/fpm_compiler.f90
+++ b/src/fpm_compiler.f90
@@ -602,7 +602,7 @@ subroutine new_compiler(self, fc)
     !> New instance of the compiler
     type(compiler_t), intent(out) :: self
 
-    character(len=*), parameter :: cc_env = "FPM_C_COMPILER"
+    character(len=*), parameter :: cc_env = "CC"
 
     self%id = get_compiler_id(fc)
 
@@ -618,16 +618,21 @@ subroutine new_archiver(self)
     type(archiver_t), intent(out) :: self
     integer :: estat, os_type
 
+    character(len=:), allocatable :: ar
+    character(len=*), parameter :: arflags = " -rs "
+
+    ar = get_env("AR", "ar")
+
     os_type = get_os_type()
     if (os_type /= OS_WINDOWS .and. os_type /= OS_UNKNOWN) then
-        self%ar = "ar -rs "
+        self%ar = ar//arflags
     else
-        call execute_command_line("ar --version > "//get_temp_filename()//" 2>&1", &
+        call execute_command_line(ar//" --version > "//get_temp_filename()//" 2>&1", &
             & exitstat=estat)
         if (estat /= 0) then
             self%ar = "lib /OUT:"
         else
-            self%ar = "ar -rs "
+            self%ar = ar//arflags
         end if
     end if
     self%use_response_file = os_type == OS_WINDOWS

--- a/src/fpm_compiler.f90
+++ b/src/fpm_compiler.f90
@@ -596,44 +596,62 @@ end function is_unknown
 
 
 !> Create new compiler instance
-subroutine new_compiler(self, fc)
-    !> Fortran compiler name or path
-    character(len=*), intent(in) :: fc
+subroutine new_compiler(self, fc, cc)
     !> New instance of the compiler
     type(compiler_t), intent(out) :: self
-
-    character(len=*), parameter :: cc_env = "CC"
+    !> Fortran compiler name or path
+    character(len=*), intent(in) :: fc
+    !> C compiler name or path
+    character(len=*), intent(in) :: cc
 
     self%id = get_compiler_id(fc)
 
     self%fc = fc
-    call get_default_c_compiler(self%fc, self%cc)
-    self%cc = get_env(cc_env, self%cc)
+    if (len_trim(cc) > 0) then
+      self%cc = cc
+    else
+      call get_default_c_compiler(self%fc, self%cc)
+    end if
 end subroutine new_compiler
 
 
 !> Create new archiver instance
-subroutine new_archiver(self)
+subroutine new_archiver(self, ar)
     !> New instance of the archiver
     type(archiver_t), intent(out) :: self
+    !> User provided archiver command
+    character(len=*), intent(in) :: ar
+
     integer :: estat, os_type
 
-    character(len=:), allocatable :: ar
-    character(len=*), parameter :: arflags = " -rs "
+    character(len=*), parameter :: arflags = " -rs ", libflags = " /OUT:"
 
-    ar = get_env("AR", "ar")
-
-    os_type = get_os_type()
-    if (os_type /= OS_WINDOWS .and. os_type /= OS_UNKNOWN) then
+    if (len_trim(ar) > 0) then
+      ! Check first for ar-like commands
+      if (check_compiler(ar, "ar")) then
         self%ar = ar//arflags
+      end if
+
+      ! Check for lib-like commands
+      if (check_compiler(ar, "lib")) then
+        self%ar = ar//libflags
+      end if
+
+      ! Fallback and assume ar-like behaviour
+      self%ar = ar//arflags
     else
-        call execute_command_line(ar//" --version > "//get_temp_filename()//" 2>&1", &
-            & exitstat=estat)
+      os_type = get_os_type()
+      if (os_type /= OS_WINDOWS .and. os_type /= OS_UNKNOWN) then
+        self%ar = "ar"//arflags
+      else
+        call execute_command_line("ar --version > "//get_temp_filename()//" 2>&1", &
+          & exitstat=estat)
         if (estat /= 0) then
-            self%ar = "lib /OUT:"
+          self%ar = "lib"//libflags
         else
-            self%ar = ar//arflags
+          self%ar = "ar"//arflags
         end if
+      end if
     end if
     self%use_response_file = os_type == OS_WINDOWS
     self%echo = .true.

--- a/src/fpm_model.f90
+++ b/src/fpm_model.f90
@@ -124,6 +124,12 @@ type :: fpm_model_t
     !> Command line flags passed to fortran for compilation
     character(:), allocatable :: fortran_compile_flags
 
+    !> Command line flags passed to C for compilation
+    character(:), allocatable :: c_compile_flags
+
+    !> Command line flags passed to the linker
+    character(:), allocatable :: link_flags
+
     !> Base directory for build
     character(:), allocatable :: output_directory
 
@@ -273,6 +279,8 @@ function info_model(model) result(s)
     s = s // ', archiver=(' // debug(model%archiver) // ')'
     !    character(:), allocatable :: fortran_compile_flags
     s = s // ', fortran_compile_flags="' // model%fortran_compile_flags // '"'
+    s = s // ', c_compile_flags="' // model%c_compile_flags // '"'
+    s = s // ', link_flags="' // model%link_flags // '"'
     !    character(:), allocatable :: output_directory
     s = s // ', output_directory="' // model%output_directory // '"'
     !    type(string_t), allocatable :: link_libraries(:)

--- a/src/fpm_targets.f90
+++ b/src/fpm_targets.f90
@@ -479,7 +479,7 @@ subroutine resolve_target_linking(targets, model)
             if (target%target_type /= FPM_TARGET_C_OBJECT) then
                 target%compile_flags = model%fortran_compile_flags//" "//global_include_flags
             else
-                target%compile_flags = global_include_flags
+                target%compile_flags = model%c_compile_flags//" "//global_include_flags
             end if
 
             allocate(target%link_objects(0))
@@ -494,7 +494,7 @@ subroutine resolve_target_linking(targets, model)
 
                 call get_link_objects(target%link_objects,target,is_exe=.true.)
 
-                target%link_flags = string_cat(target%link_objects," ")
+                target%link_flags = model%link_flags//" "//string_cat(target%link_objects," ")
 
                 if (allocated(target%link_libraries)) then
                     if (size(target%link_libraries) > 0) then


### PR DESCRIPTION
- Read Fortran compiler from `FPM_FC` or `--compiler` (deprecate `FPM_COMPILER`)
- Read Fortran compiler options from `FPM_FFLAGS` or `--flag`
- Read C compiler from `FPM_CC` or `--c-compiler` (deprecate `FPM_C_COMPILER`)
- Read C compiler options from `FPM_CFLAGS` or `--c-flag`
- Read archiver from `FPM_AR` or `--archiver`
- Read linker options from `FPM_LDFLAGS` or `--link-flag`

Closes #529