### PR TITLE
Better extraction of the Fortran compiler from the MPI wrapper

### DIFF
--- a/src/fpm_compiler.f90
+++ b/src/fpm_compiler.f90
@@ -484,10 +484,8 @@ function get_compiler_id(compiler) result(id)
 
             ! If we get a command from the wrapper, we will try to identify it
             call split(full_command, full_command_parts, delimiters=' ')
-            if(size(full_command_parts) >= 0)then
+            if(size(full_command_parts) > 0)then
                command = trim(full_command_parts(1))
-            else
-               command = ''
             endif
             if (allocated(command)) then
                 id = get_id(command)


### PR DESCRIPTION
This PR adds a very minor change.

First, it checks the MPI wrapper flag `-show` instead of `-show-me:command`, since the latter is absent in libraries like MPICH, while `-show` seems ubiquitous (at least in MPICH, OpenMPI, and Spectrum MPI have it).

Second, it strips the output string into several parts and fetches the first (command) part, to handle command outputs like:
```bash
$ mpifort --show
/usr/bin/gfortran -I/usr/include -pthread -I/usr/lib/openmpi -L/usr/lib/openmpi -Wl,-rpath -Wl,/usr/lib/openmpi -Wl,--enable-new-dtags -lmpi_usempif08 -lmpi_usempi_ignore_tkr -lmpi_mpifh -lmpi`;
```
even with the previous flag, the current implementation would not detect the compiler correctly in some instances like the following output I got from Spectrum MPI.
```bash
$ mpif90 -showme:command
gfortran -I/long_path_name/spectrum_mpi/10.4.0/binary/lib/fortsupport_gfortran
```

But perhaps at a later stage, one could do better as suggested in #354.

This seems like a very minor fix, so I did not open an issue as suggested in the contributing guidelines. However, if it is best, I can close this and open an issue first.