### PR TITLE
properly document FPM_CXX, FPM_CXXFLAGS and options

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -48,6 +48,7 @@ jobs:
     - name: Install GFortran macOS
       if: contains(matrix.os, 'macos')
       run: |
+        brew install gcc@${GCC_V}
         ln -s /usr/local/bin/gfortran-${GCC_V} /usr/local/bin/gfortran
         which gfortran-${GCC_V}
         which gfortran

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -21,14 +21,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-11, windows-latest]
         gcc_v: [9] # Version of GFortran we want to use.
         include:
         - os: ubuntu-latest
           os-arch: linux-x86_64
           release-flags: --flag '--static -g -fbacktrace -O3'
 
-        - os: macos-latest
+        - os: macos-11
           os-arch: macos-x86_64
           release-flags: --flag '-g -fbacktrace -O3'
 
@@ -48,7 +48,6 @@ jobs:
     - name: Install GFortran macOS
       if: contains(matrix.os, 'macos')
       run: |
-        brew install gcc@${GCC_V}
         ln -s /usr/local/bin/gfortran-${GCC_V} /usr/local/bin/gfortran
         which gfortran-${GCC_V}
         which gfortran

--- a/README.md
+++ b/README.md
@@ -182,11 +182,13 @@ The table below lists the environment variables that control `fpm`'s choice of c
 compiler flags, archiver locations, and link flags, each of which can be overridden by 
 passing `fpm` flags also shown in the table.
 
-| Environment Variable | Defines               | Overridden by  |
-| :------------------- | :-------------------- | :------------- |
-| `FPM_FC`             | Fortran compiler path | `--compiler`   |
-| `FPM_CC`             | C compiler path       | `--c-compiler` |
-| `FPM_FFLAGS`         | Fortran compiler flags| `--flag`       |
-| `FPM_CFLAGS`         | C compiler flags      | `--c-flag`     |
-| `FPM_AR`             | Archiver path         | `--archiver`   |
-| `FPM_LDFLAGS`        | Link flags            | `--link-flag`  |
+| Environment Variable | Defines               | Overridden by    |
+| :------------------- | :-------------------- | :--------------- |
+| `FPM_FC`             | Fortran compiler path | `--compiler`     |
+| `FPM_CC`             | C compiler path       | `--c-compiler`   |
+| `FPM_CXX`            | C++ compiler path     | `--cxx-compiler` |
+| `FPM_FFLAGS`         | Fortran compiler flags| `--flag`         |
+| `FPM_CFLAGS`         | C compiler flags      | `--c-flag`       |
+| `FPM_CXXFLAGS`       | C++ compiler flags    | `--cxx-flag`     |
+| `FPM_AR`             | Archiver path         | `--archiver`     |
+| `FPM_LDFLAGS`        | Link flags            | `--link-flag`    |

--- a/src/fpm_command_line.f90
+++ b/src/fpm_command_line.f90
@@ -148,6 +148,8 @@ character(len=80), parameter :: help_text_compiler(*) = [character(len=80) :: &
     '                    unless set by the environment variable FPM_FC.              ',&
     ' --c-compiler NAME  Specify the C compiler name. Automatically determined by    ',&
     '                    default unless set by the environment variable FPM_CC.      ',&
+    ' --cxx-compiler NAME  Specify the C++ compiler name. Automatically determined by',&
+    '                    default unless set by the environment variable FPM_CXX.     ',&
     ' --archiver NAME    Specify the archiver name. Automatically determined by      ',&
     '                    default unless set by the environment variable FPM_AR.      '&
     ]
@@ -162,6 +164,9 @@ character(len=80), parameter :: help_text_flag(*) = [character(len=80) :: &
     ' --c-flag CFLAGS   selects compile arguments specific for C source in the build.',&
     '                   The default value is set by the FPM_CFLAGS environment       ',&
     '                   variable.                                                    ',&
+    ' --cxx-flag CFLAGS selects compile arguments specific for C++ source in the     ',&
+    '                   build. The default value is set by the FPM_CXXFLAGS          ',&
+    '                   environment variable.                                        ',&
     ' --link-flag LDFLAGS  select arguments passed to the linker for the build. The  ',&
     '                   default value is set by the FPM_LDFLAGS environment variable.'&
     ]
@@ -180,6 +185,12 @@ character(len=80), parameter :: help_text_environment(*) = [character(len=80) ::
     '', &
     ' FPM_CFLAGS        sets the arguments for the C compiler', &
     '                   will be overwritten by --c-flag command line option', &
+    '', &
+    ' FPM_CXX           sets the path to the C++ compiler used for the build,', &
+    '                   will be overwritten by --cxx-compiler command line option', &
+    '', &
+    ' FPM_CXXFLAGS      sets the arguments for the C++ compiler', &
+    '                   will be overwritten by --cxx-flag command line option', &
     '', &
     ' FPM_AR            sets the path to the archiver used for the build,', &
     '                   will be overwritten by --archiver command line option', &


### PR DESCRIPTION
`fpm` doesn't document C++ compiler / flags neither in `README.md` neither in `fpm help` output.

the following PR adds it.