### PR TITLE
In the default case of command line subcommands, stop `fpm` running in time

### DIFF
--- a/src/fpm.f90
+++ b/src/fpm.f90
@@ -7,7 +7,7 @@ use fpm_command_line, only: fpm_build_settings, fpm_new_settings, &
                       fpm_clean_settings
 use fpm_dependency, only : new_dependency_tree
 use fpm_environment, only: get_env
-use fpm_filesystem, only: is_dir, join_path, number_of_rows, list_files, exists, &
+use fpm_filesystem, only: is_dir, join_path, list_files, exists, &
                    basename, filewrite, mkdir, run, os_delete_dir
 use fpm_model, only: fpm_model_t, srcfile_t, show_model, &
                     FPM_SCOPE_UNKNOWN, FPM_SCOPE_LIB, FPM_SCOPE_DEP, &


### PR DESCRIPTION
To close #727, a small modification:
1. In the default case of command line subcommands (like `>> fpm`), stop `fpm` running after print `help_text`.
2. Remove unnecessary references to `number_of_rows` in `fpm.f90`.