### PR TITLE
Add LFortran optimization flag to release profile

### DIFF
--- a/src/fpm_compiler.f90
+++ b/src/fpm_compiler.f90
@@ -168,6 +168,9 @@ character(*), parameter :: &
     flag_nag_debug = " -g -O0", &
     flag_nag_opt = " -O4", &
     flag_nag_backtrace = " -gline"
+    
+character(*), parameter :: &
+    flag_lfortran_opt = " --fast"
 
 contains
 
@@ -271,7 +274,9 @@ subroutine get_release_compile_flags(id, flags)
             flag_nag_pic
 
     case(id_lfortran)
-        flags = ""
+        flags = &
+            flag_lfortran_opt
+
     end select
 end subroutine get_release_compile_flags
 


### PR DESCRIPTION
Looks like I didn't add the `--fast` option for LFortran in the release profile. This patch adds optimization for LFortran.