### PR TITLE
Capitalize `local` folder on Windows

### DIFF
--- a/src/fpm/installer.f90
+++ b/src/fpm/installer.f90
@@ -173,7 +173,7 @@ contains
     else
       call env_variable(home, "APPDATA")
       if (allocated(home)) then
-        prefix = join_path(home, "local")
+        prefix = join_path(home, "Local")
       else
         prefix = default_prefix_win
       end if


### PR DESCRIPTION
Capitalize `local` folder (`%APPDATA%\local` -> `%APPDATA%\Local`) on Windows.