### PR TITLE
Updated URL to manifest file in help section

### DIFF
--- a/src/fpm_command_line.f90
+++ b/src/fpm_command_line.f90
@@ -884,7 +884,7 @@ contains
     ' + The fpm(1) home page is at https://github.com/fortran-lang/fpm               ', &
     ' + Registered fpm(1) packages are at https://fortran-lang.org/packages          ', &
     ' + The fpm(1) TOML file format is described at                                  ', &
-    '   https://github.com/fortran-lang/fpm/blob/main/manifest-reference.md          ', &
+    '   https://fpm.fortran-lang.org/en/spec/manifest.html                           ', &
     '']
     help_list=[character(len=80) :: &
     'NAME                                                                   ', &


### PR DESCRIPTION
URL to the manifest specification was outdated. This PR updates the URL to point at the correct one.