### PR TITLE
List names without suffix (mainly for Windows).

### DIFF
--- a/src/fpm.f90
+++ b/src/fpm.f90
@@ -474,7 +474,7 @@ subroutine cmd_run(settings,test)
                 if (exe_source%unit_scope == run_scope) then
 
                     write(stderr,'(A)',advance=(merge("yes","no ",modulo(j,nCol)==0))) &
-                                        & [character(len=col_width) :: basename(exe_target%output_file)]
+                        & [character(len=col_width) :: basename(exe_target%output_file, suffix=.false.)]
                     j = j + 1
 
                 end if
@@ -491,7 +491,7 @@ subroutine cmd_run(settings,test)
         write(stderr,*) 'Matched names:'
         do i=1,size(executables)
             write(stderr,'(A)',advance=(merge("yes","no ",modulo(j,nCol)==0))) &
-             & [character(len=col_width) :: basename(executables(i)%s)]
+                & [character(len=col_width) :: basename(executables(i)%s, suffix=.false.)]
             j = j + 1
         enddo
         write(stderr,*)


### PR DESCRIPTION
- [x] List names without suffix (mainly **for Windows**, very small update): `suffix=.false.`

#### Description

In Windows, the previous `fpm` program running `fpm test --list` (same as `fpm run --example --list`) will have the suffix:

```sh
 Matched names:
cli-test.exe   fpm-test.exe   help-test.exe  new-test.exe
```

When I want to query and test `cli-test`, I hope it is `cli-test` instead of `cli-test.exe`, so that I can **just copy and paste**, such as:
`fpm test cli-test` instead of `fpm test cli-test.exe`.

#### Current effect

```sh
 Matched names:
cli-test       fpm-test       help-test      new-test  
```

Because this is an update for Windows, another way is to add a current system judgment here, is it worth it?