### PR TITLE
Fix the build on macOS PPC

### DIFF
--- a/src/filesystem_utilities.c
+++ b/src/filesystem_utilities.c
@@ -1,7 +1,7 @@
 #include <sys/stat.h>
 #include <dirent.h>
 
-#if defined(__APPLE__) && !defined(__aarch64__)
+#if defined(__APPLE__) && !defined(__aarch64__) && !defined(__POWERPC__)
 DIR * opendir$INODE64( const char * dirName );
 struct dirent * readdir$INODE64( DIR * dir );
 #define opendir opendir$INODE64


### PR DESCRIPTION
As is, the build fails for PPC:
```
Undefined symbols:
  "_opendir$INODE64", referenced from:
      _c_opendir in libfpm.a(src_filesystem_utilities.c.o)
ld: symbol(s) not found
```
Condition in `filesystem_utilities.c` is wrong, it should be Intel-only, excluding PPC as well, not just Apple M.
This PR fixes that.