### PR TITLE
Build no tests by default

### DIFF
--- a/src/fpm.f90
+++ b/src/fpm.f90
@@ -268,7 +268,7 @@ if (allocated(error)) then
     call fpm_stop(1,'*cmd_build*:model error:'//error%message)
 end if
 
-call targets_from_sources(targets,model,error)
+call targets_from_sources(targets, model, error, include_tests=settings%test)
 if (allocated(error)) then
     call fpm_stop(1,'*cmd_build*:target error:'//error%message)
 end if
@@ -314,7 +314,7 @@ subroutine cmd_run(settings,test)
         call fpm_stop(1, '*cmd_run*:model error:'//error%message)
     end if
 
-    call targets_from_sources(targets,model,error)
+    call targets_from_sources(targets, model, error, include_tests=test)
     if (allocated(error)) then
         call fpm_stop(1, '*cmd_run*:targets error:'//error%message)
     end if

--- a/src/fpm.f90
+++ b/src/fpm.f90
@@ -85,6 +85,8 @@ subroutine build_model(model, settings, package, error)
     model%fortran_compile_flags = flags // " " // &
         & model%compiler%get_module_flag(join_path(model%output_directory, model%package_name))
 
+    model%include_tests = settings%build_tests
+
     allocate(model%packages(model%deps%ndep))
 
     ! Add sources from executable directories
@@ -268,7 +270,7 @@ if (allocated(error)) then
     call fpm_stop(1,'*cmd_build*:model error:'//error%message)
 end if
 
-call targets_from_sources(targets, model, error, include_tests=settings%test)
+call targets_from_sources(targets, model, error)
 if (allocated(error)) then
     call fpm_stop(1,'*cmd_build*:target error:'//error%message)
 end if
@@ -314,7 +316,7 @@ subroutine cmd_run(settings,test)
         call fpm_stop(1, '*cmd_run*:model error:'//error%message)
     end if
 
-    call targets_from_sources(targets, model, error, include_tests=test)
+    call targets_from_sources(targets, model, error)
     if (allocated(error)) then
         call fpm_stop(1, '*cmd_run*:targets error:'//error%message)
     end if

--- a/src/fpm/cmd/install.f90
+++ b/src/fpm/cmd/install.f90
@@ -36,7 +36,7 @@ contains
     call build_model(model, settings%fpm_build_settings, package, error)
     call handle_error(error)
 
-    call targets_from_sources(targets, model, error, include_tests=.false.)
+    call targets_from_sources(targets, model, error)
     call handle_error(error)
 
     installable = (allocated(package%library) .and. package%install%library) &

--- a/src/fpm/cmd/install.f90
+++ b/src/fpm/cmd/install.f90
@@ -36,7 +36,7 @@ contains
     call build_model(model, settings%fpm_build_settings, package, error)
     call handle_error(error)
 
-    call targets_from_sources(targets,model,error)
+    call targets_from_sources(targets, model, error, include_tests=.false.)
     call handle_error(error)
 
     installable = (allocated(package%library) .and. package%install%library) &

--- a/src/fpm_command_line.f90
+++ b/src/fpm_command_line.f90
@@ -215,7 +215,7 @@ contains
             & --show-model F &
             & --compiler "'//get_env('FPM_COMPILER','gfortran')//'" &
             & --flag:: " "&
-            & --test F &
+            & --tests F &
             & --verbose F &
             & --',help_build,version_text)
 
@@ -228,7 +228,7 @@ contains
             & flag=val_flag, &
             & list=lget('list'),&
             & show_model=lget('show-model'),&
-            & build_tests=lget('test'),&
+            & build_tests=lget('tests'),&
             & verbose=lget('verbose') )
 
         case('new')
@@ -526,7 +526,7 @@ contains
    help_list_dash = [character(len=80) :: &
    '                                                                                ', &
    ' build [--compiler COMPILER_NAME] [--profile PROF] [--flag FFLAGS] [--list]     ', &
-   '       [--test]                                                                 ', &
+   '       [--tests]                                                                ', &
    ' help [NAME(s)]                                                                 ', &
    ' new NAME [[--lib|--src] [--app] [--test] [--example]]|                         ', &
    '          [--full|--bare][--backfill]                                           ', &
@@ -644,7 +644,7 @@ contains
     '  Their syntax is                                                      ', &
     '                                                                                ', &
     '    build [--profile PROF] [--flag FFLAGS] [--list] [--compiler COMPILER_NAME]  ', &
-    '          [--test]                                                              ', &
+    '          [--tests]                                                             ', &
     '    new NAME [[--lib|--src] [--app] [--test] [--example]]|                      ', &
     '             [--full|--bare][--backfill]                                        ', &
     '    update [NAME(s)] [--fetch-only] [--clean]                                   ', &
@@ -836,7 +836,7 @@ contains
     '                                                                       ', &
     'SYNOPSIS                                                               ', &
     ' fpm build [--profile PROF] [--flag FFLAGS] [--compiler COMPILER_NAME] ', &
-    '           [--list] [--test]                                           ', &
+    '           [--list] [--tests]                                          ', &
     '                                                                       ', &
     ' fpm build --help|--version                                            ', &
     '                                                                       ', &
@@ -872,7 +872,7 @@ contains
     '                           "gfortran" unless set by the environment    ', &
     '                           variable FPM_COMPILER.                      ', &
     ' --list       list candidates instead of building or running them      ', &
-    ' --test       build tests explicitly (otherwise only done if needed)   ', &
+    ' --tests      build all tests (otherwise only if needed)               ', &
     ' --show-model show the model and exit (do not build)                   ', &
     ' --help       print this help and exit                                 ', &
     ' --version    print program version information and exit               ', &

--- a/src/fpm_command_line.f90
+++ b/src/fpm_command_line.f90
@@ -67,7 +67,7 @@ end type
 type, extends(fpm_cmd_settings)  :: fpm_build_settings
     logical                      :: list=.false.
     logical                      :: show_model=.false.
-    logical                      :: test=.false.
+    logical                      :: build_tests=.false.
     character(len=:),allocatable :: compiler
     character(len=:),allocatable :: profile
     character(len=:),allocatable :: flag
@@ -203,6 +203,7 @@ contains
             & flag=val_flag, &
             & example=lget('example'), &
             & list=lget('list'),&
+            & build_tests=.false.,&
             & name=names,&
             & runner=val_runner,&
             & verbose=lget('verbose') )
@@ -227,7 +228,7 @@ contains
             & flag=val_flag, &
             & list=lget('list'),&
             & show_model=lget('show-model'),&
-            & test=lget('test'),&
+            & build_tests=lget('test'),&
             & verbose=lget('verbose') )
 
         case('new')
@@ -420,6 +421,7 @@ contains
             & flag=val_flag, &
             & example=.false., &
             & list=lget('list'), &
+            & build_tests=.true., &
             & name=names, &
             & runner=val_runner, &
             & verbose=lget('verbose') )

--- a/src/fpm_command_line.f90
+++ b/src/fpm_command_line.f90
@@ -67,6 +67,7 @@ end type
 type, extends(fpm_cmd_settings)  :: fpm_build_settings
     logical                      :: list=.false.
     logical                      :: show_model=.false.
+    logical                      :: test=.false.
     character(len=:),allocatable :: compiler
     character(len=:),allocatable :: profile
     character(len=:),allocatable :: flag
@@ -213,7 +214,8 @@ contains
             & --show-model F &
             & --compiler "'//get_env('FPM_COMPILER','gfortran')//'" &
             & --flag:: " "&
-            & --verbose F&
+            & --test F &
+            & --verbose F &
             & --',help_build,version_text)
 
             call check_build_vals()
@@ -225,6 +227,7 @@ contains
             & flag=val_flag, &
             & list=lget('list'),&
             & show_model=lget('show-model'),&
+            & test=lget('test'),&
             & verbose=lget('verbose') )
 
         case('new')
@@ -521,6 +524,7 @@ contains
    help_list_dash = [character(len=80) :: &
    '                                                                                ', &
    ' build [--compiler COMPILER_NAME] [--profile PROF] [--flag FFLAGS] [--list]     ', &
+   '       [--test]                                                                 ', &
    ' help [NAME(s)]                                                                 ', &
    ' new NAME [[--lib|--src] [--app] [--test] [--example]]|                         ', &
    '          [--full|--bare][--backfill]                                           ', &
@@ -638,6 +642,7 @@ contains
     '  Their syntax is                                                      ', &
     '                                                                                ', &
     '    build [--profile PROF] [--flag FFLAGS] [--list] [--compiler COMPILER_NAME]  ', &
+    '          [--test]                                                              ', &
     '    new NAME [[--lib|--src] [--app] [--test] [--example]]|                      ', &
     '             [--full|--bare][--backfill]                                        ', &
     '    update [NAME(s)] [--fetch-only] [--clean]                                   ', &
@@ -828,7 +833,8 @@ contains
     ' build(1) - the fpm(1) subcommand to build a project                   ', &
     '                                                                       ', &
     'SYNOPSIS                                                               ', &
-    ' fpm build [--profile PROF] [--flag FFLAGS] [--compiler COMPILER_NAME] [-list]', &
+    ' fpm build [--profile PROF] [--flag FFLAGS] [--compiler COMPILER_NAME] ', &
+    '           [--list] [--test]                                           ', &
     '                                                                       ', &
     ' fpm build --help|--version                                            ', &
     '                                                                       ', &
@@ -864,6 +870,7 @@ contains
     '                           "gfortran" unless set by the environment    ', &
     '                           variable FPM_COMPILER.                      ', &
     ' --list       list candidates instead of building or running them      ', &
+    ' --test       build tests explicitly (otherwise only done if needed)   ', &
     ' --show-model show the model and exit (do not build)                   ', &
     ' --help       print this help and exit                                 ', &
     ' --version    print program version information and exit               ', &

--- a/src/fpm_model.f90
+++ b/src/fpm_model.f90
@@ -139,6 +139,9 @@ type :: fpm_model_t
     !> Project dependencies
     type(dependency_tree_t) :: deps
 
+    !> Whether tests should be added to the build list
+    logical :: include_tests = .true.
+
 end type fpm_model_t
 
 contains

--- a/src/fpm_targets.f90
+++ b/src/fpm_targets.f90
@@ -110,7 +110,7 @@ end type build_target_t
 contains
 
 !> High-level wrapper to generate build target information
-subroutine targets_from_sources(targets,model,error,include_tests)
+subroutine targets_from_sources(targets,model,error)
 
     !> The generated list of build targets
     type(build_target_ptr), intent(out), allocatable :: targets(:)
@@ -121,10 +121,7 @@ subroutine targets_from_sources(targets,model,error,include_tests)
     !> Error structure
     type(error_t), intent(out), allocatable :: error
 
-    !> Whether tests targets should be added
-    logical, intent(in) :: include_tests
-
-    call build_target_list(targets,model,include_tests=include_tests)
+    call build_target_list(targets,model)
 
     call resolve_module_dependencies(targets,model%external_modules,error)
     if (allocated(error)) return
@@ -153,16 +150,13 @@ end subroutine targets_from_sources
 !> is a library, then the executable target has an additional dependency on the library
 !> archive target.
 !>
-subroutine build_target_list(targets,model,include_tests)
+subroutine build_target_list(targets,model)
 
     !> The generated list of build targets
     type(build_target_ptr), intent(out), allocatable :: targets(:)
 
     !> The package model from which to construct the target list
     type(fpm_model_t), intent(inout), target :: model
-
-    !> Whether tests targets should be added
-    logical, intent(in) :: include_tests
 
     integer :: i, j, n_source
     character(:), allocatable :: xsuffix, exe_dir
@@ -197,7 +191,7 @@ subroutine build_target_list(targets,model,include_tests)
 
             do i=1,size(sources)
 
-                if (.not. include_tests) then
+                if (.not. model%include_tests) then
                     if (sources(i)%unit_scope == FPM_SCOPE_TEST) cycle
                 end if
 

--- a/test/fpm_test/test_module_dependencies.f90
+++ b/test/fpm_test/test_module_dependencies.f90
@@ -80,7 +80,7 @@ contains
                                     provides=[string_t('my_mod_2')], &
                                     uses=[string_t('my_mod_1')])
 
-        call targets_from_sources(targets,model,error)
+        call targets_from_sources(targets,model,error,include_tests=.true.)
         if (allocated(error)) return
 
         if (allocated(error)) then
@@ -151,7 +151,7 @@ contains
                                     scope=exe_scope, &
                                     uses=[string_t('my_mod_1')])
 
-        call targets_from_sources(targets,model,error)
+        call targets_from_sources(targets,model,error,include_tests=.true.)
         if (allocated(error)) return
 
         if (size(targets) /= 4) then
@@ -205,7 +205,7 @@ contains
                                     provides=[string_t('app_mod')], &
                                     uses=[string_t('app_mod')])
 
-        call targets_from_sources(targets,model,error)
+        call targets_from_sources(targets,model,error,include_tests=.true.)
         if (allocated(error)) return
 
         if (size(targets) /= 2) then
@@ -268,7 +268,7 @@ contains
                                     scope=exe_scope, &
                                     uses=[string_t('app_mod2')])
 
-        call targets_from_sources(targets,model,error)
+        call targets_from_sources(targets,model,error,include_tests=.true.)
         if (allocated(error)) return
 
         if (size(targets) /= 4) then
@@ -323,7 +323,7 @@ contains
                                     provides=[string_t('my_mod_2')], &
                                     uses=[string_t('my_mod_3')])
 
