### PR TITLE
feat: ability to read macros from manifest

### DIFF
--- a/ci/run_tests.sh
+++ b/ci/run_tests.sh
@@ -118,5 +118,9 @@ pushd c_main
 "$fpm" run
 popd
 
+pushd preprocess_cpp
+"$fpm" build
+popd
+
 # Cleanup
 rm -rf ./*/build

--- a/ci/run_tests.sh
+++ b/ci/run_tests.sh
@@ -122,5 +122,9 @@ pushd preprocess_cpp
 "$fpm" build
 popd
 
+pushd preprocess_hello
+"$fpm" build
+popd
+
 # Cleanup
 rm -rf ./*/build

--- a/example_packages/preprocess_cpp/fpm.toml
+++ b/example_packages/preprocess_cpp/fpm.toml
@@ -2,3 +2,4 @@ name = "preprocess_cpp"
 
 [preprocess]
 [preprocess.cpp]
+macros = ["TESTMACRO"]

--- a/example_packages/preprocess_cpp/fpm.toml
+++ b/example_packages/preprocess_cpp/fpm.toml
@@ -1,5 +1,7 @@
 name = "preprocess_cpp"
 
+version = "1"
+
 [preprocess]
 [preprocess.cpp]
-macros = ["TESTMACRO"]
+macros = ["TESTMACRO", "TESTMACRO2=3", "TESTMACRO3={version}"]

--- a/example_packages/preprocess_cpp/src/preprocess_cpp.f90
+++ b/example_packages/preprocess_cpp/src/preprocess_cpp.f90
@@ -9,5 +9,14 @@ contains
 #ifndef TESTMACRO
       This breaks the build.
 #endif
+
+#if TESTMACRO2 != 3
+      This breaks the build.
+#endif
+
+#if TESTMACRO3 != 1
+      This breaks the build.
+#endif
+
    end subroutine say_hello
 end module preprocess_cpp

--- a/example_packages/preprocess_hello/README.md
+++ b/example_packages/preprocess_hello/README.md
@@ -1,0 +1,2 @@
+# preprocess_hello
+My cool new project!

--- a/example_packages/preprocess_hello/app/main.f90
+++ b/example_packages/preprocess_hello/app/main.f90
@@ -2,11 +2,5 @@ program preprocess_hello
     use preprocess_hello_dependency, only: say_hello
 
     implicit none
-
-!> The build will not break because we have FOO defined as macro in fpm.toml file
-!> of this package.
-#ifndef FOO
-    This breaks the build inside the root package.
-#endif
     call say_hello()
 end program preprocess_hello

--- a/example_packages/preprocess_hello/app/main.f90
+++ b/example_packages/preprocess_hello/app/main.f90
@@ -1,0 +1,12 @@
+program preprocess_hello
+    use preprocess_hello_dependency, only: say_hello
+
+    implicit none
+
+!> The build will not break because we have FOO defined as macro in fpm.toml file
+!> of this package.
+#ifndef FOO
+    This breaks the build inside the root package.
+#endif
+    call say_hello()
+end program preprocess_hello

--- a/example_packages/preprocess_hello/fpm.toml
+++ b/example_packages/preprocess_hello/fpm.toml
@@ -1,0 +1,8 @@
+name = "preprocess_hello"
+
+[preprocess]
+[preprocess.cpp]
+macros = ["FOO"]
+
+[dependencies]
+preprocess_hello_dependency = { path = "../preprocess_hello_dependency" }

--- a/example_packages/preprocess_hello_dependency/README.md
+++ b/example_packages/preprocess_hello_dependency/README.md
@@ -1,0 +1,2 @@
+# preprocess_hello_dependency
+My cool new project!

--- a/example_packages/preprocess_hello_dependency/fpm.toml
+++ b/example_packages/preprocess_hello_dependency/fpm.toml
@@ -1,0 +1,1 @@
+name = "preprocess_hello_dependency"

--- a/example_packages/preprocess_hello_dependency/src/preprocess_hello_dependency.f90
+++ b/example_packages/preprocess_hello_dependency/src/preprocess_hello_dependency.f90
@@ -6,10 +6,9 @@ module preprocess_hello_dependency
 contains
   subroutine say_hello
 
-!> This build should break because we do not have FOO defined as macro in the fpm.toml file of
-!> this package.
-#ifndef FOO
-    This breaks the build inside dependency. This implies that macros are not getting passed to the dependeny.
+!> If this build fails, then it implies that macros are getting passed to the dependency.
+#ifdef FOO
+    This breaks the build inside dependency. This implies that macros are getting passed to the dependeny.
 #endif
     print *, "Hello, preprocess_hello_dependency!"
   end subroutine say_hello

