### PR TITLE
Add workflow to create single source fpm version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,14 +1,20 @@
 name: Release
 
 on:
+  push:
+  pull_request:
   release:
     types: [published]
 
 jobs:
   source-archive:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        format: [zip]
     env:
-      FORMAT: zip
+      FORMAT: ${{ matrix.format }}
     steps:
     - name: Checkout code
       uses: actions/checkout@v2
@@ -17,28 +23,111 @@ jobs:
 
     - name: Get version number
       run: |
-        VERSION=$(git describe --tags --abbrev=0 --match 'v*' | tr -d '[:alpha:]')
+        VERSION=$(git describe --tags ${{ env.ABBREV }} --match 'v*' | tr -d 'v')
         [ -z "$VERSION" ] && exit 1
         echo "VERSION=${VERSION}" >> $GITHUB_ENV
+      env:
+        ABBREV: ${{ github.event_name == 'release' && '--abbrev=0' || '--abbrev=7' }}
 
     - name: Create archive
       run: |
-        git archive --prefix ${{ env.PREFIX }} --format ${{ env.FORMAT }} HEAD > ${{ env.OUTPUT }}
         echo "OUTPUT=${{ env.OUTPUT }}" >> $GITHUB_ENV
+        git archive --prefix ${{ env.PREFIX }} --format ${{ env.FORMAT }} HEAD > ${{ env.OUTPUT }}
       env:
         OUTPUT: fpm-${{ env.VERSION }}.${{ env.FORMAT }}
         PREFIX: fpm-${{ env.VERSION }}/
 
-    - name: Calculate checksum
+    - name: Upload artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: ${{ env.OUTPUT }}
+        path: ${{ env.OUTPUT }}
+
+  source-single-file:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Get version number
       run: |
-        sha256sum ${{ env.OUTPUT }} > ${{ env.OUTPUT }}.sha256
+        VERSION=$(git describe --tags ${{ env.ABBREV }} --match 'v*' | tr -d 'v')
+        [ -z "$VERSION" ] && exit 1
+        echo "VERSION=${VERSION}" >> $GITHUB_ENV
+      env:
+        ABBREV: ${{ github.event_name == 'release' && '--abbrev=0' || '--abbrev=7' }}
+
+    # Note: this step is meant to remove the test targets from the package manifest,
+    #       a change in the package manifest might require to regenerate the patch file.
+    - name: Remove tests
+      run: |
+        patch -p1 < ./ci/single-file.patch
+
+    - name: Install fpm
+      uses: fortran-lang/setup-fpm@v3
+      with:
+        fpm-version: 'v0.4.0'
+
+    - name: Create single file version
+      run: |
+        echo "OUTPUT=${{ env.OUTPUT }}" >> $GITHUB_ENV
+        echo "#define FPM_BOOTSTRAP" > fpm-${{ env.VERSION }}.F90
+        fpm build --compiler ./ci/single-file-gfortran.sh
+      env:
+        OUTPUT: fpm-${{ env.VERSION }}.F90
+        OMP_NUM_THREADS: 1
+
+    - name: Build single source version
+      run: |
+        echo "EXE=${{ env.BUILD_DIR }}/fpm" >> $GITHUB_ENV
+        mkdir ${{ env.BUILD_DIR }}
+        gfortran ${{ env.OUTPUT }} -J ${{ env.BUILD_DIR }} -o ${{ env.BUILD_DIR }}/fpm
+      env:
+        BUILD_DIR: build/bootstrap
+
+    - name: Undo patch
+      run: |
+        patch -p1 -R < ./ci/single-file.patch
+
+    - name: Build fpm with bootstrap version
+      run: |
+        ${{ env.EXE }} build
+
+    - name: Upload artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: ${{ env.OUTPUT }}
+        path: ${{ env.OUTPUT }}
+
+  upload-artifacts:
+    if: github.event_name == 'release'
+    runs-on: ubuntu-latest
+    needs:
+      - source-archive
+      - source-single-file
+
+    steps:
+    - name: Download Artifacts
+      uses: actions/download-artifact@v2
+      with:
+        path: ${{ github.workspace }} # This will download all files
+
+    - name: Create SHA256 checksums
+      run: |
+        for output in fpm-*/fpm-*; do
+          pushd $(dirname "$output")
+          sha256sum $(basename "$output") | tee $(basename "$output").sha256
+          popd
+        done
 
     - name: Upload assets
       if: ${{ github.event_name == 'release' }}
       uses: svenstaro/upload-release-action@v2
       with:
         repo_token: ${{ secrets.GITHUB_TOKEN }}
-        file: ${{ env.OUTPUT }}*
+        file: fpm-*/fpm-*
         file_glob: true
         tag: ${{ github.ref }}
         overwrite: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,44 @@
