### PR TITLE
Add workflow for continuous delivery

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -197,7 +197,7 @@ jobs:
           popd
         done
       env:
-        replace: 's/-([0-9]+\.[0-9]+\.[0-9]+-[0-9]+-g)?[0-9a-f]+/-current/'
+        replace: 's/-([0-9]+\.[0-9]+\.[0-9]+-[0-9]+-g)?[0-9a-f]+//'
 
     - name: Create SHA256 checksums
       run: |

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -173,6 +173,13 @@ jobs:
       - build
 
     steps:
+    - id: deploy-on-push
+      if: ${{ github.event_name == 'push' }}
+      run:
+        echo "::set-output name=result::${{ env.DEPLOY_BRANCH }}"
+      env:
+        DEPLOY_BRANCH: ${{ secrets.DEPLOY_BRANCH && contains(github.ref, secrets.DEPLOY_BRANCH) && 1 || 0 }}
+
     - uses: actions/checkout@v2
       if: ${{ github.event_name == 'push' }}
 
@@ -201,13 +208,14 @@ jobs:
         done
 
     - name: Move/Create continuous tag
-      if: ${{ github.event_name == 'push' }}
+      if: ${{ github.event_name == 'push' && steps.deploy-on-push.outputs.result != 0 }}
       run: |
         git tag --force 'current' ${{ github.sha }}
         git push --tags --force
 
     - name: Upload assets
       uses: svenstaro/upload-release-action@v2
+      if: ${{ github.event_name == 'release' || steps.deploy-on-push.outputs.result != 0 }}
       with:
         repo_token: ${{ secrets.GITHUB_TOKEN }}
         file: fpm-*/fpm-*

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -167,16 +167,30 @@ jobs:
         path: ${{ env.FPM_RELEASE }}
 
   upload-artifacts:
-    if: github.event_name == 'release'
+    if: ${{ github.event_name == 'release' && contains(github.ref, 'v') || github.event_name == 'push' }}
     runs-on: ubuntu-latest
     needs:
       - build
 
     steps:
+    - uses: actions/checkout@v2
+      if: ${{ github.event_name == 'push' }}
+
     - name: Download Artifacts
       uses: actions/download-artifact@v2
       with:
         path: ${{ github.workspace }} # This will download all files
+
+    - name: Normalize file names for continuous delivery
+      if: ${{ github.event_name == 'push' }}
+      run: |
+        for output in fpm-*/fpm-*; do
+          pushd $(dirname "$output")
+          mv -v $(basename $output) $(basename $output | sed -E '${{ env.replace }}')
+          popd
+        done
+      env:
+        replace: 's/-([0-9]+\.[0-9]+\.[0-9]+-[0-9]+-g)?[0-9a-f]+/-current/'
 
     - name: Create SHA256 checksums
       run: |
@@ -186,12 +200,17 @@ jobs:
           popd
         done
 
+    - name: Move/Create continuous tag
+      if: ${{ github.event_name == 'push' }}
+      run: |
+        git tag --force 'current' ${{ github.sha }}
+        git push --tags --force
+
     - name: Upload assets
-      if: github.event_name == 'release'
       uses: svenstaro/upload-release-action@v2
       with:
         repo_token: ${{ secrets.GITHUB_TOKEN }}
         file: fpm-*/fpm-*
         file_glob: true
-        tag: ${{ github.ref }}
+        tag: ${{ github.event_name == 'release' && github.ref || 'current'}}
         overwrite: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,6 +105,13 @@ jobs:
       - source-single-file
 
     steps:
+    - id: deploy-on-push
+      if: ${{ github.event_name == 'push' }}
+      run:
+        echo "::set-output name=result::${{ env.DEPLOY_BRANCH }}"
+      env:
+        DEPLOY_BRANCH: ${{ secrets.DEPLOY_BRANCH && contains(github.ref, secrets.DEPLOY_BRANCH) && 1 || 0 }}
+
     - uses: actions/checkout@v2
       if: ${{ github.event_name == 'push' }}
 
@@ -133,13 +140,13 @@ jobs:
         done
 
     - name: Move/Create continuous tag
-      if: ${{ github.event_name == 'push' }}
+      if: ${{ github.event_name == 'push' && steps.deploy-on-push.outputs.result != 0 }}
       run: |
         git tag --force 'current' ${{ github.sha }}
         git push --tags --force
 
     - name: Upload assets
