### PR TITLE
Avoid infinite loop if command "fpm-" is in path, closes #709

### DIFF
--- a/src/fpm_command_line.f90
+++ b/src/fpm_command_line.f90
@@ -574,7 +574,8 @@ contains
 
         case default
 
-            if(which('fpm-'//cmdarg).ne.'')then
+	    if(cmdarg.ne.''.and.which('fpm-'//cmdarg).ne.'')then
+
                 call run('fpm-'//trim(cmdarg)//' '// get_command_arguments_quoted(),.false.)
             else
                 call set_args('&


### PR DESCRIPTION
If a copy of fpm is renamed fpm- it will be called recursively
because plugin-names are searched for in the form of "fpm-*"
because since there is no test if the plugin suffix is blank
the "fpm-" command will be called.

A relatively minor bug; but it takes a one-line change to fix
and is quite confusing to anyone with a "fpm-" command in their
path.