### PR TITLE
feat: ability to read project major, minor & patch macros

### DIFF
--- a/example_packages/version_test/fpm.toml
+++ b/example_packages/version_test/fpm.toml
@@ -1,0 +1,5 @@
+name = "version_test"
+version = "0.1.2"
+
+[preprocess]
+[preprocess.cpp]

--- a/example_packages/version_test/src/version_test.f90
+++ b/example_packages/version_test/src/version_test.f90
@@ -1,0 +1,22 @@
+module version_test
+  implicit none
+  private
+
+  public :: say_hello
+contains
+  subroutine say_hello
+    print *, "Hello, version_test!"
+#if PROJECT_VERSION_MAJOR != 0
+      This breaks the build.
+#endif
+
+#if PROJECT_VERSION_MINOR != 1
+      This breaks the build.
+#endif
+
+#if PROJECT_VERSION_PATCH != 2
+      This breaks the build.
+#endif
+
+  end subroutine say_hello
+end module version_test

--- a/src/fpm_targets.f90
+++ b/src/fpm_targets.f90
@@ -30,7 +30,7 @@ use fpm_model
 use fpm_environment, only: get_os_type, OS_WINDOWS, OS_MACOS
 use fpm_filesystem, only: dirname, join_path, canon_path
 use fpm_strings, only: string_t, operator(.in.), string_cat, fnv_1a, resize
-use fpm_compiler, only: get_macros
+use fpm_compiler, only: get_macros, get_version_macros
 implicit none
 
 private
@@ -803,6 +803,9 @@ subroutine resolve_target_linking(targets, model)
             target%compile_flags = target%compile_flags // get_macros(model%compiler%id, &
                                                             target%macros, &
                                                             target%version)
+
+            !> Get Version Macro flags.
+            target%compile_flags = target%compile_flags // get_version_macros(model%compiler%id, target%version)
  
             if (len(global_include_flags) > 0) then
                 target%compile_flags = target%compile_flags//global_include_flags


### PR DESCRIPTION
This Pull Request adds the ability to read the `PROJECT_VERSION_MAJOR,` `PROJECT_VERSION_MINOR` & `PROJECT_VERSION_PATCH` and add them as macros.

Discussed here : https://github.com/fortran-lang/stdlib/pull/675#discussion_r979434567