### PR TITLE
Enable cpp preprocessor flag for dependencies

### DIFF
--- a/ci/run_tests.sh
+++ b/ci/run_tests.sh
@@ -142,6 +142,10 @@ pushd preprocess_cpp_c
 "$fpm" run
 popd
 
+pushd preprocess_cpp_deps
+"$fpm" build
+popd
+
 pushd preprocess_hello
 "$fpm" build
 popd

--- a/example_packages/README.md
+++ b/example_packages/README.md
@@ -27,6 +27,7 @@ the features demonstrated in each package and which versions of fpm are supporte
 | makefile_complex            | External build command (makefile); local path dependency      |            Y            |  N  |
 | preprocess_cpp              | Lib only; C preprocessing; Macro parsing                      |            N            |  Y  |
 | preprocess_cpp_c            | C App; progate macros from fpm.toml to app                    |            N            |  Y  |
+| preprocess_cpp_deps         | App; cpp preprocessor settings in local path dependency only  |            N            |  Y  |
 | preprocess_hello            | App only; Macros remain local to the package                  |            N            |  Y  |
 | preprocess_hello_dependency | Lib only; Macros not getting passed here from root            |            N            |  Y  |
 | program_with_module         | App-only; module+program in single source file                |            Y            |  Y  |

--- a/example_packages/preprocess_cpp_deps/app/main.f90
+++ b/example_packages/preprocess_cpp_deps/app/main.f90
@@ -1,0 +1,6 @@
+program hello_fpm
+    use utils, only: say_hello
+
+    call say_hello()
+
+end program hello_fpm

--- a/example_packages/preprocess_cpp_deps/crate/utils/fpm.toml
+++ b/example_packages/preprocess_cpp_deps/crate/utils/fpm.toml
@@ -1,0 +1,5 @@
+name = "utils"
+
+[preprocess]
+[preprocess.cpp]
+macros = ["X=1"]

--- a/example_packages/preprocess_cpp_deps/crate/utils/src/say_hello.f90
+++ b/example_packages/preprocess_cpp_deps/crate/utils/src/say_hello.f90
@@ -1,0 +1,11 @@
+module utils
+
+    implicit none
+    
+contains
+
+    subroutine say_hello()
+        print '(a,1x,i0)', "Hello, X =", X
+    end subroutine say_hello
+
+end module utils

--- a/example_packages/preprocess_cpp_deps/fpm.toml
+++ b/example_packages/preprocess_cpp_deps/fpm.toml
@@ -1,0 +1,4 @@
+name = "preprocess_cpp_deps"
+
+[dependencies]
+utils = { path = "crate/utils" }

--- a/src/fpm.f90
+++ b/src/fpm.f90
@@ -12,7 +12,7 @@ use fpm_filesystem, only: is_dir, join_path, list_files, exists, &
 use fpm_model, only: fpm_model_t, srcfile_t, show_model, &
                     FPM_SCOPE_UNKNOWN, FPM_SCOPE_LIB, FPM_SCOPE_DEP, &
                     FPM_SCOPE_APP, FPM_SCOPE_EXAMPLE, FPM_SCOPE_TEST
-use fpm_compiler, only: new_compiler, new_archiver, set_preprocessor_flags
+use fpm_compiler, only: new_compiler, new_archiver, set_cpp_preprocessor_flags
 
 
 use fpm_sources, only: add_executable_sources, add_sources_from_dir
@@ -45,6 +45,7 @@ subroutine build_model(model, settings, package, error)
     type(package_config_t) :: dependency
     character(len=:), allocatable :: manifest, lib_dir, flags, cflags, cxxflags, ldflags
     character(len=:), allocatable :: version
+    logical :: has_cpp
 
     logical :: duplicates_found = .false.
     type(string_t) :: include_dir
@@ -79,8 +80,6 @@ subroutine build_model(model, settings, package, error)
         end select
     end if
 
-    call set_preprocessor_flags(model%compiler%id, flags, package)
-
     cflags = trim(settings%cflag)
     cxxflags = trim(settings%cxxflag)
     ldflags = trim(settings%ldflag)
