### PR TITLE
Repair --list option and correct obsolete descriptions of the --list option

### DIFF
--- a/src/fpm.f90
+++ b/src/fpm.f90
@@ -287,7 +287,7 @@ else
     call build_package(targets,model)
 endif
 
-end subroutine
+end subroutine cmd_build
 
 subroutine cmd_run(settings,test)
     class(fpm_run_settings), intent(in) :: settings

--- a/src/fpm_command_line.f90
+++ b/src/fpm_command_line.f90
@@ -864,7 +864,7 @@ contains
     help_text_flag, &
     ' --runner CMD  A command to prefix the program execution paths with.   ', &
     '               see "fpm help runner" for further details.              ', &
-    ' --list     list pathname of candidates instead of running them. Note  ', &
+    ' --list     list basenames of candidates instead of running them. Note ', &
     '            out-of-date candidates will still be rebuilt before being  ', &
     '            listed.                                                    ', &
     ' -- ARGS    optional arguments to pass to the program(s). The same     ', &
@@ -876,7 +876,9 @@ contains
     ' fpm(1) - run or display project applications:                         ', &
     '                                                                       ', &
     '  fpm run        # run a target when only one exists or list targets   ', &
-    '  fpm run --list # list all targets, running nothing.                  ', &
+    '  fpm run --list # list basename of all targets, running nothing.      ', &
+    '  fpm run "demo*" --list # list target basenames starting with "demo*".', &
+    '  fpm run "psi*" --runner # list target pathnames starting with "psi*".', &
     '  fpm run --all  # run all targets, no matter how many there are.      ', &
     '                                                                       ', &
     '  # run default program built or to be built with the compiler command ', &
@@ -885,7 +887,7 @@ contains
     '  fpm run --compiler f90                                               ', &
     '                                                                       ', &
     '  # run example programs instead of the application programs.          ', &
-    '  fpm run --example ''*''                                                ', &
+    '  fpm run --example "*"                                                ', &
     '                                                                       ', &
     '  # run a specific program and pass arguments to the command           ', &
     '  fpm run myprog -- -x 10 -y 20 --title "my title line"                ', &
@@ -1110,7 +1112,8 @@ contains
     help_text_flag, &
     ' --runner CMD  A command to prefix the program execution paths with.   ', &
     '               see "fpm help runner" for further details.              ', &
-    ' --list     list candidates instead of building or running them        ', &
+    ' --list     list candidate basenames instead of running them. Note they', &
+    ' --list     will still be built if not currently up to date.           ', &
     ' -- ARGS    optional arguments to pass to the test program(s).         ', &
     '            The same arguments are passed to all test names            ', &
     '            specified.                                                 ', &

--- a/src/fpm_command_line.f90
+++ b/src/fpm_command_line.f90
@@ -121,26 +121,25 @@ character(len=:), allocatable :: val_runner, val_compiler, val_flag, val_cflag, 
 
 !   '12345678901234567890123456789012345678901234567890123456789012345678901234567890',&
 character(len=80), parameter :: help_text_compiler(*) = [character(len=80) :: &
-    ' --compiler NAME   Specify a compiler name. The default is "gfortran"',&
-    '                   unless set by the environment variable FPM_FC.',&
-    ' --c-compiler NAME Specify the C compiler name. Automatically determined by ',&
-    '                   default unless set by the environment variable FPM_CC.',&
-    ' --archiver NAME   Specify the archiver name. Automatically determined by ',&
-    '                   default unless set by the environment variable FPM_AR.'&
+    ' --compiler NAME    Specify a compiler name. The default is "gfortran"          ',&
+    '                    unless set by the environment variable FPM_FC.              ',&
+    ' --c-compiler NAME  Specify the C compiler name. Automatically determined by    ',&
+    '                    default unless set by the environment variable FPM_CC.      ',&
+    ' --archiver NAME    Specify the archiver name. Automatically determined by      ',&
+    '                    default unless set by the environment variable FPM_AR.      '&
     ]
 
+!   '12345678901234567890123456789012345678901234567890123456789012345678901234567890',&
 character(len=80), parameter :: help_text_flag(*) = [character(len=80) :: &
-    ' --flag  FFLAGS    selects compile arguments for the build, the default',&
-    '                   value is set by the FPM_FFLAGS environment variable.', &
-    '                   These are added to the profile options if --profile', &
-    '                   is specified, else these options override the defaults.',&
-    '                   Note object and .mod directory locations are always',&
-    '                   built in.',&
+    ' --flag  FFLAGS    selects compile arguments for the build, the default value is',&
+    '                   set by the FPM_FFLAGS environment variable. These are added  ',&
+    '                   to the profile options if --profile is specified, else these ',&
+    '                   these options override the defaults. Note object and .mod    ',&
+    '                   directory locations are always built in.                     ',&
     ' --c-flag CFLAGS   selects compile arguments specific for C source in the build.',&
-    '                   The default value is set by the FPM_CFLAGS environment',&
-    '                   variable.',&
-    ' --link-flag LDFLAGS',&
-    '                   select arguments passed to the linker for the build. The',&
+    '                   The default value is set by the FPM_CFLAGS environment       ',&
+    '                   variable.                                                    ',&
+    ' --link-flag LDFLAGS  select arguments passed to the linker for the build. The  ',&
     '                   default value is set by the FPM_LDFLAGS environment variable.'&
     ]
 