-        call targets_from_sources(targets,model,error)
+        call targets_from_sources(targets,model,error,include_tests=.true.)
 
     end subroutine test_missing_library_use
 
@@ -350,7 +350,7 @@ contains
                                     scope=FPM_SCOPE_APP, &
                                     uses=[string_t('my_mod_2')])
 
-        call targets_from_sources(targets,model,error)
+        call targets_from_sources(targets,model,error,include_tests=.true.)
 
     end subroutine test_missing_program_use
 
@@ -378,7 +378,7 @@ contains
                                     provides=[string_t('my_mod')], &
                                     uses=[string_t('app_mod')])
 
-        call targets_from_sources(targets,model,error)
+        call targets_from_sources(targets,model,error,include_tests=.true.)
 
     end subroutine test_invalid_library_use
 
@@ -405,7 +405,7 @@ contains
                                     scope=FPM_SCOPE_APP, &
                                     uses=[string_t('app_mod')])
 
-        call targets_from_sources(targets,model,error)
+        call targets_from_sources(targets,model,error,include_tests=.true.)
 
     end subroutine test_subdirectory_module_use
 
@@ -525,7 +525,7 @@ contains
                                     scope=FPM_SCOPE_APP, &
                                     uses=[string_t('app_mod')])
 
-        call targets_from_sources(targets,model,error)
+        call targets_from_sources(targets,model,error,include_tests=.true.)
 
     end subroutine test_invalid_subdirectory_module_use
 

