### PR TITLE
Install script: fix query latest release from GitHub on missing curl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@ build/*
 
 # Visual Studio Code
 .vscode/
+
+# CodeBlocks
+project/*

--- a/install.sh
+++ b/install.sh
@@ -18,6 +18,15 @@ usage()
     echo ""
 }
 
+# Return value of the latest published release on GitHub, with no heading "v" (e.g., "0.7.0")
+get_latest_release()
+{
+     curl --silent "https://api.github.com/repos/$1/releases/latest" | # Get latest release from GitHub api
+     grep '"tag_name":'        |                                       # Get tag line
+     sed -E 's/.*"([^"]+)".*/\1/' |                                    # Pluck JSON value
+     sed -E 's/^v//'                                                   # Remove heading "v" if present
+}
+
 PREFIX="$HOME/.local"
 
 while [ "$1" != "" ]; do
@@ -42,7 +51,8 @@ done
 
 set -u # error on use of undefined variable
 
-SOURCE_URL="https://github.com/fortran-lang/fpm/releases/download/v0.6.0/fpm-0.6.0.F90"
+LATEST_RELEASE=$(get_latest_release "fortran-lang/fpm")
+SOURCE_URL="https://github.com/fortran-lang/fpm/releases/download/v${LATEST_RELEASE}/fpm-${LATEST_RELEASE}.F90"
 BOOTSTRAP_DIR="build/bootstrap"
 if [ -z ${FC+x} ]; then
     FC="gfortran"

--- a/install.sh
+++ b/install.sh
@@ -24,12 +24,12 @@ get_latest_release()
 
      # Check if curl is installed
     if command -v curl > /dev/null 2>&1; then
-       curl --silent " https://api.github.com/repos/$1/releases/latest" | # Get latest release from GitHub api
+       curl --silent "https://api.github.com/repos/$1/releases/latest" | # Get latest release from GitHub api
        grep '"tag_name":'        |                                       # Get tag line
        sed -E 's/.*"([^"]+)".*/\1/' |                                    # Pluck JSON value
        sed -E 's/^v//'                                                   # Remove heading "v" if present
     elif command -v wget > /dev/null 2>&1; then
-       wget -O- " https://api.github.com/repos/$1/releases/latest" | # Get latest release from GitHub api
+       wget -q -O- "https://api.github.com/repos/$1/releases/latest" | # Get latest release from GitHub api
        grep '"tag_name":'        |                                       # Get tag line
        sed -E 's/.*"([^"]+)".*/\1/' |                                    # Pluck JSON value
        sed -E 's/^v//'                                                   # Remove heading "v" if present
@@ -67,6 +67,7 @@ set -u # error on use of undefined variable
 LATEST_RELEASE=$(get_latest_release "fortran-lang/fpm")
 SOURCE_URL="https://github.com/fortran-lang/fpm/releases/download/v${LATEST_RELEASE}/fpm-${LATEST_RELEASE}.F90"
 BOOTSTRAP_DIR="build/bootstrap"
+
 if [ -z ${FC+x} ]; then
     FC="gfortran"
 fi

--- a/install.sh
+++ b/install.sh
@@ -21,10 +21,23 @@ usage()
 # Return value of the latest published release on GitHub, with no heading "v" (e.g., "0.7.0")
 get_latest_release()
 {
-     curl --silent "https://api.github.com/repos/$1/releases/latest" | # Get latest release from GitHub api
-     grep '"tag_name":'        |                                       # Get tag line
-     sed -E 's/.*"([^"]+)".*/\1/' |                                    # Pluck JSON value
-     sed -E 's/^v//'                                                   # Remove heading "v" if present
+
+     # Check if curl is installed
+    if command -v curl > /dev/null 2>&1; then
+       curl --silent " https://api.github.com/repos/$1/releases/latest" | # Get latest release from GitHub api
+       grep '"tag_name":'        |                                       # Get tag line
+       sed -E 's/.*"([^"]+)".*/\1/' |                                    # Pluck JSON value
+       sed -E 's/^v//'                                                   # Remove heading "v" if present
+    elif command -v wget > /dev/null 2>&1; then
+       wget -O- " https://api.github.com/repos/$1/releases/latest" | # Get latest release from GitHub api
+       grep '"tag_name":'        |                                       # Get tag line
+       sed -E 's/.*"([^"]+)".*/\1/' |                                    # Pluck JSON value
+       sed -E 's/^v//'                                                   # Remove heading "v" if present
+    else
+       # Fallback to a known working version
+       echo "0.6.0"
+    fi
+
 }
 
 PREFIX="$HOME/.local"

