### PR TITLE
fpm_environment: lower windows check precedence in get_os_type function

### DIFF
--- a/src/fpm_environment.f90
+++ b/src/fpm_environment.f90
@@ -51,15 +51,6 @@ contains
         first_run = .false.
         r = OS_UNKNOWN
 
-        ! Check environment variable `OS`.
-        call get_environment_variable('OS', val, length, rc)
-
-        if (rc == 0 .and. length > 0 .and. index(val, 'Windows_NT') > 0) then
-            r = OS_WINDOWS
-            ret = r
-            return
-        end if
-
         ! Check environment variable `OSTYPE`.
         call get_environment_variable('OSTYPE', val, length, rc)
 
@@ -112,6 +103,15 @@ contains
                 ret = r
                 return
             end if
+        end if
+
+        ! Check environment variable `OS`.
+        call get_environment_variable('OS', val, length, rc)
+
+        if (rc == 0 .and. length > 0 .and. index(val, 'Windows_NT') > 0) then
+            r = OS_WINDOWS
+            ret = r
+            return
         end if
 
         ! Linux


### PR DESCRIPTION
- partially fixes #242 

I have lowered the precedence of the windows check so that this problem does not occur in `cygwin`. 

Known issues:
- `MINGW` still poses an issue as mentioned in https://github.com/fortran-lang/fpm/issues/242#issuecomment-728936642

I am not sure how to fix the issue for `MINGW`. If someone can guide me, I will be happy to fix it.