### PR TITLE
Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/01_bug.yaml
+++ b/.github/ISSUE_TEMPLATE/01_bug.yaml
@@ -1,0 +1,39 @@
+name: Bug Report
+description: Something is not working
+labels: [bug]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      placeholder: Please include steps to reproduce your issue, provide example code snippets if possible
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behaviour
+      placeholder: What did you expect to happen instead
+    validations:
+      required: true
+  - type: input
+    id: fpm-version
+    attributes:
+      label: Version of fpm
+      placeholder: 0.4.0, 04da9a1ce99e8fce1abdb7eb9a2073f3188038ea, ...
+    validations:
+      required: true
+  - type: input
+    id: platform
+    attributes:
+      label: Platform and Architecture
+      placeholder: MacOS/ARM, Windows, OpenBSD, ...
+    validations:
+      required: true
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional Information
+      placeholder: Further relevant context, i.e. links to other issues
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/02_packaging.yaml
+++ b/.github/ISSUE_TEMPLATE/02_packaging.yaml
@@ -1,5 +1,5 @@
 name: Packaging Issue
-description: Porting or packaging a project to fpm `
+description: Porting or packaging a project to fpm
 labels: [packaging]
 body:
   - type: input

--- a/.github/ISSUE_TEMPLATE/02_packaging.yaml
+++ b/.github/ISSUE_TEMPLATE/02_packaging.yaml
@@ -1,0 +1,32 @@
+name: Packaging Issue
+description: Porting or packaging a project to fpm `
+labels: [packaging]
+body:
+  - type: input
+    id: project
+    attributes:
+      label: Upstream Project
+      placeholder: URL for the upstream project
+    validations:
+      required: true
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      placeholder: Please describe the issue with porting or packaging a project with fpm
+    validations:
+      required: true
+  - type: input
+    id: fpm-version
+    attributes:
+      label: Version of fpm
+      placeholder: 0.4.0, 04da9a1ce99e8fce1abdb7eb9a2073f3188038ea, ...
+    validations:
+      required: true
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional Information
+      placeholder: Further relevant context, i.e. links to other issues
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/03_feature.yaml
+++ b/.github/ISSUE_TEMPLATE/03_feature.yaml
@@ -1,0 +1,28 @@
+name: Feature request
+description: An idea for a new feature
+labels: [enhancement]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      placeholder: |
+        Please describe the feature, please provide examples
+        Use codefences (```) to add literal codeblocks for examples
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Possible Solution
+      placeholder: |
+        Please describe possible solutions or currently available workarounds if available.
+    validations:
+      required: false
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional Information
+      placeholder: Further relevant context, i.e. links to other issues
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/04_specification.yaml
+++ b/.github/ISSUE_TEMPLATE/04_specification.yaml
@@ -1,0 +1,42 @@
+name: Specification Proposal
+description: Suggestion for extending the package manifest, command line interface, ...
+labels: [specification]
+body:
+  - type: textarea
+    id: motivation
+    attributes:
+      label: Motivation
+      placeholder: |
+        What is the purpose of this proposal. Please provide usage examples for the new functionality as well.
+    validations:
+      required: true
+  - type: textarea
+    id: description
+    attributes:
+      label: Specification
+      placeholder: |
+        Please provide possible realisations of this proposal, i.e. an example how this would work in the manifest.
+
+        Use code fences to provide the example.
+
+        ```toml
+        [extra]
+        fpm = "feature"
+        ```
+    validations:
+      required: true
+  - type: textarea
+    id: prior-art
+    attributes:
+      label: Prior Art
+      placeholder: |
+        Include links and references to other package manager or build systems if available.
+    validations:
+      required: false
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional Information
+      placeholder: Further relevant context, i.e. links to other issues
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/05_free.md
+++ b/.github/ISSUE_TEMPLATE/05_free.md
@@ -1,0 +1,4 @@
+---
+name: Free Form
+about: If the topic doesn't fit anything above and is not suitable for the lists below
+---

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,10 @@
+contact_links:
+  - name: Fpm discussion board
+    url: https://github.com/fortran-lang/fpm/discussions
+    about: Discussion about fpm related topics
+  - name: Fortran-lang discourse
+    url: https://fortran-lang.discourse.group/
+    about: Discussion about all things Fortran
+  - name: Fortran-lang mailing list
+    url: https://groups.io/g/fortran-lang
+    about: Mailinglist for the Fortran language


### PR DESCRIPTION
You can checkout the available templates here:
https://github.com/awvwgk/fortran-package-manager/issues/new/choose

Provides:
- Issue form for bug reports
- Issue form for packaging issues
- Issue form for feature requests
- Issue form for specification proposals
- Issue template for blank issue
- Link to fpm discussion board
- Link to Fortran-lang discourse
- Link to Fortran-lang mailing list

Closes #555 

Screenshot:

<details><summary>New issue</summary>

![image](https://user-images.githubusercontent.com/28669218/132120817-be6be71c-dcc5-4f1c-b516-cab03207e7c6.png)
</details>

<details><summary>Bug report form</summary>

![image](https://user-images.githubusercontent.com/28669218/132120867-8dea1800-e26c-43ba-aaad-7f9f2bfc6fd4.png)
</details>
<details><summary>Packaging issue form</summary>

![image](https://user-images.githubusercontent.com/28669218/132120919-ca3effc5-7ca4-4e36-99cb-7b1d78fdad4f.png)
</details>
<details><summary>Feature request form</summary>

![image](https://user-images.githubusercontent.com/28669218/132120957-12c360ad-99e1-4e27-8736-feaa57fa4cbf.png)
</details>
<details><summary>Specification proposal form</summary>

![image](https://user-images.githubusercontent.com/28669218/132120974-1611326c-ad6f-4dd5-86e8-8059fc73175e.png)
</details>
<details><summary>Blank issue</summary>

![image](https://user-images.githubusercontent.com/28669218/132120987-0e921d67-867e-495a-ac66-47e71639043f.png)
</details>