### PR TITLE
`install.sh`: fix broken `wget` in install script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -71,7 +71,13 @@ if [ $? -ne 0 ]; then
   exit 1
 fi
 
-LATEST_RELEASE=$(get_latest_release "fortran-lang/fpm" $FETCH)
+LATEST_RELEASE=$(get_latest_release "fortran-lang/fpm" "$FETCH")
+
+if [ -z "$LATEST_RELEASE" ]; then
+  echo "Could not fetch the latest release from GitHub. Install curl or wget, and ensure network connectivity."
+  exit 1
+fi
+
 SOURCE_URL="https://github.com/fortran-lang/fpm/releases/download/v${LATEST_RELEASE}/fpm-${LATEST_RELEASE}.F90"
 BOOTSTRAP_DIR="build/bootstrap"
 

--- a/install.sh
+++ b/install.sh
@@ -68,14 +68,14 @@ set -u # error on use of undefined variable
 FETCH=$(get_fetch_command)
 if [ $? -ne 0 ]; then
   echo "No download mechanism found. Install curl or wget first."
-  exit 1
+  exit 2
 fi
 
 LATEST_RELEASE=$(get_latest_release "fortran-lang/fpm" "$FETCH")
 
 if [ -z "$LATEST_RELEASE" ]; then
   echo "Could not fetch the latest release from GitHub. Install curl or wget, and ensure network connectivity."
-  exit 1
+  exit 3
 fi
 
 SOURCE_URL="https://github.com/fortran-lang/fpm/releases/download/v${LATEST_RELEASE}/fpm-${LATEST_RELEASE}.F90"


### PR DESCRIPTION
install.sh: quote `"$FETCH"` to pass it as a single string, as passing `$FETCH` would split the command as different arguments. If so, wget would dump to a local file instead of stdout, which breaks the install script. 

Also put one more check.

cf. #836 