### PR TITLE
Small fix for fpm_model

### DIFF
--- a/src/fpm_model.f90
+++ b/src/fpm_model.f90
@@ -200,6 +200,13 @@ function info_srcfile(source) result(s)
     case default
         s = s // "INVALID"
     end select
+    !    type(string_t), allocatable :: modules_provided(:)
+    s = s // ", modules_provided=["
+    do i = 1, size(source%modules_provided)
+        s = s // '"' // source%modules_provided(i)%s // '"'
+        if (i < size(source%modules_provided)) s = s // ", "
+    end do
+    s = s // "]"
     !    integer :: unit_type = FPM_UNIT_UNKNOWN
     s = s // ", unit_type="
     select case(source%unit_type)
@@ -220,42 +227,27 @@ function info_srcfile(source) result(s)
     case default
         s = s // "INVALID"
     end select
-
-    select case (source%unit_type)
-    case (FPM_UNIT_PROGRAM, FPM_UNIT_MODULE, FPM_UNIT_SUBMODULE, &
-         FPM_UNIT_SUBPROGRAM, FPM_UNIT_CSOURCE, FPM_UNIT_CHEADER)
-        !    type(string_t), allocatable :: modules_provided(:)
-        s = s // ", modules_provided=["
-        do i = 1, size(source%modules_provided)
-            s = s // '"' // source%modules_provided(i)%s // '"'
-            if (i < size(source%modules_provided)) s = s // ", "
-        end do
-        s = s // "]"
-        
-        !    type(string_t), allocatable :: modules_used(:)
-        s = s // ", modules_used=["
-        do i = 1, size(source%modules_used)
-            s = s // '"' // source%modules_used(i)%s // '"'
-            if (i < size(source%modules_used)) s = s // ", "
-        end do
-        s = s // "]"
-        !    type(string_t), allocatable :: include_dependencies(:)
-        s = s // ", include_dependencies=["
-        do i = 1, size(source%include_dependencies)
-            s = s // '"' // source%include_dependencies(i)%s // '"'
-            if (i < size(source%include_dependencies)) s = s // ", "
-        end do
-        s = s // "]"
-        !    type(string_t), allocatable :: link_libraries(:)
-        s = s // ", link_libraries=["
-        do i = 1, size(source%link_libraries)
-            s = s // '"' // source%link_libraries(i)%s // '"'
-            if (i < size(source%link_libraries)) s = s // ", "
-        end do
-        s = s // "]"
-    case default
-        ! pass
-    end select
+    !    type(string_t), allocatable :: modules_used(:)
+    s = s // ", modules_used=["
+    do i = 1, size(source%modules_used)
+        s = s // '"' // source%modules_used(i)%s // '"'
+        if (i < size(source%modules_used)) s = s // ", "
+    end do
+    s = s // "]"
+    !    type(string_t), allocatable :: include_dependencies(:)
+    s = s // ", include_dependencies=["
+    do i = 1, size(source%include_dependencies)
+        s = s // '"' // source%include_dependencies(i)%s // '"'
+        if (i < size(source%include_dependencies)) s = s // ", "
+    end do
+    s = s // "]"
+    !    type(string_t), allocatable :: link_libraries(:)
+    s = s // ", link_libraries=["
+    do i = 1, size(source%link_libraries)
+        s = s // '"' // source%link_libraries(i)%s // '"'
+        if (i < size(source%link_libraries)) s = s // ", "
+    end do
+    s = s // "]"
     !    integer(int64) :: digest
     s = s // ", digest=" // str(source%digest)
     !end type srcfile_t

--- a/src/fpm_model.f90
+++ b/src/fpm_model.f90
@@ -200,13 +200,6 @@ function info_srcfile(source) result(s)
     case default
         s = s // "INVALID"
     end select
-    !    type(string_t), allocatable :: modules_provided(:)
-    s = s // ", modules_provided=["
-    do i = 1, size(source%modules_provided)
-        s = s // '"' // source%modules_provided(i)%s // '"'
-        if (i < size(source%modules_provided)) s = s // ", "
-    end do
-    s = s // "]"
     !    integer :: unit_type = FPM_UNIT_UNKNOWN
     s = s // ", unit_type="
     select case(source%unit_type)