-      if: ${{ github.event_name == 'release' || github.event_name == 'push' }}
+      if: ${{ github.event_name == 'release' || steps.deploy-on-push.outputs.result != 0 }}
       uses: svenstaro/upload-release-action@v2
       with:
         repo_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -129,7 +129,7 @@ jobs:
           popd
         done
       env:
-        replace: 's/-([0-9]+\.[0-9]+\.[0-9]+-[0-9]+-g)?[0-9a-f]+/-current/'
+        replace: 's/-([0-9]+\.[0-9]+\.[0-9]+-[0-9]+-g)?[0-9a-f]+//'
 
     - name: Create SHA256 checksums
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,17 +98,31 @@ jobs:
         path: ${{ env.OUTPUT }}
 
   upload-artifacts:
-    if: github.event_name == 'release'
+    if: ${{ github.event_name == 'release' && contains(github.ref, 'v') || github.event_name == 'push' }}
     runs-on: ubuntu-latest
     needs:
       - source-archive
       - source-single-file
 
     steps:
+    - uses: actions/checkout@v2
+      if: ${{ github.event_name == 'push' }}
+
     - name: Download Artifacts
       uses: actions/download-artifact@v2
       with:
         path: ${{ github.workspace }} # This will download all files
+
+    - name: Normalize file names for continuous delivery
+      if: ${{ github.event_name == 'push' }}
+      run: |
+        for output in fpm-*/fpm-*; do
+          pushd $(dirname "$output")
+          mv -v $(basename $output) $(basename $output | sed -E '${{ env.replace }}')
+          popd
+        done
+      env:
+        replace: 's/-([0-9]+\.[0-9]+\.[0-9]+-[0-9]+-g)?[0-9a-f]+/-current/'
 
     - name: Create SHA256 checksums
       run: |
@@ -118,12 +132,18 @@ jobs:
           popd
         done
 
+    - name: Move/Create continuous tag
+      if: ${{ github.event_name == 'push' }}
+      run: |
+        git tag --force 'current' ${{ github.sha }}
+        git push --tags --force
+
     - name: Upload assets
-      if: ${{ github.event_name == 'release' }}
+      if: ${{ github.event_name == 'release' || github.event_name == 'push' }}
       uses: svenstaro/upload-release-action@v2
       with:
         repo_token: ${{ secrets.GITHUB_TOKEN }}
         file: fpm-*/fpm-*
         file_glob: true
-        tag: ${{ github.ref }}
+        tag: ${{ github.event_name == 'release' && github.ref || 'current'}}
         overwrite: true

--- a/README.md
+++ b/README.md
@@ -32,11 +32,14 @@ non-Fortran related package manager.
 ### Setting up fpm
 
 #### Binary download
-`x86-64` binaries are available [to download](https://github.com/fortran-lang/fpm/releases) for Windows, MacOS and Linux.
+
+Binaries for the latest stable release are available [to download](https://github.com/fortran-lang/fpm/releases/latest) for Windows, MacOS, and Linux.
 
 __Note:__ On Linux and MacOS, you will need to enable executable permission before you can use the binary.
 
 _e.g._ `$ chmod u+x fpm-0.4.0-linux-x86_64`
+
+The binaries at the [current tag](https://github.com/fortran-lang/fpm/releases/tag/current) are updated automatically to always provide the current git version from the default branch.
 
 
 #### [Conda]
@@ -147,7 +150,7 @@ To build manually using the single source distribution, run the following code (
 
 ```
 mkdir _tmp
-curl -LJ https://github.com/fortran-lang/fpm/releases/download/v0.3.0/fpm-0.3.0.F90 > _tmp/fpm.F90
+curl -LJ https://github.com/fortran-lang/fpm/releases/download/current/fpm.F90 > _tmp/fpm.F90
 gfortran -J _tmp _tmp/fpm.F90 -o _tmp/fpm
 _tmp/fpm install --flag "-g -fbacktrace -O3"
 rm -r _tmp


### PR DESCRIPTION
Since our default branch is always deployable, we can easily create a continuous release which contains the latest fpm binaries and source version. This PR adds a workflow to create and move a tag called `current` with the head of the git repository and update the binary artifacts to the latest CI outputs.

Example: https://github.com/awvwgk/fortran-package-manager/releases/tag/current