@@ -705,15 +704,15 @@ contains
     'SUBCOMMANDS                                                            ', &
     '  Valid fpm(1) subcommands are:                                        ', &
     '                                                                       ', &
-    '  + build Compile the packages into the "build/" directory.            ', &
-    '  + new   Create a new Fortran package directory with sample files.    ', &
-    '  + update  Update the project dependencies.                           ', &
-    '  + run   Run the local package binaries. defaults to all binaries for ', &
-    '          that release.                                                ', &
-    '  + test  Run the tests.                                               ', &
-    '  + help  Alternate to the --help switch for displaying help text.     ', &
-    '  + list  Display brief descriptions of all subcommands.               ', &
-    '  + install Install project                                            ', &
+    '  + build    Compile the packages into the "build/" directory.         ', &
+    '  + new      Create a new Fortran package directory with sample files. ', &
+    '  + update   Update the project dependencies.                          ', &
+    '  + run      Run the local package binaries. defaults to all binaries  ', &
+    '             for that release.                                         ', &
+    '  + test     Run the tests.                                            ', &
+    '  + help     Alternate to the --help switch for displaying help text.  ', &
+    '  + list     Display brief descriptions of all subcommands.            ', &
+    '  + install  Install project                                           ', &
     '                                                                       ', &
     '  Their syntax is                                                      ', &
     '                                                                                ', &
@@ -758,7 +757,7 @@ contains
     '   directory.                                                          ', &
     '                                                                       ', &
     '   If "file" does not exist or cannot be read, then an error occurs and', &
-    '   the program stops.  Each line of the file is prefixed with "options"', &
+    '   the program stops. Each line of the file is prefixed with "options" ', &
     '   and interpreted as a separate argument. The file itself may not     ', &
     '   contain @file arguments. That is, it is not processed recursively.  ', &
     '                                                                       ', &
@@ -932,11 +931,11 @@ contains
     '                   default. ',&
     help_text_compiler, &
     help_text_flag, &
-    ' --list       list candidates instead of building or running them      ', &
-    ' --tests      build all tests (otherwise only if needed)               ', &
-    ' --show-model show the model and exit (do not build)                   ', &
-    ' --help       print this help and exit                                 ', &
-    ' --version    print program version information and exit               ', &
+    ' --list        list candidates instead of building or running them     ', &
+    ' --tests       build all tests (otherwise only if needed)              ', &
+    ' --show-model  show the model and exit (do not build)                  ', &
+    ' --help        print this help and exit                                ', &
+    ' --version     print program version information and exit              ', &
     '                                                                       ', &
     help_text_environment, &
     '                                                                       ', &

--- a/src/fpm_filesystem.F90
+++ b/src/fpm_filesystem.F90
@@ -94,21 +94,18 @@ function basename(path,suffix) result (base)
         with_suffix = suffix
     end if
 
-    if (with_suffix) then
-        call split(path,file_parts,delimiters='\/')
-        if(size(file_parts).gt.0)then
-           base = trim(file_parts(size(file_parts)))
-        else
-           base = ''
-        endif
+    call split(path,file_parts,delimiters='\/')
+    if(size(file_parts).gt.0)then
+       base = trim(file_parts(size(file_parts)))
     else
-        call split(path,file_parts,delimiters='\/.')
+       base = ''
+    endif
+    if(.not.with_suffix)then
+        call split(base,file_parts,delimiters='.')
         if(size(file_parts).ge.2)then
            base = trim(file_parts(size(file_parts)-1))
-        else
-           base = ''
         endif
-    end if
+    endif
 
 end function basename
 


### PR DESCRIPTION
Fixes #606.

--list now has non-intuitive differences between build --list and [run,test] --list and install --list, as it originally showed the full pathname of targets on all commands.  Not sure if it should be renamed on [run,test]  to --show; or if their should be a --path option specifically for the long names;  but on [run,test] you can still get full pathnames via --runner so no functionality is lost; but 
I do think it is less intuitive what --list does not, as it varies somewhat become subcommands.https://urbanjost.github.io/fpm-tools/manual.html

Did not add a new test for checking the --list option, but the need for this patch would probably be avoidable if we had one.  Will try to add one in a separate PR, as a good number of features are not tested and we probably could use a separate project to get the tests up to par  (especially since part of the design of fpm is specifically to encourage the development of tests :>).

To review the revised help text as HTML see this regenerated version of ['fpm version 0.4.0 manual']( https://urbanjost.github.io/fpm-tools/manual.html)
