### PR TITLE
Fix issue with backend pretty output

### DIFF
--- a/src/fpm_backend_console.f90
+++ b/src/fpm_backend_console.f90
@@ -101,7 +101,7 @@ subroutine console_update_line(console,line_no,str)
     ! Step back to line
     write(stdout,'(A)',advance="no") repeat(LINE_UP,n)//LINE_RESET
 
-    write(stdout,'(A)') str
+    write(stdout,'(A)',advance="no") str
 
     ! Step forward to end
     write(stdout,'(A)',advance="no") repeat(LINE_DOWN,n)//LINE_RESET


### PR DESCRIPTION
Not sure if anyone else has encountered this issue where 'pretty' output is messed up if the console is not scrolled to the bottom.
This PR fixes that.

![image](https://user-images.githubusercontent.com/26024234/158204718-6a5a9509-8c95-45bd-a82b-f12a3b4044f8.png)
