### PR TITLE
Fix for backtrace error when file not found in: src/fpm_source_parsing.f90

### DIFF
--- a/src/fpm_source_parsing.f90
+++ b/src/fpm_source_parsing.f90
@@ -83,11 +83,11 @@ function parse_f_source(f_filename,error) result(f_source)
     character(:), allocatable :: temp_string, mod_name, string_parts(:)
 
     ! check the f_filename exists before attempting to process 
-	inquire(file=f_filename, exist=exists)
-	if (.not. exists) then
-		call file_not_found_error(error, f_filename)
-		return
-	end if
+    inquire(file=f_filename, exist=exists)
+    if (.not. exists) then
+        call file_not_found_error(error, f_filename)
+        return
+    end if
 
     f_source%file_name = f_filename
 

--- a/src/fpm_source_parsing.f90
+++ b/src/fpm_source_parsing.f90
@@ -22,7 +22,7 @@ use fpm_model, only: srcfile_t, &
                     FPM_UNIT_SUBMODULE, FPM_UNIT_SUBPROGRAM, &
                     FPM_UNIT_CSOURCE, FPM_UNIT_CHEADER, FPM_SCOPE_UNKNOWN, &
                     FPM_SCOPE_LIB, FPM_SCOPE_DEP, FPM_SCOPE_APP, FPM_SCOPE_TEST
-use fpm_filesystem, only: read_lines, read_lines_expanded
+use fpm_filesystem, only: read_lines, read_lines_expanded, exists
 implicit none
 
 private
@@ -77,14 +77,11 @@ function parse_f_source(f_filename,error) result(f_source)
     type(error_t), allocatable, intent(out) :: error
 
     integer :: stat
-    logical :: exists
     integer :: fh, n_use, n_include, n_mod, i, j, ic, pass
     type(string_t), allocatable :: file_lines(:), file_lines_lower(:)
     character(:), allocatable :: temp_string, mod_name, string_parts(:)
 
-    ! check the f_filename exists before attempting to process 
-    inquire(file=f_filename, exist=exists)
-    if (.not. exists) then
+    if (.not. exists(f_filename)) then
         call file_not_found_error(error, f_filename)
         return
     end if

--- a/src/fpm_source_parsing.f90
+++ b/src/fpm_source_parsing.f90
@@ -15,7 +15,7 @@
 !> - `[[parse_c_source]]`
 !>
 module fpm_source_parsing
-use fpm_error, only: error_t, file_parse_error, fatal_error
+use fpm_error, only: error_t, file_parse_error, fatal_error, file_not_found_error
 use fpm_strings, only: string_t, string_cat, len_trim, split, lower, str_ends_with, fnv_1a, is_fortran_name
 use fpm_model, only: srcfile_t, &
                     FPM_UNIT_UNKNOWN, FPM_UNIT_PROGRAM, FPM_UNIT_MODULE, &
@@ -77,9 +77,17 @@ function parse_f_source(f_filename,error) result(f_source)
     type(error_t), allocatable, intent(out) :: error
 
     integer :: stat
+    logical :: exists
     integer :: fh, n_use, n_include, n_mod, i, j, ic, pass
     type(string_t), allocatable :: file_lines(:), file_lines_lower(:)
     character(:), allocatable :: temp_string, mod_name, string_parts(:)
+
+    ! check the f_filename exists before attempting to process 
+	inquire(file=f_filename, exist=exists)
+	if (.not. exists) then
+		call file_not_found_error(error, f_filename)
+		return
+	end if
 
     f_source%file_name = f_filename
 


### PR DESCRIPTION
When using `fpm run` and a source file stated in a projects `fpm.toml` is missing a backtrace would be generated - example below:

```console
% fpm run
 + mkdir -p build/dependencies
At line 86 of file ./src/fpm_source_parsing.f90
Fortran runtime error: Cannot open file 'app/aoc_day02_p2.f90': No such file or directory

Error termination. Backtrace:
#0  0x104ea9147
#1  0x104ea9dbf
#2  0x104eaa743
#3  0x104f6f553
#4  0x104f6f787
#5  0x104a85e0f
#6  0x104a87db7
#7  0x104a8b837
#8  0x104a6311b
#9  0x104a64af3
#10  0x104a612a3
#11  0x104adbf2f
```

This patch checks for the files existence, before any further parsing is attempted. 

After applying this proposed fix, when a file is missing (as in the example above) then an error is shown instead of the backtrace:

```console 
% fpm run
<ERROR>*cmd_run*:model error:'app/aoc_day02_p2.f90' could not be found, check if the file exists
STOP 1
```

Uses the *fpm* subroutine `file_not_found_error` which I hope is the correct action to perform on the error.
