### PR TITLE
make canon_path more canonical

### DIFF
--- a/src/fpm_command_line.f90
+++ b/src/fpm_command_line.f90
@@ -317,9 +317,13 @@ contains
             & help_new, version_text)
             select case(size(unnamed))
             case(1)
-                write(stderr,'(*(7x,g0,/))') &
-                & '<USAGE> fpm new NAME [[--lib|--src] [--app] [--test] [--example]]|[--full|--bare] [--backfill]'
-                call fpm_stop(1,'directory name required')
+                if(lget('backfill'))then ! if no directory name but --backfill assume current directory
+                    name='.'
+                else
+                    write(stderr,'(*(7x,g0,/))') &
+                    & '<USAGE> fpm new NAME [[--lib|--src] [--app] [--test] [--example]]|[--full|--bare] [--backfill]'
+                    call fpm_stop(1,'directory name required')
+                endif
             case(2)
                 name=trim(unnamed(2))
             case default

--- a/test/fpm_test/test_filesystem.f90
+++ b/test/fpm_test/test_filesystem.f90
@@ -1,6 +1,8 @@
 module test_filesystem
+
     use testsuite, only : new_unittest, unittest_t, error_t, test_failed
     use fpm_filesystem, only: canon_path
+    use fpm_os,    only : get_current_directory
     implicit none
     private
 
@@ -26,17 +28,21 @@ contains
 
         !> Error handling
         type(error_t), allocatable, intent(out) :: error
+        character(len=:),allocatable :: cwd
+
+        call get_current_directory(cwd, error)
+        if (allocated(error)) return
 
         call check_string(error, &
             & canon_path("git/project/src/origin"), "git/project/src/origin")
         if (allocated(error)) return
 
         call check_string(error,  &
-            & canon_path("./project/src/origin"), "project/src/origin")
+            & canon_path("./project/src/origin"), cwd//"/project/src/origin")
         if (allocated(error)) return
 
         call check_string(error, &
-            & canon_path("./project/src///origin/"), "project/src/origin")
+            & canon_path("./project/src///origin/"), cwd//"/project/src/origin")
         if (allocated(error)) return
 
         call check_string(error, &
@@ -72,7 +78,7 @@ contains
         if (allocated(error)) return
 
         call check_string(error, &
-            & canon_path("././././././/////a/b/.///././////.///c/../../../"), ".")
+            & canon_path("././././././/////a/b/.///././////.///c/../../../"), cwd)
         if (allocated(error)) return
 
         call check_string(error, &


### PR DESCRIPTION
canon_path is intended to be replaced with an equivalent of realpath(3c), and since there is already a procedure to get the current directory, a step towards canon_path returning what a realpath(3c) would is to replace a leading "." with the current directory.

This also allows the `new` subcommand to use the pathname "."  when the --backfill option is present. It has been a non-intuitive feature of fpm that a backfill requires a full pathname, as in
```bash
fpm new `pwd` --backfill
````
instead of
```bash
fpm new --backfill
fpm new . --backfill
```
