### PR TITLE
fix: function for getting executable path

### DIFF
--- a/test/new_test/new_test.f90
+++ b/test/new_test/new_test.f90
@@ -75,11 +75,7 @@ character(len=:),allocatable  :: rm_command
    do i=1,size(cmds)
       message=''
       write(*,*)path//' '//cmds(i)
-      if (get_os_type() == OS_WINDOWS) then
-         call execute_command_line(path//'fpm.exe'//' '//cmds(i),exitstat=estat,cmdstat=cstat,cmdmsg=message)
-      else
-         call execute_command_line(path//'fpm'//' '//cmds(i),exitstat=estat,cmdstat=cstat,cmdmsg=message)
-      end if
+      call execute_command_line(path//' '//cmds(i),exitstat=estat,cmdstat=cstat,cmdmsg=message)
       write(*,'(*(g0))')'CMD=',trim(cmds(i)),' EXITSTAT=',estat,' CMDSTAT=',cstat,' MESSAGE=',trim(message)
    enddo
 
@@ -178,9 +174,12 @@ contains
     allocate(character(len=length) :: prog)
     call get_command_argument(0, prog)
     path = dirname(prog)
-    prog = join_path(path, "..", "app", "")
+    prog = join_path(path, "..", "app", "fpm")
     if (.not.exists(prog)) then
-       prog = join_path(path, "..", "..", "app", "")
+       prog = join_path(path, "..", "..", "app", "fpm")
+    end if
+    if (get_os_type() == OS_WINDOWS) then
+      prog = prog // '.exe'
     end if
   end function
 end program new_test

--- a/test/new_test/new_test.f90
+++ b/test/new_test/new_test.f90
@@ -75,7 +75,11 @@ character(len=:),allocatable  :: rm_command
    do i=1,size(cmds)
       message=''
       write(*,*)path//' '//cmds(i)
-      call execute_command_line(path//' '//cmds(i),exitstat=estat,cmdstat=cstat,cmdmsg=message)
+      if (get_os_type() == OS_WINDOWS) then
+         call execute_command_line(path//'fpm.exe'//' '//cmds(i),exitstat=estat,cmdstat=cstat,cmdmsg=message)
+      else
+         call execute_command_line(path//'fpm'//' '//cmds(i),exitstat=estat,cmdstat=cstat,cmdmsg=message)
+      end if
       write(*,'(*(g0))')'CMD=',trim(cmds(i)),' EXITSTAT=',estat,' CMDSTAT=',cstat,' MESSAGE=',trim(message)
    enddo
 
@@ -174,17 +178,9 @@ contains
     allocate(character(len=length) :: prog)
     call get_command_argument(0, prog)
     path = dirname(prog)
-    if (get_os_type() == OS_WINDOWS) then
-      prog = join_path(path, "..", "app", "fpm.exe")
-      if (.not.exists(prog)) then
-        prog = join_path(path, "..", "..", "app", "fpm.exe")
-      end if
-    else
-      prog = join_path(path, "..", "app", "fpm")
-      if (.not.exists(prog)) then
-        prog = join_path(path, "..", "..", "app", "fpm")
-      end if
+    prog = join_path(path, "..", "app", "")
+    if (.not.exists(prog)) then
+       prog = join_path(path, "..", "..", "app", "")
     end if
-
   end function
 end program new_test


### PR DESCRIPTION
In this PR, the function `get_command_path`, earlier used to give us the` fpm.exe` or `fpm` based on the Operating System. But, that should be supplied to the `execute_command_line`  instead of getting it from the function.  This also makes the function more cleaner and does not need to deal with the checks for identifying the Operating System.