### PR TITLE
Update module output directory command for flang-new/f18

### DIFF
--- a/src/fpm_compiler.f90
+++ b/src/fpm_compiler.f90
@@ -61,6 +61,8 @@ enum, bind(C)
         id_nvhpc, &
         id_nag, &
         id_flang, &
+        id_flang_new, &
+        id_f18, &
         id_ibmxl, &
         id_cray, &
         id_lahey, &
@@ -380,7 +382,8 @@ function get_include_flag(self, path) result(flags)
     case default
         flags = "-I "//path
 
-    case(id_caf, id_gcc, id_f95, id_cray, id_nvhpc, id_pgi, id_flang, &
+    case(id_caf, id_gcc, id_f95, id_cray, id_nvhpc, id_pgi, &
+        & id_flang, id_flang_new, id_f18, &
         & id_intel_classic_nix, id_intel_classic_mac, &
         & id_intel_llvm_nix, id_lahey, id_nag, id_ibmxl, &
         & id_lfortran)
@@ -406,6 +409,9 @@ function get_module_flag(self, path) result(flags)
 
     case(id_nvhpc, id_pgi, id_flang)
         flags = "-module "//path
+
+    case(id_flang_new, id_f18)
+        flags = "-module-dir "//path
 
     case(id_intel_classic_nix, id_intel_classic_mac, &
         & id_intel_llvm_nix)
@@ -443,7 +449,7 @@ subroutine get_default_c_compiler(f_compiler, c_compiler)
     case(id_intel_llvm_nix,id_intel_llvm_windows)
         c_compiler = 'icx'
 
-    case(id_flang)
+    case(id_flang, id_flang_new, id_f18)
         c_compiler='clang'
 
     case(id_ibmxl)
@@ -555,6 +561,16 @@ function get_id(compiler) result(id)
 
     if (check_compiler(compiler, "nagfor")) then
         id = id_nag
+        return
+    end if
+
+    if (check_compiler(compiler, "flang-new")) then
+        id = id_flang_new
+        return
+    end if
+
+    if (check_compiler(compiler, "f18")) then
+        id = id_f18
         return
     end if
 


### PR DESCRIPTION
Currently the new LLVM flang driver is mistaken for the classic flang driver and therefore it fails with

```
❯ fpm build --compiler flang-new -C example_packages/hello_fpm
fpm: Entering directory '/home/awvwgk/projects/src/git/fortran-package-manager/example_packages/hello_fpm'
 + mkdir -p build/dependencies
 + mkdir -p build/flang-new_00000000811C9DC5/hello_fpm
 + flang-new -c ./../hello_complex/source/subdir/constants.f90  -module build/flang-new_00000000811C9DC5/hello_fpm -I build/flang-new_00000000811C9DC5/hello_fpm  -o build/flang-new_00000000811C9DC5/hello_fpm/.._hello_complex_source_subdir_constants.f90.o
```

With this patch we can run the `flang-new` driver and get the expected error due to missing code generation:

```
❯ ./fpm-flang build --compiler flang-new -C example_packages/hello_fpm
fpm: Entering directory '/home/awvwgk/projects/src/git/fortran-package-manager/example_packages/hello_fpm'
 + mkdir -p build/dependencies
 + mkdir -p build/flang-new_00000000811C9DC5
 + mkdir -p build/flang-new_00000000811C9DC5/hello_fpm/
 + flang-new -c ./../hello_complex/source/subdir/constants.f90  -module-dir build/flang-new_00000000811C9DC5 -Ibuild/flang-new_00000000811C9DC5 -o build/flang-new_00000000811C9DC5/hello_fpm/.._hello_complex_source_subdir_constants.f90.o
error: code-generation is not available yet
```

The `f18` driver is less picky and takes `-J`, `-module` and `-module-dir` to specify the module output directory, I went with the latter since this is apparently in line with `flang-new`.

---

Note that there is `flang` in LLVM flang which is not the classic flang compiler, but presumably an internal component for the `flang-new` / `f18` drivers (or maybe the other way round?). We will currently detect it as classic flang and fail with

```
❯ ./fpm-flang build --compiler flang -C example_packages/hello_fpm
fpm: Entering directory '/home/awvwgk/projects/src/git/fortran-package-manager/example_packages/hello_fpm'
 + mkdir -p build/flang_00000000811C9DC5
 + mkdir -p build/flang_00000000811C9DC5/hello_fpm/
 + flang -c ../hello_complex/source/subdir/constants.f90  -module build/flang_00000000811C9DC5 -Ibuild/flang_00000000811C9DC5 -o build/flang_00000000811C9DC5/hello_fpm/.._hello_complex_source_subdir_constants.f90.o
error: unknown argument: '-module build/flang_00000000811C9DC5'
flang: in /home/awvwgk/projects/src/git/fortran-package-manager/example_packages/hello_fpm, flang-new failed with exit status 1: /usr/bin/flang-new -fc1 -Ibuild/flang_00000000811C9DC5 -module-suffix .f18.mod -fdebug-unparse -fno-analyzed-objects-for-unparse -module-dir build/flang_00000000811C9DC5 -c ../hello_complex/source/subdir/constants.f90 -module build/flang_00000000811C9DC5 -Ibuild/flang_00000000811C9DC5 -o build/flang_00000000811C9DC5/hello_fpm/.._hello_complex_source_subdir_constants.f90.o
```

But I can't figure out how I'm supposed to correctly use it anyway.