### PR TITLE
Bump version to 0.7.0

### DIFF
--- a/fpm.toml
+++ b/fpm.toml
@@ -1,5 +1,5 @@
 name = "fpm"
-version = "0.6.0"
+version = "0.7.0"
 license = "MIT"
 author = "fpm maintainers"
 maintainer = ""

--- a/src/fpm_command_line.f90
+++ b/src/fpm_command_line.f90
@@ -223,7 +223,7 @@ contains
         end select
         unix = os_is_unix(os)
         version_text = [character(len=80) :: &
-         &  'Version:     0.6.0, alpha',                               &
+         &  'Version:     0.7.0, alpha',                               &
          &  'Program:     fpm(1)',                                     &
          &  'Description: A Fortran package manager and build system', &
          &  'Home Page:   https://github.com/fortran-lang/fpm',        &


### PR DESCRIPTION
Test release at: https://github.com/gnikit/fpm/releases/tag/v0.7.0

PR merge instructions: https://github.com/fortran-lang/fpm/wiki/Release-Process

----

As a result of discussion in https://fortran-lang.discourse.group/t/should-fpm-release-versions-more-often/4596 to get features from main and Current release to the conda-forge, homebrew, etc.

## Summary:

- C++ support
- C preprocessor bug fixes
- Minor bug fixes