### PR TITLE
the C++ compiler is clang++

### DIFF
--- a/src/fpm_compiler.f90
+++ b/src/fpm_compiler.f90
@@ -599,7 +599,7 @@ subroutine get_default_cxx_compiler(f_compiler, cxx_compiler)
         cxx_compiler = 'icpx'
 
     case(id_flang, id_flang_new, id_f18)
-        cxx_compiler='clang'
+        cxx_compiler='clang++'
 
     case(id_ibmxl)
         cxx_compiler='xlc++'


### PR DESCRIPTION
it seems to me that the C++ compiler is expected to be `clang++` (and not `clang`).

it looks like a typo to me.