--- a/test/fpm_test/test_module_dependencies.f90
+++ b/test/fpm_test/test_module_dependencies.f90
@@ -80,7 +80,7 @@ contains
                                     provides=[string_t('my_mod_2')], &
                                     uses=[string_t('my_mod_1')])
 
-        call targets_from_sources(targets,model,error,include_tests=.true.)
+        call targets_from_sources(targets,model,error)
         if (allocated(error)) return
 
         if (allocated(error)) then
@@ -151,7 +151,7 @@ contains
                                     scope=exe_scope, &
                                     uses=[string_t('my_mod_1')])
 
-        call targets_from_sources(targets,model,error,include_tests=.true.)
+        call targets_from_sources(targets,model,error)
         if (allocated(error)) return
 
         if (size(targets) /= 4) then
@@ -205,7 +205,7 @@ contains
                                     provides=[string_t('app_mod')], &
                                     uses=[string_t('app_mod')])
 
-        call targets_from_sources(targets,model,error,include_tests=.true.)
+        call targets_from_sources(targets,model,error)
         if (allocated(error)) return
 
         if (size(targets) /= 2) then
@@ -268,7 +268,7 @@ contains
                                     scope=exe_scope, &
                                     uses=[string_t('app_mod2')])
 
-        call targets_from_sources(targets,model,error,include_tests=.true.)
+        call targets_from_sources(targets,model,error)
         if (allocated(error)) return
 
         if (size(targets) /= 4) then