@@ -92,15 +91,11 @@ subroutine build_model(model, settings, package, error)
     end if
     model%build_prefix = join_path("build", basename(model%compiler%fc))
 
-    model%fortran_compile_flags = flags
-    model%c_compile_flags = cflags
-    model%cxx_compile_flags = cxxflags
-    model%link_flags = ldflags
-
     model%include_tests = settings%build_tests
 
     allocate(model%packages(model%deps%ndep))
 
+    has_cpp = .false.
     do i = 1, model%deps%ndep
         associate(dep => model%deps%dep(i))
             manifest = join_path(dep%proj_dir, "fpm.toml")
@@ -115,8 +110,14 @@ subroutine build_model(model, settings, package, error)
             
             if (allocated(dependency%preprocess)) then
                 do j = 1, size(dependency%preprocess)
-                    if (package%preprocess(j)%name == "cpp" .and. allocated(dependency%preprocess(j)%macros)) then
+                    if (dependency%preprocess(j)%name == "cpp") then
+                        if (.not. has_cpp) has_cpp = .true.
+                        if (allocated(dependency%preprocess(j)%macros)) then
                         model%packages(i)%macros = dependency%preprocess(j)%macros
+                        end if
+                    else
+                        write(stderr, '(a)') 'Warning: Preprocessor ' // package%preprocess(i)%name // &
+                            ' is not supported; will ignore it'
                     end if
                 end do
             end if
@@ -155,6 +156,12 @@ subroutine build_model(model, settings, package, error)
         end associate
     end do
     if (allocated(error)) return
+
+    if (has_cpp) call set_cpp_preprocessor_flags(model%compiler%id, flags)
+    model%fortran_compile_flags = flags
+    model%c_compile_flags = cflags
+    model%cxx_compile_flags = cxxflags
+    model%link_flags = ldflags
 
     ! Add sources from executable directories
     if (is_dir('app') .and. package%build%auto_executables) then

--- a/src/fpm_compiler.f90
+++ b/src/fpm_compiler.f90
@@ -394,18 +394,10 @@ subroutine get_debug_compile_flags(id, flags)
     end select
 end subroutine get_debug_compile_flags
 
-subroutine set_preprocessor_flags (id, flags, package)
+pure subroutine set_cpp_preprocessor_flags(id, flags)
     integer(compiler_enum), intent(in) :: id
     character(len=:), allocatable, intent(inout) :: flags
-    type(package_config_t), intent(in) :: package
     character(len=:), allocatable :: flag_cpp_preprocessor
-    
-    integer :: i
-
-    !> Check if there is a preprocess table
-    if (.not.allocated(package%preprocess)) then
-        return
-    end if
 
     !> Modify the flag_cpp_preprocessor on the basis of the compiler.
     select case(id)
@@ -421,16 +413,9 @@ subroutine set_preprocessor_flags (id, flags, package)
         flag_cpp_preprocessor = "--cpp"
     end select
 
-    do i = 1, size(package%preprocess)
-        if (package%preprocess(i)%name == "cpp") then
-            flags = flag_cpp_preprocessor// flags
-            exit
-        else
-            write(stderr, '(a)') 'Warning: preprocessor ' // package%preprocess(i)%name // ' is not supported; will ignore it'
-        end if
-    end do
+    flags = flag_cpp_preprocessor// flags
 
-end subroutine set_preprocessor_flags
+end subroutine set_cpp_preprocessor_flags
 
 !> This function will parse and read the macros list and 
 !> return them as defined flags.


### PR DESCRIPTION
- [x] Use `has_cpp` to handle the `cpp` preprocessor settings for dependency occurrences, thus activating `cpp` flags;
- [x] Modify subroutine `set_preprocessor_flags` to `set_cpp_preprocessor_flags`
- [x] Add a example package: `preprocess_cpp_deps`;
- [x] Fix #782.

### Description

All dependencies are accessed in the `do` loop, so check whether there are any cpp preprocessor settings in the loop.