--- a/example_packages/preprocess_hello_dependency/src/preprocess_hello_dependency.f90
+++ b/example_packages/preprocess_hello_dependency/src/preprocess_hello_dependency.f90
@@ -1,0 +1,16 @@
+module preprocess_hello_dependency
+  implicit none
+  private
+
+  public :: say_hello
+contains
+  subroutine say_hello
+
+!> This build should break because we do not have FOO defined as macro in the fpm.toml file of
+!> this package.
+#ifndef FOO
+    This breaks the build inside dependency. This implies that macros are not getting passed to the dependeny.
+#endif
+    print *, "Hello, preprocess_hello_dependency!"
+  end subroutine say_hello
+end module preprocess_hello_dependency

--- a/src/fpm.f90
+++ b/src/fpm.f90
@@ -78,7 +78,7 @@ subroutine build_model(model, settings, package, error)
         end select
     end if
 
-    call set_preprocessor_flags(model%compiler%id, flags)
+    call set_preprocessor_flags(model%compiler%id, flags, package)
 
     cflags = trim(settings%cflag)
     ldflags = trim(settings%ldflag)

--- a/src/fpm.f90
+++ b/src/fpm.f90
@@ -44,6 +44,7 @@ subroutine build_model(model, settings, package, error)
     integer :: i, j
     type(package_config_t) :: dependency
     character(len=:), allocatable :: manifest, lib_dir, flags, cflags, ldflags
+    character(len=:), allocatable :: version
 
     logical :: duplicates_found = .false.
     type(string_t) :: include_dir
@@ -166,6 +167,17 @@ subroutine build_model(model, settings, package, error)
             if (allocated(error)) exit
 
             model%packages(i)%name = dependency%name
+            call package%version%to_string(version)
+            model%packages(i)%version = version
+            
+            if (allocated(dependency%preprocess)) then
+                do j = 1, size(dependency%preprocess)
+                    if (package%preprocess(j)%name == "cpp") then
+                        model%packages(i)%macros = dependency%preprocess(j)%macros
+                    end if
+                end do
+            end if
+
             if (.not.allocated(model%packages(i)%sources)) allocate(model%packages(i)%sources(0))
 
             if (allocated(dependency%library)) then

--- a/src/fpm/manifest/preprocess.f90
+++ b/src/fpm/manifest/preprocess.f90
@@ -53,7 +53,7 @@ contains
       type(toml_table), intent(inout) :: table
 
       !> Error handling
-      type(error_t), allocatable, intent(inout) :: error
+      type(error_t), allocatable, intent(out) :: error
 
       call check(table, error)
       if (allocated(error)) return

--- a/src/fpm_compiler.f90
+++ b/src/fpm_compiler.f90
@@ -26,6 +26,7 @@
 ! Open64            ?          ?       -module         -I            -mp        discontinued
 ! Unisys            ?          ?       ?               ?             ?          discontinued
 module fpm_compiler
+use,intrinsic :: iso_fortran_env, only: stderr=>error_unit
 use fpm_environment, only: &
         get_env, &
         get_os_type, &
@@ -412,6 +413,8 @@ subroutine set_preprocessor_flags (id, flags, package)
             flags = flag_cpp_preprocessor// flags
             call get_macros_from_manifest(id, flags, package, i)
             exit
+        else
+            write(stderr, '(a)') 'Warning: preprocessor ' // package%preprocess(i)%name // ' is not supported; will ignore it'
         end if
     end do
 

--- a/src/fpm_compiler.f90
+++ b/src/fpm_compiler.f90
@@ -382,9 +382,8 @@ end subroutine get_debug_compile_flags
 
 subroutine set_preprocessor_flags (id, flags, package)
     integer(compiler_enum), intent(in) :: id
+    character(len=:), allocatable, intent(inout) :: flags
     type(package_config_t), intent(in) :: package
-    type(error_t), allocatable :: error
-    character(len=:), allocatable :: flags
     character(len=:), allocatable :: flag_cpp_preprocessor
     
     integer :: i
@@ -424,15 +423,14 @@ end subroutine set_preprocessor_flags
 !> under preprocess section for a specific preprocessor
 subroutine get_macros_from_manifest(id, flags, package, index_of_preprocessor)
     integer(compiler_enum), intent(in) :: id
+    character(len=:), allocatable, intent(inout) :: flags
     type(package_config_t), intent(in) :: package
-    type(error_t), allocatable :: error
-    character(len=:), allocatable :: flags
+    integer, intent(in) :: index_of_preprocessor
     character(len=:), allocatable :: macro_definition_symbol
     character(:), allocatable :: valued_macros(:)
     character(len=:), allocatable :: version
 
     integer :: i
-    integer :: index_of_preprocessor
 
     !> Check if there is a preprocess table
     if (.not.allocated(package%preprocess)) then

--- a/src/fpm_model.f90
+++ b/src/fpm_model.f90
@@ -122,6 +122,12 @@ type package_t
     !> Array of sources
     type(srcfile_t), allocatable :: sources(:)
 
+    !> List of macros.
+    type(string_t), allocatable :: macros(:)
+
+    !> Package version number.
+    character(:), allocatable :: version
+
 end type package_t
 
 


### PR DESCRIPTION
This pull request add the ability to parse and read the `macros` array defined in the manifest file for a preprocessor under `preprocess` section.