### PR TITLE
Fix show-model option

### DIFF
--- a/src/fpm_sources.f90
+++ b/src/fpm_sources.f90
@@ -96,6 +96,7 @@ subroutine add_sources_from_dir(sources,directory,scope,with_executables,recurse
         if (allocated(error)) return
 
         dir_sources(i)%unit_scope = scope
+        allocate(dir_sources(i)%link_libraries(0))
 
         ! Exclude executables unless specified otherwise
         exclude_source(i) = (dir_sources(i)%unit_type == FPM_UNIT_PROGRAM)

--- a/test/fpm_test/test_source_parsing.f90
+++ b/test/fpm_test/test_source_parsing.f90
@@ -643,6 +643,11 @@ contains
             return
         end if
 
+        if (allocated(f_source%link_libraries)) then
+            call test_failed(error,'Unexpected link_libraries - expecting unallocated')
+            return
+        end if
+
         if (.not.('proto.h' .in. f_source%include_dependencies)) then
             call test_failed(error,'Missing file in include_dependencies')
             return


### PR DESCRIPTION
To close #615 .

Init the `f_source%link_libraries` array length as 0.