### PR TITLE
Consistently call execute_command_line(3f) from the run(3f) wrapper

### DIFF
--- a/src/fpm/error.f90
+++ b/src/fpm/error.f90
@@ -166,12 +166,16 @@ contains
         integer, intent(in) :: value
         !> Error message
         character(len=*), intent(in) :: message
+        integer :: iostat
         if(message/='')then
+           flush(unit=stderr,iostat=iostat)
+           flush(unit=stdout,iostat=iostat)
            if(value>0)then
               write(stderr,'("<ERROR>",a)')trim(message)
            else
               write(stderr,'("<INFO> ",a)')trim(message)
            endif
+           flush(unit=stderr,iostat=iostat)
         endif
         stop value
     end subroutine fpm_stop


### PR DESCRIPTION
Tracebacks from system commands are generally not useful to the user. And the tracebacks generally go to stderr. In one recent issue the user was not capturing stderr, which resulted in just a message compiling was begun and nothing else (the compiler command was not in the user path). Changing all the calls in fpm_filesystem.f90 to use the run(3f) procedure and capturing and printing cmdmsg from execute_command_line(3f) creates a cleaner and more understandable message. System command issues such as missing commands, file system permission problems, full filesystems, ... generate a cleaner and more useful user message.

Using run(3f) for all the calls also gives a single point of command execution for future consistent behavior and for easier debugging. Custom options such as echo mode, colorizing messages, verbose mode, ... do not require duplicate code and can be consistently applied using the run(3f) wrapper. So this lays the groundwork for some future enhancements as well.

Flushing stdout and stderr in fpm_stop(3f) helps the messages appear synchronously, so the error message appears at the expected point in the output as well.

See [#830](https://github.com/fortran-lang/fpm/issues/830) for an example of an issue where this would have helped.

The following example illustrates the difference when the compiler (ifort(1) in this case) is not in the path. This would apply to any system command failure, but it captures the idea and duplicates the actual case in #830 ...

```text
fpm728 test --compiler ifort
fpm: Entering directory '/home/urbanjs/venus/V600/REMOVE/fpm'
2K1Gfilesystem_utilities.c		   93mcompiling...0m
2K1G[  0%] Compiling...Fortran runtime error: EXECUTE_COMMAND_LINE: Invalid command line

Error termination. Backtrace:
	at ./src/fpm_filesystem.F90:907
	at ./src/fpm_compiler.f90:866
	at ./src/fpm_backend.F90:324
	at ./src/fpm_backend.F90:125
	at ./src/fpm.f90:439
	at app/main.f90:72
	at app/main.f90:11
```

```text
fpm test --compiler ifort
fpm: Entering directory '/home/urbanjs/venus/V600/REMOVE/fpm'
2K1Gfilesystem_utilities.c		   93mcompiling...0m
2K1G[  0%] Compiling...<ERROR> failed command: icc -c ./src/filesystem_utilities.c  -o build/ifort_00000000811C9DC5/fpm/src_filesystem_utilities.c.o>build/ifort_00000000811C9DC5/fpm/src_filesystem_utilities.c.o.log 2>&1
<ERROR>*run*:Invalid command line
STOP 1
```