### PR TITLE
Add OMP critical for make_archive

### DIFF
--- a/src/fpm_compiler.f90
+++ b/src/fpm_compiler.f90
@@ -787,10 +787,12 @@ subroutine make_archive(self, output, args, log_file, stat)
     integer, intent(out) :: stat
 
     if (self%use_response_file) then
+        !$omp critical
         call write_response_file(output//".resp" , args)
         call run(self%ar // output // " @" // output//".resp", echo=self%echo, &
             &  verbose=self%verbose, redirect=log_file, exitstat=stat)
         call delete_file(output//".resp")
+        !$omp end critical
     else
         call run(self%ar // output // " " // string_cat(args, " "), &
             & echo=self%echo, verbose=self%verbose, redirect=log_file, exitstat=stat)

--- a/src/fpm_compiler.f90
+++ b/src/fpm_compiler.f90
@@ -774,6 +774,9 @@ end subroutine link
 
 
 !> Create an archive
+!> @todo An OMP critical section is added for Windows OS,
+!> which may be related to a bug in Mingw64-openmp and is expected to be resolved in the future,
+!> see issue #707 and #708.
 subroutine make_archive(self, output, args, log_file, stat)
     !> Instance of the archiver object
     class(archiver_t), intent(in) :: self


### PR DESCRIPTION
Fixes #707 .

### Description

When building an archive, it involves generating and deleting the `.rsp` file. When compiling in **parallel**, this will cause an error to be reported. It can be solved by adding `!$OMP critical`.

This PR ensures that when generating the archive file, only a single thread is used, and it is set as a `critical` process, ensuring that this part of the code is not affected by other threads.


