### PR TITLE
Fix modules listing (for install)

### DIFF
--- a/src/fpm_targets.f90
+++ b/src/fpm_targets.f90
@@ -690,7 +690,7 @@ subroutine filter_modules(targets, list)
             if (n + size(target%source%modules_provided) >= size(list)) call resize(list)
             do j = 1, size(target%source%modules_provided)
                 n = n + 1
-                list(n)%s = join_path(target%output_dir, "fpm", &
+                list(n)%s = join_path(target%output_dir, &
                     target%source%modules_provided(j)%s)
             end do
         end associate

--- a/src/fpm_targets.f90
+++ b/src/fpm_targets.f90
@@ -687,6 +687,7 @@ subroutine filter_modules(targets, list)
     do i = 1, size(targets)
         associate(target => targets(i)%ptr)
             if (.not.allocated(target%source)) cycle
+            if (target%source%unit_type == FPM_UNIT_SUBMODULE) cycle
             if (n + size(target%source%modules_provided) >= size(list)) call resize(list)
             do j = 1, size(target%source%modules_provided)
                 n = n + 1


### PR DESCRIPTION
Quick fix so that [`setup-stdlib`](https://github.com/LKedward/quickstart-fortran/blob/main/utils/setup-stdlib.bat) from quickstart-fortran works with the latest *fpm*.

- Remove spurious "fpm" from the module path
- Skip submodules when collecting modules for install

