### PR TITLE
Fix --show-model, init c_source%parent_modules.

### DIFF
--- a/src/fpm_source_parsing.f90
+++ b/src/fpm_source_parsing.f90
@@ -463,6 +463,7 @@ function parse_c_source(c_filename,error) result(c_source)
 
     allocate(c_source%modules_used(0))
     allocate(c_source%modules_provided(0))
+    allocate(c_source%parent_modules(0))
 
     open(newunit=fh,file=c_filename,status='old')
     file_lines = read_lines(fh)

--- a/test/fpm_test/test_source_parsing.f90
+++ b/test/fpm_test/test_source_parsing.f90
@@ -818,6 +818,11 @@ contains
             call test_failed(error,'Unexpected link_libraries - expecting unallocated')
             return
         end if
+        
+        if (size(f_source%parent_modules) /= 0) then
+            call test_failed(error,'Incorrect number of parent_modules - expecting zero')
+            return
+        end if
 
         if (.not.('proto.h' .in. f_source%include_dependencies)) then
             call test_failed(error,'Missing file in include_dependencies')


### PR DESCRIPTION
- [x] Init the `c_source%parent_modules` array length as 0.

### Description

Similar as #693, and related to #711, but not fully resolved #711 (Only bug1, not bug2)

If `parent_modules` is not length-initialized, a segfault will occur when printing the dependency tree (`fpm build --show-model`).