### PR TITLE
Improve error handling for invalid `git` dependencies

### DIFF
--- a/src/fpm/manifest/dependency.f90
+++ b/src/fpm/manifest/dependency.f90
@@ -148,25 +148,18 @@ contains
                 call syntax_error(error, "Key "//list(ikey)%key//" is not allowed in dependency "//name)
                 exit
 
-            case("git")
+            case("git", "path")
                 if (url_present) then
                     call syntax_error(error, "Dependency "//name//" cannot have both git and path entries")
                     exit
                 end if
                 call get_value(table, "git", url)
                 if (.not.allocated(url)) then
-                    call syntax_error(error, "Dependency "//name//" has invalid git source")
+                    call syntax_error(error, "Dependency "//name//" has invalid source")
                     exit
                 end if
                 url_present = .true.
-                
-            case("path")
-                if (url_present) then
-                    call syntax_error(error, "Dependency "//name//" cannot have both git and path entries")
-                    exit
-                end if
-                url_present = .true.
-                has_path = .true.
+                has_path = list(ikey)%key == 'path'
 
             case("branch", "rev", "tag")
                 if (git_target_present) then

--- a/src/fpm/manifest/dependency.f90
+++ b/src/fpm/manifest/dependency.f90
@@ -148,18 +148,25 @@ contains
                 call syntax_error(error, "Key "//list(ikey)%key//" is not allowed in dependency "//name)
                 exit
 
-            case("git", "path")
+            case("git")
                 if (url_present) then
                     call syntax_error(error, "Dependency "//name//" cannot have both git and path entries")
                     exit
                 end if
                 call get_value(table, "git", url)
                 if (.not.allocated(url)) then
-                    call syntax_error(error, "Dependency "//name//" has invalid source")
+                    call syntax_error(error, "Dependency "//name//" has invalid git source")
                     exit
                 end if
                 url_present = .true.
-                has_path = list(ikey)%key == 'path'
+                
+            case("path")
+                if (url_present) then
+                    call syntax_error(error, "Dependency "//name//" cannot have both git and path entries")
+                    exit
+                end if
+                url_present = .true.
+                has_path = .true.
 
             case("branch", "rev", "tag")
                 if (git_target_present) then

--- a/test/fpm_test/test_manifest.f90
+++ b/test/fpm_test/test_manifest.f90
@@ -354,18 +354,20 @@ contains
     !> Try to create a git dependency with invalid source format
     subroutine test_dependency_invalid_git(error)
         use fpm_manifest_dependency
-        use fpm_toml, only : new_table, toml_table, set_value
+        use fpm_toml, only : new_table, add_table, toml_table, set_value
 
         !> Error handling
         type(error_t), allocatable, intent(out) :: error
 
         type(toml_table) :: table
+        type(toml_table), pointer :: child
         integer :: stat
         type(dependency_config_t) :: dependency
-
+        
         call new_table(table)
         table%key = 'example'
-        call set_value(table, 'git', '{ path = "../../package" }', stat)
+        call add_table(table, 'git', child)
+        call set_value(child, 'path', '../../package')
 
         call new_dependency(dependency, table, error=error)
 

--- a/test/fpm_test/test_manifest.f90
+++ b/test/fpm_test/test_manifest.f90
@@ -31,6 +31,7 @@ contains
             & new_unittest("dependency-gitpath", test_dependency_gitpath, should_fail=.true.), &
             & new_unittest("dependency-nourl", test_dependency_nourl, should_fail=.true.), &
             & new_unittest("dependency-gitconflict", test_dependency_gitconflict, should_fail=.true.), &
+            & new_unittest("dependency-invalid-git", test_dependency_invalid_git, should_fail=.true.), &
             & new_unittest("dependency-wrongkey", test_dependency_wrongkey, should_fail=.true.), &
             & new_unittest("dependencies-empty", test_dependencies_empty), &
             & new_unittest("dependencies-typeerror", test_dependencies_typeerror, should_fail=.true.), &
@@ -348,6 +349,27 @@ contains
         call new_dependency(dependency, table, error=error)
 
     end subroutine test_dependency_gitconflict
+
+
+    !> Try to create a git dependency with invalid source format
+    subroutine test_dependency_invalid_git(error)
+        use fpm_manifest_dependency
+        use fpm_toml, only : new_table, toml_table, set_value
+
+        !> Error handling
+        type(error_t), allocatable, intent(out) :: error
+
+        type(toml_table) :: table
+        integer :: stat
+        type(dependency_config_t) :: dependency
+
+        call new_table(table)
+        table%key = 'example'
+        call set_value(table, 'git', '{ path = "../../package" }', stat)
+
+        call new_dependency(dependency, table, error=error)
+
+    end subroutine test_dependency_invalid_git
 
 
     !> Try to create a dependency with conflicting entries

--- a/test/fpm_test/test_manifest.f90
+++ b/test/fpm_test/test_manifest.f90
@@ -363,7 +363,7 @@ contains
         type(toml_table), pointer :: child
         integer :: stat
         type(dependency_config_t) :: dependency
-        
+
         call new_table(table)
         table%key = 'example'
         call add_table(table, 'git', child)


### PR DESCRIPTION
Checks for a valid `git` dependency and improves the error message if the dependency couldn't get resolved.

Tackles https://github.com/fortran-lang/fpm/issues/724.