### PR TITLE
Create top-level `.gitignore` with `fpm new`

### DIFF
--- a/src/fpm.f90
+++ b/src/fpm.f90
@@ -8,7 +8,7 @@ use fpm_command_line, only: fpm_build_settings, fpm_new_settings, &
 use fpm_dependency, only : new_dependency_tree
 use fpm_environment, only: get_env
 use fpm_filesystem, only: is_dir, join_path, number_of_rows, list_files, exists, &
-                   basename, filewrite, mkdir, run, os_delete_dir
+                   basename, mkdir, run, os_delete_dir
 use fpm_model, only: fpm_model_t, srcfile_t, show_model, &
                     FPM_SCOPE_UNKNOWN, FPM_SCOPE_LIB, FPM_SCOPE_DEP, &
                     FPM_SCOPE_APP, FPM_SCOPE_EXAMPLE, FPM_SCOPE_TEST
@@ -58,11 +58,6 @@ subroutine build_model(model, settings, package, error)
     call new_dependency_tree(model%deps, cache=join_path("build", "cache.toml"))
     call model%deps%add(package, error)
     if (allocated(error)) return
-
-    ! build/ directory should now exist
-    if (.not.exists("build/.gitignore")) then
-      call filewrite(join_path("build", ".gitignore"),["*"])
-    end if
 
     call new_compiler(model%compiler, settings%compiler, settings%c_compiler, &
         & settings%cxx_compiler, echo=settings%verbose, verbose=settings%verbose)

--- a/src/fpm/cmd/new.f90
+++ b/src/fpm/cmd/new.f90
@@ -101,7 +101,7 @@ character(len=:,kind=tfc),allocatable :: gitignorefile(:)
     bname=basename(settings%name)
 
     littlefile=[character(len=80) :: '# '//bname, 'My cool new project!']
-    
+
     ! create NAME/README.md
     call warnwrite(join_path(settings%name, 'README.md'), littlefile)
     

--- a/src/fpm/cmd/new.f90
+++ b/src/fpm/cmd/new.f90
@@ -73,6 +73,7 @@ integer,parameter            :: tfc = selected_char_kind('DEFAULT')
 character(len=:,kind=tfc),allocatable :: bname          ! baeename of NAME
 character(len=:,kind=tfc),allocatable :: tomlfile(:)
 character(len=:,kind=tfc),allocatable :: littlefile(:)
+character(len=:,kind=tfc),allocatable :: gitignorefile(:)
 
     !> TOP DIRECTORY NAME PROCESSING
     !> see if requested new directory already exists and process appropriately
@@ -100,9 +101,14 @@ character(len=:,kind=tfc),allocatable :: littlefile(:)
     bname=basename(settings%name)
 
     littlefile=[character(len=80) :: '# '//bname, 'My cool new project!']
-
+    
     ! create NAME/README.md
     call warnwrite(join_path(settings%name, 'README.md'), littlefile)
+    
+    gitignorefile=[character(len=5) :: 'build']
+
+    ! create NAME/.gitignore
+    call warnwrite(join_path(settings%name, '.gitignore'), gitignorefile)
 
     ! start building NAME/fpm.toml
     if(settings%with_full)then

--- a/src/fpm/cmd/update.f90
+++ b/src/fpm/cmd/update.f90
@@ -2,7 +2,7 @@ module fpm_cmd_update
   use fpm_command_line, only : fpm_update_settings
   use fpm_dependency, only : dependency_tree_t, new_dependency_tree
   use fpm_error, only : error_t, fpm_stop
-  use fpm_filesystem, only : exists, mkdir, join_path, delete_file, filewrite
+  use fpm_filesystem, only : exists, mkdir, join_path, delete_file
   use fpm_manifest, only : package_config_t, get_package_data
   implicit none
   private
@@ -26,7 +26,6 @@ contains
 
     if (.not.exists("build")) then
       call mkdir("build")
-      call filewrite(join_path("build", ".gitignore"),["*"])
     end if
 
     cache = join_path("build", "cache.toml")


### PR DESCRIPTION
The `.gitignore` file inside `build` is moved to top-level to keep all the related configuration information in one place. It is created with `fpm new`.

See https://github.com/fortran-lang/fpm/pull/757 for discussion.