### PR TITLE
Support for dependency path relative to the fpm.toml it’s written in

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,8 @@ or from [miniconda](https://docs.conda.io/en/latest/miniconda.html).
 
 #### [MSYS2]
 
-Fpm is available as MinGW package in the MSYS2 package manager.
+Fpm is available as MinGW package in the MSYS2 package manager,
+which supports parallelization of the target compilation.
 To install fpm with pacman use
 
 ```

--- a/ci/run_tests.sh
+++ b/ci/run_tests.sh
@@ -118,5 +118,9 @@ pushd c_main
 "$fpm" run
 popd
 
+pushd hello_fpm_path
+"$fpm" run
+popd
+
 # Cleanup
 rm -rf ./*/build

--- a/example_packages/hello_fpm_path/app/main.f90
+++ b/example_packages/hello_fpm_path/app/main.f90
@@ -1,0 +1,10 @@
+program hello_fpm
+    use utils1_m, only: say_hello1
+    use utils1_1_m, only: say_hello1_1
+    use utils2_m, only: say_hello2
+
+    call say_hello1()
+    call say_hello1_1()
+    call say_hello2()
+
+end program hello_fpm

--- a/example_packages/hello_fpm_path/crate/utils1/fpm.toml
+++ b/example_packages/hello_fpm_path/crate/utils1/fpm.toml
@@ -1,0 +1,4 @@
+name = "utils1"
+
+[dependencies]
+utils1_1 = { path = "../utils1_1" }

--- a/example_packages/hello_fpm_path/crate/utils1/src/say_hello.f90
+++ b/example_packages/hello_fpm_path/crate/utils1/src/say_hello.f90
@@ -1,0 +1,11 @@
+module utils1_m
+
+    implicit none
+    
+contains
+    
+    subroutine say_hello1()
+        print '(a)', "Hello, utils1."
+    end subroutine say_hello1
+
+end module utils1_m

--- a/example_packages/hello_fpm_path/crate/utils1_1/fpm.toml
+++ b/example_packages/hello_fpm_path/crate/utils1_1/fpm.toml
@@ -1,0 +1,1 @@
+name = "utils1_1"

--- a/example_packages/hello_fpm_path/crate/utils1_1/src/say_hello.f90
+++ b/example_packages/hello_fpm_path/crate/utils1_1/src/say_hello.f90
@@ -1,0 +1,11 @@
+module utils1_1_m
+
+    implicit none
+    
+contains
+    
+    subroutine say_hello1_1()
+        print '(a)', "Hello, utils1_1."
+    end subroutine say_hello1_1
+
+end module utils1_1_m

--- a/example_packages/hello_fpm_path/crate/utils2/fpm.toml
+++ b/example_packages/hello_fpm_path/crate/utils2/fpm.toml
@@ -1,0 +1,1 @@
+name = "utils2"

--- a/example_packages/hello_fpm_path/crate/utils2/src/say_hello.f90
+++ b/example_packages/hello_fpm_path/crate/utils2/src/say_hello.f90
@@ -1,0 +1,11 @@
+module utils2_m
+
+    implicit none
+    
+contains
+    
+    subroutine say_hello2()
+        print '(a)', "Hello, utils2."
+    end subroutine say_hello2
+
+end module utils2_m

--- a/example_packages/hello_fpm_path/fpm.toml
+++ b/example_packages/hello_fpm_path/fpm.toml
@@ -1,0 +1,5 @@
+name = "hello_fpm_path"
+
+[dependencies]
+utils1 = { path = "crate/utils1" }
+utils2 = { path = "crate/utils2" }

--- a/src/fpm/cmd/new.f90
+++ b/src/fpm/cmd/new.f90
@@ -369,8 +369,8 @@ character(len=:,kind=tfc),allocatable :: littlefile(:)
         &'                                                                                ',&
         &'#M_strings = { path = "M_strings" }                                             ',&
         &'                                                                                ',&
-        &'  #  If you specify paths outside of your repository (ie. paths with a          ',&
-        &'  #  slash in them) things will not work for your users!                        ',&
+        &'  # This tells fpm that we depend on a crate called M_strings which is found    ',&
+        &'  # in the M_strings folder (relative to the fpm.toml it’s written in).         ',&
         &'  #                                                                             ',&
         &'  # For a more verbose layout use normal tables rather than inline tables       ',&
         &'  # to specify dependencies:                                                    ',&

--- a/src/fpm/manifest.f90
+++ b/src/fpm/manifest.f90
@@ -14,7 +14,7 @@ module fpm_manifest
     use fpm_manifest_library, only : library_config_t
     use fpm_mainfest_preprocess, only : preprocess_config_t
     use fpm_manifest_package, only : package_config_t, new_package
-    use fpm_error, only : error_t, fatal_error, file_not_found_error
+    use fpm_error, only : error_t, fatal_error
     use fpm_toml, only : toml_table, read_package_file
     use fpm_manifest_test, only : test_config_t
     use fpm_filesystem, only: join_path, exists, dirname, is_dir

--- a/src/fpm/manifest/dependency.f90
+++ b/src/fpm/manifest/dependency.f90
@@ -27,6 +27,8 @@ module fpm_manifest_dependency
     use fpm_git, only : git_target_t, git_target_tag, git_target_branch, &
         & git_target_revision, git_target_default
     use fpm_toml, only : toml_table, toml_key, toml_stat, get_value
+    use fpm_filesystem, only: windows_path
+    use fpm_environment, only: get_os_type, OS_WINDOWS
     implicit none
     private
 
@@ -80,6 +82,7 @@ contains
 
         call get_value(table, "path", url)
         if (allocated(url)) then
+            if (get_os_type() == OS_WINDOWS) url = windows_path(url)
             if (present(root)) url = root//url  ! Relative to the fpm.toml it’s written in
             call move_alloc(url, self%path)
         else

--- a/src/fpm/manifest/dependency.f90
+++ b/src/fpm/manifest/dependency.f90
@@ -57,13 +57,16 @@ contains
 
 
     !> Construct a new dependency configuration from a TOML data structure
-    subroutine new_dependency(self, table, error)
+    subroutine new_dependency(self, table, root, error)
 
         !> Instance of the dependency configuration
         type(dependency_config_t), intent(out) :: self
 
         !> Instance of the TOML data structure
         type(toml_table), intent(inout) :: table
+
+        !> Root directory of the manifest
+        character(*), intent(in), optional :: root
 
         !> Error handling
         type(error_t), allocatable, intent(out) :: error
@@ -77,6 +80,7 @@ contains
 
         call get_value(table, "path", url)
         if (allocated(url)) then
+            if (present(root)) url = root//url  ! Relative to the fpm.toml it’s written in
             call move_alloc(url, self%path)
         else
             call get_value(table, "git", url)
@@ -173,13 +177,16 @@ contains
 
 
     !> Construct new dependency array from a TOML data structure
-    subroutine new_dependencies(deps, table, error)
+    subroutine new_dependencies(deps, table, root, error)
 
         !> Instance of the dependency configuration
         type(dependency_config_t), allocatable, intent(out) :: deps(:)
 
         !> Instance of the TOML data structure
         type(toml_table), intent(inout) :: table
+
+        !> Root directory of the manifest
+        character(*), intent(in), optional :: root
 
         !> Error handling
         type(error_t), allocatable, intent(out) :: error
@@ -199,7 +206,7 @@ contains
                 call syntax_error(error, "Dependency "//list(idep)%key//" must be a table entry")
                 exit
             end if
-            call new_dependency(deps(idep), node, error)
+            call new_dependency(deps(idep), node, root, error)
             if (allocated(error)) exit
         end do
 

--- a/src/fpm/manifest/example.f90
+++ b/src/fpm/manifest/example.f90
@@ -69,7 +69,7 @@ contains
 
         call get_value(table, "dependencies", child, requested=.false.)
         if (associated(child)) then
-            call new_dependencies(self%dependency, child, error)
+            call new_dependencies(self%dependency, child, error=error)
             if (allocated(error)) return
         end if
 

--- a/src/fpm/manifest/executable.f90
+++ b/src/fpm/manifest/executable.f90
@@ -80,7 +80,7 @@ contains
 
         call get_value(table, "dependencies", child, requested=.false.)
         if (associated(child)) then
-            call new_dependencies(self%dependency, child, error)
+            call new_dependencies(self%dependency, child, error=error)
             if (allocated(error)) return
         end if
 

--- a/src/fpm/manifest/package.f90
+++ b/src/fpm/manifest/package.f90
@@ -192,13 +192,13 @@ contains
 
         call get_value(table, "dependencies", child, requested=.false.)
         if (associated(child)) then
-            call new_dependencies(self%dependency, child, error)
+            call new_dependencies(self%dependency, child, root, error)
             if (allocated(error)) return
         end if
 
         call get_value(table, "dev-dependencies", child, requested=.false.)
         if (associated(child)) then
-            call new_dependencies(self%dev_dependency, child, error)
+            call new_dependencies(self%dev_dependency, child, root, error)
             if (allocated(error)) return
         end if
 

--- a/src/fpm/manifest/test.f90
+++ b/src/fpm/manifest/test.f90
@@ -69,7 +69,7 @@ contains
 
         call get_value(table, "dependencies", child, requested=.false.)
         if (associated(child)) then
-            call new_dependencies(self%dependency, child, error)
+            call new_dependencies(self%dependency, child, error=error)
             if (allocated(error)) return
         end if
 

--- a/src/fpm_filesystem.F90
+++ b/src/fpm_filesystem.F90
@@ -286,7 +286,11 @@ function join_path(a1,a2,a3,a4,a5) result(path)
         has_cache = .true.
     end if
 
-    path = a1 // filesep // a2
+    if (a1 == "") then
+        path = a2
+    else
+        path = a1 // filesep // a2
+    end if
 
     if (present(a3)) then
         path = path // filesep // a3

--- a/src/fpm_filesystem.F90
+++ b/src/fpm_filesystem.F90
@@ -219,7 +219,6 @@ function dirname(path) result (dir)
     character(:), allocatable :: dir
 
     dir = path(1:scan(path,'/\',back=.true.))
-    if (len_trim(dir) == 0) dir = "."
 
 end function dirname
 

--- a/test/fpm_test/test_manifest.f90
+++ b/test/fpm_test/test_manifest.f90
@@ -252,7 +252,7 @@ contains
         call new_table(table)
         table%key = "example"
 
-        call new_dependency(dependency, table, error)
+        call new_dependency(dependency, table, error=error)
 
     end subroutine test_dependency_empty
 
@@ -274,7 +274,7 @@ contains
         call set_value(table, 'path', '"package"', stat)
         call set_value(table, 'tag', '"v20.1"', stat)
 
-        call new_dependency(dependency, table, error)
+        call new_dependency(dependency, table, error=error)
 
     end subroutine test_dependency_pathtag
 
@@ -295,7 +295,7 @@ contains
         table%key = 'example'
         call set_value(table, 'tag', '"v20.1"', stat)
 
-        call new_dependency(dependency, table, error)
+        call new_dependency(dependency, table, error=error)
 
     end subroutine test_dependency_nourl
 
@@ -317,7 +317,7 @@ contains
         call set_value(table, 'path', '"package"', stat)
         call set_value(table, 'git', '"https://gitea.com/fortran-lang/pack"', stat)
 
-        call new_dependency(dependency, table, error)
+        call new_dependency(dependency, table, error=error)
 
     end subroutine test_dependency_gitpath
 
@@ -340,7 +340,7 @@ contains
         call set_value(table, 'branch', '"latest"', stat)
         call set_value(table, 'tag', '"v20.1"', stat)
 
-        call new_dependency(dependency, table, error)
+        call new_dependency(dependency, table, error=error)
 
     end subroutine test_dependency_gitconflict
 
@@ -361,7 +361,7 @@ contains
         table%key = 'example'
         call set_value(table, 'not-available', '"anywhere"', stat)
 
-        call new_dependency(dependency, table, error)
+        call new_dependency(dependency, table, error=error)
 
     end subroutine test_dependency_wrongkey
 
@@ -379,7 +379,7 @@ contains
 
         call new_table(table)
 
-        call new_dependencies(dependencies, table, error)
+        call new_dependencies(dependencies, table, error=error)
         if (allocated(error)) return
 
         if (allocated(dependencies)) then
@@ -405,7 +405,7 @@ contains
         call new_table(table)
         call add_array(table, 'dep1', children, stat)
 
-        call new_dependencies(dependencies, table, error)
+        call new_dependencies(dependencies, table, error=error)
 
     end subroutine test_dependencies_typeerror
 

--- a/test/fpm_test/test_package_dependencies.f90
+++ b/test/fpm_test/test_package_dependencies.f90
@@ -183,7 +183,7 @@ contains
         call add_table(table, "proj4", ptr)
         call set_value(ptr, "path", "vendor")
 
-        call new_dependencies(nodes, table, error)
+        call new_dependencies(nodes, table, error=error)
         if (allocated(error)) return
 
         call new_dependency_tree(deps%dependency_tree_t)

--- a/test/fpm_test/test_package_dependencies.f90
+++ b/test/fpm_test/test_package_dependencies.f90
@@ -186,6 +186,9 @@ contains
         call new_dependencies(nodes, table, error=error)
         if (allocated(error)) return
 
+        call new_dependencies(nodes, table, root='.', error=error)
+        if (allocated(error)) return
+
         call new_dependency_tree(deps%dependency_tree_t)
         call deps%add(nodes, error)
         if (allocated(error)) return


### PR DESCRIPTION
To close #605 .

### Description

The previous dependency `path` was always quite the same as the top-level project, which made it difficult to make such an `fpm` package called by a higher-level project.
`Rust-cargo` seems to take a more reasonable approach: dependency paths are relative to the `Cargo.toml` it’s written in.

This PR attempts to support such improvements, which will allow us to publish `fpm` packages with component libraries.

```sh
---- pkg-1
      |---- fpm.toml
      |---- crate
              |---- pkg-2
              |---- pkg-3

# pkg-1 fpm.toml
[dependencies]
pkg-2 = { path = 'crate/pkg-2' }

# pkg-2 fpm.toml
[dependencies]
pkg-3 = { path = '../pkg-3' }
```

### What this PR does
- [x] Update the interfaces of `dependency.f90::new_dependecy` and `dependency.f90::new_dependecies`, adding the `root` optional argument.
- [x] Add an example;
- [x] Update test and help manual;
- [x] Update README for MSYS2-fpm. (Not related to this PR, but a minor revision)
- [x] Update the handling of `join_path("", "fpm.toml")`:
```fortran
print *, join_path("", "fpm.toml")  !! Original: `/fpm.toml`
print *, join_path("", "fpm.toml")  !! New:      `fpm.toml`
```
- [x] On Windows, adapt the path style of the Windows system to the dependency path.
