### PR TITLE
make canon_path more canonical

### DIFF
--- a/src/fpm_command_line.f90
+++ b/src/fpm_command_line.f90
@@ -317,9 +317,13 @@ contains
             & help_new, version_text)
             select case(size(unnamed))
             case(1)
-                write(stderr,'(*(7x,g0,/))') &
-                & '<USAGE> fpm new NAME [[--lib|--src] [--app] [--test] [--example]]|[--full|--bare] [--backfill]'
-                call fpm_stop(1,'directory name required')
+                if(lget('backfill'))then ! if no directory name but --backfill assume current directory
+                    name='.'
+                else
+                    write(stderr,'(*(7x,g0,/))') &
+                    & '<USAGE> fpm new NAME [[--lib|--src] [--app] [--test] [--example]]|[--full|--bare] [--backfill]'
+                    call fpm_stop(1,'directory name required')
+                endif
             case(2)
                 name=trim(unnamed(2))
             case default

--- a/test/fpm_test/test_filesystem.f90
+++ b/test/fpm_test/test_filesystem.f90
@@ -1,6 +1,8 @@
 module test_filesystem
+
     use testsuite, only : new_unittest, unittest_t, error_t, test_failed
     use fpm_filesystem, only: canon_path
+    use fpm_os,    only : get_current_directory
     implicit none
     private
 
@@ -26,17 +28,21 @@ contains
 
         !> Error handling
         type(error_t), allocatable, intent(out) :: error
+        character(len=:),allocatable :: cwd
+
+        call get_current_directory(cwd, error)
+        if (allocated(error)) return
 
         call check_string(error, &
             & canon_path("git/project/src/origin"), "git/project/src/origin")
         if (allocated(error)) return
 
         call check_string(error,  &
-            & canon_path("./project/src/origin"), "project/src/origin")
+            & canon_path("./project/src/origin"), cwd//"/project/src/origin")
         if (allocated(error)) return
 
         call check_string(error, &
-            & canon_path("./project/src///origin/"), "project/src/origin")
+            & canon_path("./project/src///origin/"), cwd//"/project/src/origin")
         if (allocated(error)) return
 
         call check_string(error, &
@@ -72,7 +78,7 @@ contains
         if (allocated(error)) return
 
         call check_string(error, &
-            & canon_path("././././././/////a/b/.///././////.///c/../../../"), ".")
+            & canon_path("././././././/////a/b/.///././////.///c/../../../"), cwd)
         if (allocated(error)) return
 
         call check_string(error, &


### PR DESCRIPTION
making canon_path more like realpath exposed uses of canon_path not compatible with a realpath call; so treating . or a missing name as a special case directly in the new subcommand.