@@ -227,27 +220,42 @@ function info_srcfile(source) result(s)
     case default
         s = s // "INVALID"
     end select
-    !    type(string_t), allocatable :: modules_used(:)
-    s = s // ", modules_used=["
-    do i = 1, size(source%modules_used)
-        s = s // '"' // source%modules_used(i)%s // '"'
-        if (i < size(source%modules_used)) s = s // ", "
-    end do
-    s = s // "]"
-    !    type(string_t), allocatable :: include_dependencies(:)
-    s = s // ", include_dependencies=["
-    do i = 1, size(source%include_dependencies)
-        s = s // '"' // source%include_dependencies(i)%s // '"'
-        if (i < size(source%include_dependencies)) s = s // ", "
-    end do
-    s = s // "]"
-    !    type(string_t), allocatable :: link_libraries(:)
-    s = s // ", link_libraries=["
-    do i = 1, size(source%link_libraries)
-        s = s // '"' // source%link_libraries(i)%s // '"'
-        if (i < size(source%link_libraries)) s = s // ", "
-    end do
-    s = s // "]"
+
+    select case (source%unit_type)
+    case (FPM_UNIT_PROGRAM, FPM_UNIT_MODULE, FPM_UNIT_SUBMODULE, &
+         FPM_UNIT_SUBPROGRAM, FPM_UNIT_CSOURCE, FPM_UNIT_CHEADER)
+        !    type(string_t), allocatable :: modules_provided(:)
+        s = s // ", modules_provided=["
+        do i = 1, size(source%modules_provided)
+            s = s // '"' // source%modules_provided(i)%s // '"'
+            if (i < size(source%modules_provided)) s = s // ", "
+        end do
+        s = s // "]"
+        
+        !    type(string_t), allocatable :: modules_used(:)
+        s = s // ", modules_used=["
+        do i = 1, size(source%modules_used)
+            s = s // '"' // source%modules_used(i)%s // '"'
+            if (i < size(source%modules_used)) s = s // ", "
+        end do
+        s = s // "]"
+        !    type(string_t), allocatable :: include_dependencies(:)
+        s = s // ", include_dependencies=["
+        do i = 1, size(source%include_dependencies)
+            s = s // '"' // source%include_dependencies(i)%s // '"'
+            if (i < size(source%include_dependencies)) s = s // ", "
+        end do
+        s = s // "]"
+        !    type(string_t), allocatable :: link_libraries(:)
+        s = s // ", link_libraries=["
+        do i = 1, size(source%link_libraries)
+            s = s // '"' // source%link_libraries(i)%s // '"'
+            if (i < size(source%link_libraries)) s = s // ", "
+        end do
+        s = s // "]"
+    case default
+        ! pass
+    end select
     !    integer(int64) :: digest
     s = s // ", digest=" // str(source%digest)
     !end type srcfile_t

--- a/src/fpm_source_parsing.f90
+++ b/src/fpm_source_parsing.f90
@@ -99,10 +99,8 @@ function parse_f_source(f_filename,error) result(f_source)
        file_lines_lower(i)%s=adjustl(lower(file_lines_lower(i)%s))
     enddo
 
-    ! Ignore empty files, returned as FPM_UNIT_UNKNOWN
-    if (len_trim(file_lines_lower) < 1) return
-
-    f_source%digest = fnv_1a(file_lines)
+    ! fnv_1a can only be applied to non-zero-length arrays
+    if (len_trim(file_lines_lower) > 0) f_source%digest = fnv_1a(file_lines)
 
     do pass = 1,2
         n_use = 0


### PR DESCRIPTION
I found fpm will crash when executing `fpm build --show-model`, if there are empty source files in project.

After looking into code, I found `parse_f_source` returns an instance of `srcfile_t` with its `allocatable` members uninitialized for empty source files. 
```fortran
! Ignore empty files, returned as FPM_UNIT_UNKNOWN
if (len_trim(file_lines_lower) < 1) return
```
As a result, in `info_srcfile` function, an error will occur when printing `srcfile_t` objects with `FPM_UNIT_UNKNOWN` type.

So I make it skip for `FPM_UNIT_UNKNOWN` type.