--- a/install.sh
+++ b/install.sh
@@ -18,24 +18,26 @@ usage()
     echo ""
 }
 
+# Return a download command
+get_fetch_command()
+{
+    if command -v curl > /dev/null 2>&1; then
+        echo "curl -L"
+    elif command -v wget > /dev/null 2>&1; then
+        echo "wget -O -"
+    else
+        echo "No download mechanism found. Install curl or wget first."
+        return 1
+    fi
+}
+
 # Return value of the latest published release on GitHub, with no heading "v" (e.g., "0.7.0")
 get_latest_release()
 {
-     # Check if curl is installed
-    if command -v curl > /dev/null 2>&1; then
-       curl --silent "https://api.github.com/repos/$1/releases/latest" | # Get latest release from GitHub api
-       grep '"tag_name":'        |                                       # Get tag line
-       sed -E 's/.*"([^"]+)".*/\1/' |                                    # Pluck JSON value
-       sed -E 's/^v//'                                                   # Remove heading "v" if present
-    elif command -v wget > /dev/null 2>&1; then
-       wget -q -O- "https://api.github.com/repos/$1/releases/latest" | # Get latest release from GitHub api
-       grep '"tag_name":'        |                                       # Get tag line
-       sed -E 's/.*"([^"]+)".*/\1/' |                                    # Pluck JSON value
-       sed -E 's/^v//'                                                   # Remove heading "v" if present
-    else
-       # Fallback to a known working version
-       echo "0.6.0"
-    fi
+     $2 "https://api.github.com/repos/$1/releases/latest" | # Get latest release from GitHub api
+     grep '"tag_name":'        |                            # Get tag line
+     sed -E 's/.*"([^"]+)".*/\1/' |                         # Pluck JSON value
+     sed -E 's/^v//'                                        # Remove heading "v" if present
 }
 
 PREFIX="$HOME/.local"
@@ -62,7 +64,14 @@ done
 
 set -u # error on use of undefined variable
 
-LATEST_RELEASE=$(get_latest_release "fortran-lang/fpm")
+# Get download command
+FETCH=$(get_fetch_command)
+if [ $? -ne 0 ]; then
+  echo "No download mechanism found. Install curl or wget first."
+  exit 1
+fi
+
+LATEST_RELEASE=$(get_latest_release "fortran-lang/fpm" $FETCH)
 SOURCE_URL="https://github.com/fortran-lang/fpm/releases/download/v${LATEST_RELEASE}/fpm-${LATEST_RELEASE}.F90"
 BOOTSTRAP_DIR="build/bootstrap"
 
@@ -74,15 +83,6 @@ if [ -z ${FFLAGS+x} ]; then
 fi
 
 mkdir -p $BOOTSTRAP_DIR
-
-if command -v curl > /dev/null 2>&1; then
-    FETCH="curl -L"
-elif command -v wget > /dev/null 2>&1; then
-    FETCH="wget -O -"
-else
-    echo "No download mechanism found. Install curl or wget first."
-    exit 1
-fi
 
 $FETCH $SOURCE_URL > $BOOTSTRAP_DIR/fpm.F90
 


### PR DESCRIPTION
Improve the command to query the latest release version from Github by trying curl then wget; with fallback to the last known version release if none of the two commands is available