### PR TITLE
Bump version to 0.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Binaries for the latest stable release are available [to download](https://githu
 
 __Note:__ On Linux and MacOS, you will need to enable executable permission before you can use the binary.
 
-_e.g._ `$ chmod u+x fpm-0.4.0-linux-x86_64`
+_e.g._ `$ chmod u+x fpm-0.5.0-linux-x86_64`
 
 The binaries at the [current tag](https://github.com/fortran-lang/fpm/releases/tag/current) are updated automatically to always provide the current git version from the default branch.
 

--- a/fpm.toml
+++ b/fpm.toml
@@ -1,5 +1,5 @@
 name = "fpm"
-version = "0.4.0"
+version = "0.5.0"
 license = "MIT"
 author = "fpm maintainers"
 maintainer = ""

--- a/install.sh
+++ b/install.sh
@@ -42,7 +42,7 @@ done
 
 set -u # error on use of undefined variable
 
-SOURCE_URL="https://github.com/fortran-lang/fpm/releases/download/v0.4.0/fpm-0.4.0.F90"
+SOURCE_URL="https://github.com/fortran-lang/fpm/releases/download/v0.5.0/fpm-0.5.0.F90"
 BOOTSTRAP_DIR="build/bootstrap"
 if [ -z ${FC+x} ]; then
     FC="gfortran"

--- a/src/fpm_command_line.f90
+++ b/src/fpm_command_line.f90
@@ -194,7 +194,7 @@ contains
             case default     ; os_type =  "OS Type:     UNKNOWN"
         end select
         version_text = [character(len=80) :: &
-         &  'Version:     0.4.0, alpha',                               &
+         &  'Version:     0.5.0, alpha',                               &
          &  'Program:     fpm(1)',                                     &
          &  'Description: A Fortran package manager and build system', &
          &  'Home Page:   https://github.com/fortran-lang/fpm',        &


### PR DESCRIPTION
Test release at https://github.com/awvwgk/fortran-package-manager/releases/tag/v0.5.0

Tentative release notes:

```markdown
Alpha release update for the Fortran package manager (fpm).

**Changes**

- tests are only build for fpm test and not by default anymore (https://github.com/fortran-lang/fpm/pull/572)

- environment variables for setting Fortran and C compiler changed (https://github.com/fortran-lang/fpm/pull/549, https://github.com/fortran-lang/fpm/pull/584)

- add LFortran optimization flag to release profile (https://github.com/fortran-lang/fpm/pull/597) 


**New features**

- command line arguments for linker, archiver and C-compiler added (https://github.com/fortran-lang/fpm/pull/549)


**Fixes**

- tabs are correctly expanded in source file scanning (https://github.com/fortran-lang/fpm/pull/521)

- installer script will use fpm update to avoid stale dependencies (https://github.com/fortran-lang/fpm/pull/557)

- use multiple build output directories depending on link line options (https://github.com/fortran-lang/fpm/pull/575)

- update truncated help text (https://github.com/fortran-lang/fpm/pull/578)

- fix directory removal in fpm new tests (https://github.com/fortran-lang/fpm/pull/579)

- use MSVS like commands for Intel compilers on Windows (https://github.com/fortran-lang/fpm/pull/590)

- add critical section to mkdir in backend (https://github.com/fortran-lang/fpm/pull/613)

- fix modules listing (for install) (https://github.com/fortran-lang/fpm/pull/612)

- repair --list option and correct obsolete descriptions of the --list option (https://github.com/fortran-lang/fpm/pull/607)

- fix incorrect Intel release flag on Windows (https://github.com/fortran-lang/fpm/pull/602)

- list names without suffix for Windows (https://github.com/fortran-lang/fpm/pull/595)


**Repository updates**

- add files and workflow to make installer on release (https://github.com/fortran-lang/fpm/pull/616)

- issue templates added to guide reporting of bugs, package issues, feature requests and specification proposals (https://github.com/fortran-lang/fpm/pull/558)

- default branch renamed to *main* (https://github.com/fortran-lang/fpm/pull/565)

- update documentation on distributions supporting fpm, like spack and MSYS2 (https://github.com/fortran-lang/fpm/pull/562)

- new workflow to automatically generate single source fpm versions (https://github.com/fortran-lang/fpm/pull/563)

- continuous delivery of current fpm git source implemented (https://github.com/fortran-lang/fpm/pull/564, https://github.com/fortran-lang/fpm/pull/569)

- update of bootstrapping instructions (https://github.com/fortran-lang/fpm/pull/587)

- update README.md compiler, archiver, & link flags (https://github.com/fortran-lang/fpm/pull/598)
```