### PR TITLE
fix 32-bit platform issues with M_CLI2

### DIFF
--- a/fpm.toml
+++ b/fpm.toml
@@ -12,7 +12,7 @@ rev = "e49f5523e4ee67db6628618864504448fb8c8939"
 
 [dependencies.M_CLI2]
 git = "https://github.com/urbanjost/M_CLI2.git"
-rev = "ea6bbffc1c2fb0885e994d37ccf0029c99b19f24"
+rev = "90a1a146e19c8ad37b0469b8cbd04bc28eb67a50"
 
 [[test]]
 name = "cli-test"

--- a/fpm.toml
+++ b/fpm.toml
@@ -12,7 +12,7 @@ rev = "e49f5523e4ee67db6628618864504448fb8c8939"
 
 [dependencies.M_CLI2]
 git = "https://github.com/urbanjost/M_CLI2.git"
-rev = "90a1a146e19c8ad37b0469b8cbd04bc28eb67a50"
+rev = "7264878cdb1baff7323cc48596d829ccfe7751b8"
 
 [[test]]
 name = "cli-test"


### PR DESCRIPTION
Tests of fpm on i-386 versions of OpenBSD exposed an error in the M_CLI2 procedure locate_c where, when calculating the maximum number of times to split the search in a binary search for keywords the function INT instead of NINT was used; which on 32-bit platforms caused the value to be low by one due to truncation.  Newer versions of M_CLI2 has this fixed. Changing the fpm.toml file to use a newer version

should fix #795 