### PR TITLE
Add: critical section to mkdir in backend

### DIFF
--- a/src/fpm_backend.f90
+++ b/src/fpm_backend.f90
@@ -268,9 +268,11 @@ subroutine build_target(model,target,stat)
 
     integer :: fh
 
+    !$omp critical
     if (.not.exists(dirname(target%output_file))) then
         call mkdir(dirname(target%output_file))
     end if
+    !$omp end critical
 
     select case(target%target_type)
 


### PR DESCRIPTION
Minor fix to get parallel builds working on Windows where `mkdir` fails if the directory already exists.