### PR TITLE
Fix compilation with NAG

### DIFF
--- a/fpm.toml
+++ b/fpm.toml
@@ -8,7 +8,7 @@ copyright = "2020 fpm contributors"
 [dependencies]
 [dependencies.toml-f]
 git = "https://github.com/toml-f/toml-f"
-rev = "2f5eaba864ff630ba0c3791126a3f811b6e437f3"
+rev = "e49f5523e4ee67db6628618864504448fb8c8939"
 
 [dependencies.M_CLI2]
 git = "https://github.com/urbanjost/M_CLI2.git"

--- a/src/fpm_command_line.f90
+++ b/src/fpm_command_line.f90
@@ -483,8 +483,7 @@ contains
             c_compiler = sget('c-compiler')
             cxx_compiler = sget('cxx-compiler')
             archiver = sget('archiver')
-            allocate(install_settings)
-            install_settings = fpm_install_settings(&
+            allocate(install_settings, source=fpm_install_settings(&
                 list=lget('list'), &
                 profile=val_profile,&
                 prune=.not.lget('no-prune'), &
@@ -497,7 +496,7 @@ contains
                 cxxflag=val_cxxflag, &
                 ldflag=val_ldflag, &
                 no_rebuild=lget('no-rebuild'), &
-                verbose=lget('verbose'))
+                verbose=lget('verbose')))
             call get_char_arg(install_settings%prefix, 'prefix')
             call get_char_arg(install_settings%libdir, 'libdir')
             call get_char_arg(install_settings%bindir, 'bindir')

--- a/src/fpm_compiler.f90
+++ b/src/fpm_compiler.f90
@@ -176,7 +176,7 @@ character(*), parameter :: &
 character(*), parameter :: &
     flag_nag_coarray = " -coarray=single", &
     flag_nag_pic = " -PIC", &
-    flag_nag_check = " -C=all", &
+    flag_nag_check = " -C", &
     flag_nag_debug = " -g -O0", &
     flag_nag_opt = " -O4", &
     flag_nag_backtrace = " -gline"

--- a/src/fpm_sources.f90
+++ b/src/fpm_sources.f90
@@ -65,13 +65,16 @@ subroutine add_sources_from_dir(sources,directory,scope,with_executables,recurse
 
     integer :: i
     logical, allocatable :: is_source(:), exclude_source(:)
+    logical :: recurse_
     type(string_t), allocatable :: file_names(:)
     type(string_t), allocatable :: src_file_names(:)
     type(string_t), allocatable :: existing_src_files(:)
     type(srcfile_t), allocatable :: dir_sources(:)
 
+    recurse_ = .true.
+    if (present(recurse)) recurse_ = recurse
     ! Scan directory for sources
-    call list_files(directory, file_names,recurse=merge(recurse,.true.,present(recurse)))
+    call list_files(directory, file_names,recurse=recurse_)
 
     if (allocated(sources)) then
         allocate(existing_src_files(size(sources)))


### PR DESCRIPTION
- [x] work around compiler error encountered in NAG for `fpm_command_line.f90`
- [x] update TOML Fortran to include `recursive` attribute in serializer
- [x] fix usage of optional argument when not present
- ~~fix error in test suite for namelist IO~~ (see #754)
- ~~fix signed integer overflow error in file checksum~~ (see #754)
- ~~correctly resolve module duplicates~~ (see #754)

Requires

- [x] https://github.com/toml-f/toml-f/pull/113

See #752 for original NAG report, tracked in #754