### PR TITLE
docs(README): improve Homebrew references

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,8 +104,8 @@ For more details check the package information [here](https://spack.readthedocs.
 
 #### Homebrew
 
-The Fortran Package Manager (fpm) is available for the [homebrew](https://brew.sh/) package manager on MacOS via an additional tap.
-To install fpm via brew, include the new tap and install it using
+The Fortran Package Manager (fpm) is available for the [Homebrew](https://brew.sh/) package manager via an additional tap.
+To install fpm via Homebrew, include the new tap and install using
 
 ```
 brew tap fortran-lang/fortran

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ For more details check the package information [here](https://spack.readthedocs.
 #### Homebrew
 
 The Fortran Package Manager (fpm) is available for the [Homebrew](https://brew.sh/) package manager via an additional tap.
-To install fpm via Homebrew, include the new tap and install using
+To install fpm via brew, include the new tap and install using
 
 ```
 brew tap fortran-lang/fortran


### PR DESCRIPTION
This commit edits README.md to 

1. Remove OS-specificity in references to Homebrew and
2. Capitalize Homebrew in the manner of the README.md file on [brew.sh](https://brew.sh).

Homebrew works on macOS, Linux, and Windows Subsystem for Linux.