### PR TITLE
Fix submodule shaking

### DIFF
--- a/ci/run_tests.sh
+++ b/ci/run_tests.sh
@@ -76,8 +76,6 @@ test ! -e ./build/gfortran_*/submodule_tree_shake/src_parent_unused.f90.o
 test ! -e ./build/gfortran_*/submodule_tree_shake/src_parent_unused.f90.o.log
 test ! -e ./build/gfortran_*/submodule_tree_shake/src_child_unused.f90.o
 test ! -e ./build/gfortran_*/submodule_tree_shake/src_child_unused.f90.o.log
-test ! -e ./build/gfortran_*/submodule_tree_shake/src_grandchild.f90.o
-test ! -e ./build/gfortran_*/submodule_tree_shake/src_grandchild.f90.o.log
 popd
 
 pushd version_file

--- a/example_packages/submodule_tree_shake/src/child1.f90
+++ b/example_packages/submodule_tree_shake/src/child1.f90
@@ -10,7 +10,7 @@ end interface
 contains
 
 module procedure my_sub1
-    a = 1
+    a = my_fun()
 end procedure my_sub1
 
 end submodule child1

--- a/src/fpm_source_parsing.f90
+++ b/src/fpm_source_parsing.f90
@@ -614,6 +614,7 @@ function parse_sequence(string,t1,t2,t3,t4) result(found)
         select case(token_n)
         case(1)
             incr = len(t1)
+            if (pos+incr-1>n) return
             match = string(pos:pos+incr-1) == t1
         case(2)
             if (.not.present(t2)) exit

--- a/src/fpm_targets.f90
+++ b/src/fpm_targets.f90
@@ -615,24 +615,26 @@ subroutine prune_build_targets(targets, root_package)
         end if
 
         if (allocated(target%source)) then
-            do j=1,size(target%source%modules_used)
-                        
-                if (.not.(target%source%modules_used(j)%s .in. modules_used)) then
 
-                    modules_used = [modules_used, target%source%modules_used(j)]
+            ! Add modules from this target and from any of it's children submodules
+            do j=1,size(target%source%modules_provided)
 
-                    ! Recurse into child submodules
-                    do k=1,size(targets)
-                        if (allocated(targets(k)%ptr%source)) then
-                            if (targets(k)%ptr%source%unit_type == FPM_UNIT_SUBMODULE) then
-                                if (target%source%modules_used(j)%s .in. targets(k)%ptr%source%parent_modules) then
-                                    call collect_used_modules(targets(k)%ptr)
-                                end if
-                            end if
-                        end if
-                    end do
+                if (.not.(target%source%modules_provided(j)%s .in. modules_used)) then
+
+                    modules_used = [modules_used, target%source%modules_provided(j)]
 
                 end if
+
+                ! Recurse into child submodules
+                do k=1,size(targets)
+                    if (allocated(targets(k)%ptr%source)) then
+                        if (targets(k)%ptr%source%unit_type == FPM_UNIT_SUBMODULE) then
+                            if (target%source%modules_provided(j)%s .in. targets(k)%ptr%source%parent_modules) then
+                                call collect_used_modules(targets(k)%ptr)
+                            end if
+                        end if
+                    end if
+                end do
 
             end do
         end if


### PR DESCRIPTION
Fixes #703

I made an incorrect assumption in https://github.com/fortran-lang/fpm/pull/676 that grandchild submodules only need to be built if their immediate parent is used elsewhere. Actually the whole submodule hierarchy needs to be built if the top-level parent is used.