+name: Release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  source-archive:
+    runs-on: ubuntu-latest
+    env:
+      FORMAT: zip
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Get version number
+      run: |
+        VERSION=$(git describe --tags --abbrev=0 --match 'v*' | tr -d '[:alpha:]')
+        [ -z "$VERSION" ] && exit 1
+        echo "VERSION=${VERSION}" >> $GITHUB_ENV
+
+    - name: Create archive
+      run: |
+        git archive --prefix ${{ env.PREFIX }} --format ${{ env.FORMAT }} HEAD > ${{ env.OUTPUT }}
+        echo "OUTPUT=${{ env.OUTPUT }}" >> $GITHUB_ENV
+      env:
+        OUTPUT: fpm-${{ env.VERSION }}.${{ env.FORMAT }}
+        PREFIX: fpm-${{ env.VERSION }}/
+
+    - name: Calculate checksum
+      run: |
+        sha256sum ${{ env.OUTPUT }} > ${{ env.OUTPUT }}.sha256
+
+    - name: Upload assets
+      if: ${{ github.event_name == 'release' }}
+      uses: svenstaro/upload-release-action@v2
+      with:
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        file: ${{ env.OUTPUT }}*
+        file_glob: true
+        tag: ${{ github.ref }}
+        overwrite: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,11 +23,8 @@ jobs:
 
     - name: Get version number
       run: |
-        VERSION=$(git describe --tags ${{ env.ABBREV }} --match 'v*' | tr -d 'v')
-        [ -z "$VERSION" ] && exit 1
+        VERSION=$(git describe --tags --match 'v*' --always | tr -d 'v')
         echo "VERSION=${VERSION}" >> $GITHUB_ENV
-      env:
-        ABBREV: ${{ github.event_name == 'release' && '--abbrev=0' || '--abbrev=7' }}
 
     - name: Create archive
       run: |
@@ -53,11 +50,8 @@ jobs:
 
     - name: Get version number
       run: |
-        VERSION=$(git describe --tags ${{ env.ABBREV }} --match 'v*' | tr -d 'v')
-        [ -z "$VERSION" ] && exit 1
+        VERSION=$(git describe --tags --match 'v*' --always | tr -d 'v')
         echo "VERSION=${VERSION}" >> $GITHUB_ENV
-      env:
-        ABBREV: ${{ github.event_name == 'release' && '--abbrev=0' || '--abbrev=7' }}
 
     # Note: this step is meant to remove the test targets from the package manifest,
     #       a change in the package manifest might require to regenerate the patch file.
@@ -79,6 +73,8 @@ jobs:
         OUTPUT: fpm-${{ env.VERSION }}.F90
         OMP_NUM_THREADS: 1
 
+    # Building the bootstrap version from the single source version is the most expensive
+    # step in this workflow, since we have to compile several thousand lines of source.
     - name: Build single source version
       run: |
         echo "EXE=${{ env.BUILD_DIR }}/fpm" >> $GITHUB_ENV

--- a/ci/single-file-gfortran.sh
+++ b/ci/single-file-gfortran.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+output="${OUTPUT:-fpm-single-file.F90}"
+
+args=("$@")
+file=$(printf "%s\n" "${args[@]}" | grep -P '^.+\.[fF]90$')
+if [ $? = 0 ]; then
+  echo " + Appending source file '$file' to '${output}'"
+  cat $file >> "${output}"
+fi
+exec gfortran "${args[@]}"

--- a/ci/single-file.patch
+++ b/ci/single-file.patch
@@ -1,0 +1,29 @@
+diff --git a/fpm.toml b/fpm.toml
+index 12ec05aa..20425dfd 100644
+--- a/fpm.toml
++++ b/fpm.toml
+@@ -14,22 +14,5 @@ rev = "2f5eaba864ff630ba0c3791126a3f811b6e437f3"
+ git = "https://github.com/urbanjost/M_CLI2.git"
+ rev = "ea6bbffc1c2fb0885e994d37ccf0029c99b19f24"
+ 
+-[[test]]
+-name = "cli-test"
+-source-dir = "test/cli_test"
+-main = "cli_test.f90"
+-
+-[[test]]
+-name = "new-test"
+-source-dir = "test/new_test"
+-main = "new_test.f90"
+-
+-[[test]]
+-name = "fpm-test"
+-source-dir = "test/fpm_test"
+-main = "main.f90"
+-
+-[[test]]
+-name = "help-test"
+-source-dir = "test/help_test"
+-main = "help_test.f90"
++[build]
++auto-tests = false


### PR DESCRIPTION
This adds the script to generate the single source file version of fpm for bootstrapping. The following steps are used to generate the bootstrap version:

1. remove test targets from package manifest by patch (remove after #92 is resolved)
2. install an existing binary of fpm
3. call fpm with compiler wrapper script to collect single source version
4. build bootstrap version from single source version
5. reverse patch the package manifest (remove after #92 is resolved)
6. build fpm using the bootstrap version
7. upload single source file version

Finally, the single source file version is uploaded on releases.

This patch also changes the release workflow to run on every commit, but only upload on releases. This allows to use the created artifacts from PRs to quickly bootstrap a new fpm version with some new features implemented.

~~Requires #560~~
Closes #391 
Closes #559