@@ -323,7 +323,7 @@ contains
                                     provides=[string_t('my_mod_2')], &
                                     uses=[string_t('my_mod_3')])
 
-        call targets_from_sources(targets,model,error,include_tests=.true.)
+        call targets_from_sources(targets,model,error)
 
     end subroutine test_missing_library_use
 
@@ -350,7 +350,7 @@ contains
                                     scope=FPM_SCOPE_APP, &
                                     uses=[string_t('my_mod_2')])
 
-        call targets_from_sources(targets,model,error,include_tests=.true.)
+        call targets_from_sources(targets,model,error)
 
     end subroutine test_missing_program_use
 
@@ -378,7 +378,7 @@ contains
                                     provides=[string_t('my_mod')], &
                                     uses=[string_t('app_mod')])
 
-        call targets_from_sources(targets,model,error,include_tests=.true.)
+        call targets_from_sources(targets,model,error)
 
     end subroutine test_invalid_library_use
 
@@ -405,7 +405,7 @@ contains
                                     scope=FPM_SCOPE_APP, &
                                     uses=[string_t('app_mod')])
 
-        call targets_from_sources(targets,model,error,include_tests=.true.)
+        call targets_from_sources(targets,model,error)
 
     end subroutine test_subdirectory_module_use
 
@@ -525,7 +525,7 @@ contains
                                     scope=FPM_SCOPE_APP, &
                                     uses=[string_t('app_mod')])
 
-        call targets_from_sources(targets,model,error,include_tests=.true.)
+        call targets_from_sources(targets,model,error)
 
     end subroutine test_invalid_subdirectory_module_use
 


### PR DESCRIPTION
Fixes #92

- Change default behavior of `build` to exclude tests (sources with FPM_SCOPE_TEST)
- Add command line option `--test` to force building tests
- Update help messages