### PR TITLE
Library configuration: allow multiple source directories

### DIFF
--- a/ci/run_tests.sh
+++ b/ci/run_tests.sh
@@ -158,5 +158,11 @@ pushd cpp_files
 "$fpm" test
 popd
 
+pushd many_source_folders
+"$fpm" build
+"$fpm" run
+"$fpm" test
+popd
+
 # Cleanup
 rm -rf ./*/build

--- a/example_packages/README.md
+++ b/example_packages/README.md
@@ -25,6 +25,7 @@ the features demonstrated in each package and which versions of fpm are supporte
 | link_executable             | Link external library to a single executable                  |            N            |  Y  |
 | link_external               | Link external library                                         |            N            |  Y  |
 | makefile_complex            | External build command (makefile); local path dependency      |            Y            |  N  |
+| many_source_folders         | Source files split among multiple directories                 |            N            |  Y  |
 | preprocess_cpp              | Lib only; C preprocessing; Macro parsing                      |            N            |  Y  |
 | preprocess_cpp_c            | C App; progate macros from fpm.toml to app                    |            N            |  Y  |
 | preprocess_cpp_deps         | App; cpp preprocessor settings in local path dependency only  |            N            |  Y  |

--- a/example_packages/many_source_folders/README.md
+++ b/example_packages/many_source_folders/README.md
@@ -1,0 +1,2 @@
+# two_exe_dirs
+My cool new project!

--- a/example_packages/many_source_folders/fpm.toml
+++ b/example_packages/many_source_folders/fpm.toml
@@ -1,0 +1,19 @@
+name = "two_exe_dirs"
+version = "0.1.0"
+license = "license"
+author = "Federico Perini"
+maintainer = "federico.perini@gmail.com"
+copyright = "Copyright 2023, Federico Perini"
+[build]
+auto-executables = false
+auto-tests = true 
+auto-examples = true
+[install]
+library = false
+[[executable]]
+name="test_main"
+source-dir=["src","src2"]
+[[test]]
+name="test_modules"
+main="test.f90"
+source-dir=["test","test2"] 

--- a/example_packages/many_source_folders/fpm.toml
+++ b/example_packages/many_source_folders/fpm.toml
@@ -15,5 +15,5 @@ name="test_main"
 source-dir=["src","src2"]
 [[test]]
 name="test_modules"
-main="test.f90"
+main="check.f90"
 source-dir=["test","test2"] 

--- a/example_packages/many_source_folders/src/mod1.f90
+++ b/example_packages/many_source_folders/src/mod1.f90
@@ -1,0 +1,10 @@
+module mod1 
+  implicit none
+  private
+
+  public :: say_hello
+contains
+  subroutine say_hello
+    print *, "Hello, from folder src/ !" 
+  end subroutine say_hello
+end module mod1

--- a/example_packages/many_source_folders/src2/main.f90
+++ b/example_packages/many_source_folders/src2/main.f90
@@ -1,0 +1,8 @@
+program main2
+  use mod1 
+  use mod2
+  implicit none
+
+  call say_hello()
+  call say_hello2() 
+end program main2

--- a/example_packages/many_source_folders/src2/mod2.f90
+++ b/example_packages/many_source_folders/src2/mod2.f90
@@ -1,0 +1,10 @@
+module mod2 
+  implicit none
+  private
+
+  public :: say_hello2
+contains
+  subroutine say_hello2
+    print *, "Hello, from folder src2/ !"
+  end subroutine say_hello2
+end module mod2

--- a/example_packages/many_source_folders/test/check.f90
+++ b/example_packages/many_source_folders/test/check.f90
@@ -1,0 +1,17 @@
+program test_many_folders
+use mod1
+use mod2
+use test1
+use test2
+implicit none
+
+call say_hello()
+call say_hello2()
+print *, "All source modules found!"
+
+call print_test1()
+call print_test2()
+
+stop 0
+
+end program check

--- a/example_packages/many_source_folders/test/check.f90
+++ b/example_packages/many_source_folders/test/check.f90
@@ -11,7 +11,8 @@ print *, "All source modules found!"
 
 call print_test1()
 call print_test2()
+print *, "All test modules found!"
 
 stop 0
 
-end program check
+end program test_many_folders

--- a/example_packages/many_source_folders/test/test1.f90
+++ b/example_packages/many_source_folders/test/test1.f90
@@ -1,6 +1,6 @@
 module test1
    contains
-   subroutine print_test()
+   subroutine print_test1()
       print *, "Hello, from test folder test/ ! "
    end subroutine
 end module test1   

--- a/example_packages/many_source_folders/test/test1.f90
+++ b/example_packages/many_source_folders/test/test1.f90
@@ -1,0 +1,6 @@
+module test1
+   contains
+   subroutine print_test()
+      print *, "Hello, from test folder test/ ! "
+   end subroutine
+end module test1   

--- a/example_packages/many_source_folders/test2/test2.f90
+++ b/example_packages/many_source_folders/test2/test2.f90
@@ -1,0 +1,6 @@
+module test2
+   contains
+   subroutine print_test2()
+      print *, "Hello, from test folder test2/ ! "
+   end subroutine
+end module test2   

--- a/src/fpm.f90
+++ b/src/fpm.f90
@@ -191,7 +191,7 @@ subroutine build_model(model, settings, package, error)
     end if
     if (is_dir('example') .and. package%build%auto_examples) then
 
-        call add_executable_source_directories(model%source_dirs,package%executable,error)
+        call add_executable_source_directories(model%source_dirs,package%example,error)
         if (allocated(error)) return
 
         call add_sources_from_dir(model%packages(1)%sources,'example', FPM_SCOPE_EXAMPLE, &
@@ -204,7 +204,7 @@ subroutine build_model(model, settings, package, error)
     end if
     if (is_dir('test') .and. package%build%auto_tests) then
 
-        call add_executable_source_directories(model%source_dirs,package%executable,error)
+        call add_executable_source_directories(model%source_dirs,package%test,error)
         if (allocated(error)) return
 
         call add_sources_from_dir(model%packages(1)%sources,'test', FPM_SCOPE_TEST, &

--- a/src/fpm.f90
+++ b/src/fpm.f90
@@ -16,7 +16,8 @@ use fpm_model, only: fpm_model_t, srcfile_t, show_model, &
 use fpm_compiler, only: new_compiler, new_archiver, set_cpp_preprocessor_flags
 
 
-use fpm_sources, only: add_executable_sources, add_sources_from_dir
+use fpm_sources, only: add_executable_sources, add_sources_from_dir, &
+                       add_executable_source_directories
 use fpm_targets, only: targets_from_sources, &
                         resolve_target_linking, build_target_t, build_target_ptr, &
                         FPM_TARGET_EXECUTABLE, FPM_TARGET_ARCHIVE
@@ -53,6 +54,7 @@ subroutine build_model(model, settings, package, error)
 
     model%package_name = package%name
 
+    allocate(model%source_dirs(0))
     allocate(model%include_dirs(0))
     allocate(model%link_libraries(0))
     allocate(model%external_modules(0))
@@ -202,6 +204,10 @@ subroutine build_model(model, settings, package, error)
 
     end if
     if (allocated(package%executable)) then
+
+        call add_executable_source_directories(model%source_dirs,package%executable,error)
+        if (allocated(error)) return
+
         call add_executable_sources(model%packages(1)%sources, package%executable, FPM_SCOPE_APP, &
                                      auto_discover=package%build%auto_executables, &
                                      error=error)
@@ -212,6 +218,10 @@ subroutine build_model(model, settings, package, error)
 
     end if
     if (allocated(package%example)) then
+
+        call add_executable_source_directories(model%source_dirs,package%example,error)
+        if (allocated(error)) return
+
         call add_executable_sources(model%packages(1)%sources, package%example, FPM_SCOPE_EXAMPLE, &
                                      auto_discover=package%build%auto_examples, &
                                      error=error)
@@ -222,6 +232,10 @@ subroutine build_model(model, settings, package, error)
 
     end if
     if (allocated(package%test)) then
+
+        call add_executable_source_directories(model%source_dirs,package%test,error)
+        if (allocated(error)) return
+
         call add_executable_sources(model%packages(1)%sources, package%test, FPM_SCOPE_TEST, &
                                      auto_discover=package%build%auto_tests, &
                                      error=error)

--- a/src/fpm.f90
+++ b/src/fpm.f90
@@ -178,8 +178,7 @@ subroutine build_model(model, settings, package, error)
     ! Add sources from executable directories
     if (is_dir('app') .and. package%build%auto_executables) then
 
-        call add_executable_source_directories(model%source_dirs,package%executable,error)
-        if (allocated(error)) return
+        model%source_dirs = [model%source_dirs,string_t('app')]
 
         call add_sources_from_dir(model%packages(1)%sources,'app', FPM_SCOPE_APP, &
                                    with_executables=.true., error=error)
@@ -191,8 +190,7 @@ subroutine build_model(model, settings, package, error)
     end if
     if (is_dir('example') .and. package%build%auto_examples) then
 
-        call add_executable_source_directories(model%source_dirs,package%example,error)
-        if (allocated(error)) return
+        model%source_dirs = [model%source_dirs,string_t('example')]
 
         call add_sources_from_dir(model%packages(1)%sources,'example', FPM_SCOPE_EXAMPLE, &
                                    with_executables=.true., error=error)
@@ -204,8 +202,7 @@ subroutine build_model(model, settings, package, error)
     end if
     if (is_dir('test') .and. package%build%auto_tests) then
 
-        call add_executable_source_directories(model%source_dirs,package%test,error)
-        if (allocated(error)) return
+        model%source_dirs = [model%source_dirs,string_t('test')]
 
         call add_sources_from_dir(model%packages(1)%sources,'test', FPM_SCOPE_TEST, &
                                    with_executables=.true., error=error)

--- a/src/fpm.f90
+++ b/src/fpm.f90
@@ -330,7 +330,7 @@ end subroutine check_modules_for_duplicates
 subroutine check_module_names(model, error)
     type(fpm_model_t), intent(in) :: model
     type(error_t), allocatable, intent(out) :: error
-    integer :: i,j,k,l,m
+    integer :: k,l,m
     logical :: valid,errors_found,enforce_this_file
     type(string_t) :: package_name,module_name,package_prefix
 

--- a/src/fpm.f90
+++ b/src/fpm.f90
@@ -130,12 +130,14 @@ subroutine build_model(model, settings, package, error)
             if (allocated(dependency%library)) then
 
                 if (allocated(dependency%library%source_dir)) then
-                    lib_dir = join_path(dep%proj_dir, dependency%library%source_dir)
-                    if (is_dir(lib_dir)) then
-                        call add_sources_from_dir(model%packages(i)%sources, lib_dir, FPM_SCOPE_LIB, &
-                            error=error)
-                        if (allocated(error)) exit
-                    end if
+                    do j=1,size(dependency%library%source_dir)
+                        lib_dir = join_path(dep%proj_dir, dependency%library%source_dir(j)%s)
+                        if (is_dir(lib_dir)) then
+                            call add_sources_from_dir(model%packages(i)%sources, lib_dir, FPM_SCOPE_LIB, &
+                                error=error)
+                            if (allocated(error)) exit
+                        end if
+                    end do
                 end if
 
                 if (allocated(dependency%library%include_dir)) then

--- a/src/fpm.f90
+++ b/src/fpm.f90
@@ -177,6 +177,10 @@ subroutine build_model(model, settings, package, error)
 
     ! Add sources from executable directories
     if (is_dir('app') .and. package%build%auto_executables) then
+
+        call add_executable_source_directories(model%source_dirs,package%executable,error)
+        if (allocated(error)) return
+
         call add_sources_from_dir(model%packages(1)%sources,'app', FPM_SCOPE_APP, &
                                    with_executables=.true., error=error)
 
@@ -186,6 +190,10 @@ subroutine build_model(model, settings, package, error)
 
     end if
     if (is_dir('example') .and. package%build%auto_examples) then
+
+        call add_executable_source_directories(model%source_dirs,package%executable,error)
+        if (allocated(error)) return
+
         call add_sources_from_dir(model%packages(1)%sources,'example', FPM_SCOPE_EXAMPLE, &
                                    with_executables=.true., error=error)
 
@@ -195,6 +203,10 @@ subroutine build_model(model, settings, package, error)
 
     end if
     if (is_dir('test') .and. package%build%auto_tests) then
+
+        call add_executable_source_directories(model%source_dirs,package%executable,error)
+        if (allocated(error)) return
+
         call add_sources_from_dir(model%packages(1)%sources,'test', FPM_SCOPE_TEST, &
                                    with_executables=.true., error=error)
 

--- a/src/fpm/cmd/install.f90
+++ b/src/fpm/cmd/install.f90
@@ -28,7 +28,6 @@ contains
     type(fpm_model_t) :: model
     type(build_target_ptr), allocatable :: targets(:)
     type(installer_t) :: installer
-    character(len=:), allocatable :: lib, dir
     type(string_t), allocatable :: list(:)
     logical :: installable
 
@@ -88,7 +87,6 @@ contains
     type(build_target_ptr), intent(in) :: targets(:)
 
     integer :: ii, ntargets
-    character(len=:), allocatable :: lib
     type(string_t), allocatable :: install_target(:), temp(:)
 
     allocate(install_target(0))

--- a/src/fpm/manifest.f90
+++ b/src/fpm/manifest.f90
@@ -36,7 +36,7 @@ contains
         !> Instance of the library meta data
         type(library_config_t), intent(out) :: self
 
-        self%source_dir = "src"
+        self%source_dir = [string_t("src")]
         self%include_dir = [string_t("include")]
 
     end subroutine default_library

--- a/src/fpm/manifest.f90
+++ b/src/fpm/manifest.f90
@@ -52,7 +52,7 @@ contains
         character(len=*), intent(in) :: name
 
         self%name = name
-        self%source_dir = "app"
+        self%source_dir = [string_t("app")]
         self%main = "main.f90"
 
     end subroutine default_executable
@@ -67,7 +67,7 @@ contains
         character(len=*), intent(in) :: name
 
         self%name = name // "-demo"
-        self%source_dir = "example"
+        self%source_dir = [string_t("example")]
         self%main = "main.f90"
 
     end subroutine default_example
@@ -82,7 +82,7 @@ contains
         character(len=*), intent(in) :: name
 
         self%name = name // "-test"
-        self%source_dir = "test"
+        self%source_dir = [string_t("test")]
         self%main = "main.f90"
 
     end subroutine default_test

--- a/src/fpm/manifest/library.f90
+++ b/src/fpm/manifest/library.f90
@@ -22,7 +22,7 @@ module fpm_manifest_library
     type :: library_config_t
 
         !> Source path prefix
-        character(len=:), allocatable :: source_dir
+        type(string_t), allocatable :: source_dir(:)
 
         !> Include path prefix
         type(string_t), allocatable :: include_dir(:)
@@ -56,7 +56,9 @@ contains
         call check(table, error)
         if (allocated(error)) return
 
-        call get_value(table, "source-dir", self%source_dir, "src")
+        call get_list(table, "source-dir", self%source_dir, error)
+        if (allocated(error)) return
+
         call get_value(table, "build-script", self%build_script)
 
         call get_list(table, "include-dir", self%include_dir, error)
@@ -65,6 +67,11 @@ contains
         ! Set default value of include-dir if not found in manifest
         if (.not.allocated(self%include_dir)) then
             self%include_dir = [string_t("include")]
+        end if
+
+        ! Set default value of source-dir if not found in manifest
+        if (.not.allocated(self%source_dir)) then
+            self%source_dir = [string_t("src")]
         end if
 
     end subroutine new_library
@@ -127,7 +134,7 @@ contains
 
         write(unit, fmt) "Library target"
         if (allocated(self%source_dir)) then
-            write(unit, fmt) "- source directory", self%source_dir
+            write(unit, fmt) "- source directory", string_cat(self%source_dir,",")
         end if
         if (allocated(self%include_dir)) then
             write(unit, fmt) "- include directory", string_cat(self%include_dir,",")

--- a/src/fpm/manifest/test.f90
+++ b/src/fpm/manifest/test.f90
@@ -19,6 +19,7 @@ module fpm_manifest_test
     use fpm_manifest_executable, only : executable_config_t
     use fpm_error, only : error_t, syntax_error, bad_name_error
     use fpm_toml, only : toml_table, toml_key, toml_stat, get_value, get_list
+    use fpm_strings, only: string_t, string_cat
     implicit none
     private
 
@@ -64,7 +65,15 @@ contains
         if (bad_name_error(error,'test',self%name))then
            return
         endif
-        call get_value(table, "source-dir", self%source_dir, "test")
+
+        call get_list(table, "source-dir", self%source_dir, error)
+        if (allocated(error)) return
+
+        ! Set default value of source-dir if not found in manifest
+        if (.not.allocated(self%source_dir)) then
+            self%source_dir = [string_t("test")]
+        end if
+
         call get_value(table, "main", self%main, "main.f90")
 
         call get_value(table, "dependencies", child, requested=.false.)
@@ -153,8 +162,8 @@ contains
             write(unit, fmt) "- name", self%name
         end if
         if (allocated(self%source_dir)) then
-            if (self%source_dir /= "test" .or. pr > 2) then
-                write(unit, fmt) "- source directory", self%source_dir
+            if (self%source_dir(1)%s /= "test" .or. size(self%source_dir)/=1 .or. pr > 2) then
+                write(unit, fmt) "- source directory", string_cat(self%source_dir,",")
             end if
         end if
         if (allocated(self%main)) then

--- a/src/fpm_compiler.F90
+++ b/src/fpm_compiler.F90
@@ -187,7 +187,7 @@ character(*), parameter :: &
 character(*), parameter :: &
     flag_lfortran_opt = " --fast"
 
-    
+
 contains
 
 
@@ -417,7 +417,7 @@ pure subroutine set_cpp_preprocessor_flags(id, flags)
 
 end subroutine set_cpp_preprocessor_flags
 
-!> This function will parse and read the macros list and 
+!> This function will parse and read the macros list and
 !> return them as defined flags.
 function get_macros(id, macros_list, version) result(macros)
     integer(compiler_enum), intent(in) :: id
@@ -427,7 +427,7 @@ function get_macros(id, macros_list, version) result(macros)
     character(len=:), allocatable :: macros
     character(len=:), allocatable :: macro_definition_symbol
     character(:), allocatable :: valued_macros(:)
-    
+
 
     integer :: i
 
@@ -450,10 +450,10 @@ function get_macros(id, macros_list, version) result(macros)
     end if
 
     do i = 1, size(macros_list)
-        
+
         !> Split the macro name and value.
         call split(macros_list(i)%s, valued_macros, delimiters="=")
- 
+
         if (size(valued_macros) > 1) then
             !> Check if the value of macro starts with '{' character.
             if (str_begins_with_str(trim(valued_macros(size(valued_macros))), "{")) then
@@ -463,15 +463,15 @@ function get_macros(id, macros_list, version) result(macros)
 
                     !> Check if the string contains "version" as substring.
                     if (index(valued_macros(size(valued_macros)), "version") /= 0) then
-                    
+
                         !> These conditions are placed in order to ensure proper spacing between the macros.
                         macros = macros//macro_definition_symbol//trim(valued_macros(1))//'='//version
                         cycle
                     end if
                 end if
-            end if 
+            end if
         end if
-         
+
         macros = macros//macro_definition_symbol//macros_list(i)%s
 
     end do
@@ -648,8 +648,6 @@ function get_id(compiler) result(id)
     character(len=*), intent(in) :: compiler
     integer(kind=compiler_enum) :: id
 
-    integer :: stat
-
     if (check_compiler(compiler, "gfortran")) then
         id = id_gcc
         return
@@ -794,7 +792,7 @@ subroutine new_compiler(self, fc, cc, cxx, echo, verbose)
     logical, intent(in) :: verbose
 
     self%id = get_compiler_id(fc)
-    
+
     self%echo = echo
     self%verbose = verbose
     self%fc = fc

--- a/src/fpm_model.f90
+++ b/src/fpm_model.f90
@@ -168,6 +168,9 @@ type :: fpm_model_t
     !> Base directory for build
     character(:), allocatable :: build_prefix
 
+    !> Source directories
+    type(string_t), allocatable :: source_dirs(:)
+
     !> Include directories
     type(string_t), allocatable :: include_dirs(:)
 

--- a/src/fpm_sources.f90
+++ b/src/fpm_sources.f90
@@ -167,7 +167,6 @@ subroutine add_executable_sources(sources,executables,scope,auto_discover,error)
     call get_executable_source_dirs(exe_dirs,executables)
 
     do i=1,size(exe_dirs)
-        print *, 'add sources from dir ',exe_dirs(i)%s
         call add_sources_from_dir(sources,exe_dirs(i)%s, scope, &
                      with_executables=auto_discover, recurse=.false., error=error)
 
@@ -258,7 +257,6 @@ subroutine get_executable_source_dirs(exe_dirs,executables)
     do i=1,size(executables)
         if (.not.allocated(executables(i)%source_dir)) cycle
         do j=1,size(executables(i)%source_dir)
-            print *, 'test source dir ',executables(i)%source_dir(j)%s
             if (.not.(executables(i)%source_dir(j)%s .in. dirs_temp)) then
 
                 n = n + 1

--- a/src/fpm_targets.f90
+++ b/src/fpm_targets.f90
@@ -499,27 +499,17 @@ subroutine resolve_module_dependencies(targets,external_modules,source_dirs,erro
                     cycle
                 end if
 
-                print *, 'search ',targets(i)%ptr%source%modules_used(j)%s
-
                 if (any(targets(i)%ptr%source%unit_scope == &
                     [FPM_SCOPE_APP, FPM_SCOPE_EXAMPLE, FPM_SCOPE_TEST])) then
-                    print *, '1 use include_dir=',targets(i)%ptr%source%file_name
                     dep%ptr => &
                         find_module_dependency(targets,targets(i)%ptr%source%modules_used(j)%s, &
                                                source_dirs = source_dirs)
                 else
-                    print *, '2'
                     dep%ptr => &
                         find_module_dependency(targets,targets(i)%ptr%source%modules_used(j)%s)
                 end if
 
                 if (.not.associated(dep%ptr)) then
-                    block
-                        integer :: k
-                        do k=1,size(targets(i)%ptr%dependencies)
-                            print *, 'dep ',k,'  = ',targets(i)%ptr%dependencies(k)%ptr%source%file_name
-                        end do
-                    end block
                     call fatal_error(error, &
                             'Unable to find source for module dependency: "' // &
                             targets(i)%ptr%source%modules_used(j)%s // &
@@ -556,8 +546,6 @@ function find_module_dependency(targets,module_name,source_dirs) result(target_p
 
         do l=1,size(targets(k)%ptr%source%modules_provided)
 
-            print *, 'search scope ',targets(k)%ptr%source%file_name
-
             if (module_name == targets(k)%ptr%source%modules_provided(l)%s) then
                 select case(targets(k)%ptr%source%unit_scope)
                 case (FPM_SCOPE_LIB, FPM_SCOPE_DEP)
@@ -567,7 +555,6 @@ function find_module_dependency(targets,module_name,source_dirs) result(target_p
 
                     ! If this target is part of an executable build, the provided module must be
                     ! in any of the source file folders
-                    print *, 'search scope ',targets(k)%ptr%source%unit_scope,' modules in ',source_dirs(d)%s
                     if (present(source_dirs)) then
                         do d=1,size(source_dirs)
                             ! source file is within the include_dirs(d) or a subdirectory

--- a/src/fpm_targets.f90
+++ b/src/fpm_targets.f90
@@ -476,13 +476,19 @@ end subroutine add_dependency
 subroutine resolve_module_dependencies(targets,external_modules,source_dirs,error)
     type(build_target_ptr), intent(inout), target :: targets(:)
     type(string_t), intent(in) :: external_modules(:)
-    type(string_t), intent(in) :: source_dirs(:)
+    type(string_t), allocatable, intent(in) :: source_dirs(:)
     type(error_t), allocatable, intent(out) :: error
 
     type(build_target_ptr) :: dep
     type(string_t), allocatable :: dirs(:)
 
-    integer :: i, j
+    integer :: i, j, ndir
+
+    if (allocated(source_dirs)) then
+        ndir = size(source_dirs)
+    else
+        ndir = 0
+    end if
 
     do i=1,size(targets)
 
@@ -504,7 +510,7 @@ subroutine resolve_module_dependencies(targets,external_modules,source_dirs,erro
                     [FPM_SCOPE_APP, FPM_SCOPE_EXAMPLE, FPM_SCOPE_TEST])) then
 
                     ! Fallback to default source dirs if model%source_dir not initialized
-                    if (size(source_dirs)>0) then
+                    if (ndir>0) then
                         dirs = source_dirs
                     else
                         dirs = [string_t(dirname(targets(i)%ptr%source%file_name))]

--- a/src/fpm_targets.f90
+++ b/src/fpm_targets.f90
@@ -480,6 +480,7 @@ subroutine resolve_module_dependencies(targets,external_modules,source_dirs,erro
     type(error_t), allocatable, intent(out) :: error
 
     type(build_target_ptr) :: dep
+    type(string_t), allocatable :: dirs(:)
 
     integer :: i, j
 
@@ -501,9 +502,18 @@ subroutine resolve_module_dependencies(targets,external_modules,source_dirs,erro
 
                 if (any(targets(i)%ptr%source%unit_scope == &
                     [FPM_SCOPE_APP, FPM_SCOPE_EXAMPLE, FPM_SCOPE_TEST])) then
+
+                    ! Fallback to default source dirs if model%source_dir not initialized
+                    if (size(source_dirs)>0) then
+                        dirs = source_dirs
+                    else
+                        dirs = [string_t(dirname(targets(i)%ptr%source%file_name))]
+                    endif
+
                     dep%ptr => &
                         find_module_dependency(targets,targets(i)%ptr%source%modules_used(j)%s, &
-                                               source_dirs = source_dirs)
+                                               source_dirs = dirs)
+
                 else
                     dep%ptr => &
                         find_module_dependency(targets,targets(i)%ptr%source%modules_used(j)%s)

--- a/test/fpm_test/test_manifest.f90
+++ b/test/fpm_test/test_manifest.f90
@@ -240,7 +240,7 @@ contains
         allocate(package%executable(1))
         call default_executable(package%executable(1), name)
 
-        call check_string(error, package%executable(1)%source_dir, "app", &
+        call check_string(error, package%executable(1)%source_dir(1)%s, "app", &
             & "Default executable source-dir")
         if (allocated(error)) return
 

--- a/test/fpm_test/test_manifest.f90
+++ b/test/fpm_test/test_manifest.f90
@@ -205,9 +205,15 @@ contains
         allocate(package%library)
         call default_library(package%library)
 
-        call check_string(error, package%library%source_dir, "src", &
-            & "Default library source-dir")
-        if (allocated(error)) return
+        if (.not.allocated(package%library%source_dir)) then
+            call test_failed(error,"Default source-dir list not allocated")
+            return
+        end if
+
+        if (.not.("src".in.package%library%source_dir)) then
+            call test_failed(error,"'src' not in default source-dir list")
+            return
+        end if
 
         if (.not.allocated(package%library%include_dir)) then
             call test_failed(error,"Default include-dir list not allocated")
@@ -742,9 +748,15 @@ contains
         call new_library(library, table, error)
         if (allocated(error)) return
 
-        call check_string(error, library%source_dir, "src", &
-            & "Default library source-dir")
-        if (allocated(error)) return
+        if (.not.allocated(library%source_dir)) then
+            call test_failed(error,"Default source-dir list not allocated")
+            return
+        end if
+
+        if (.not.("src".in.library%source_dir)) then
+            call test_failed(error,"'src' not in default source-dir list")
+            return
+        end if
 
         if (.not.allocated(library%include_dir)) then
             call test_failed(error,"Default include-dir list not allocated")


### PR DESCRIPTION
This PR fixes #821 . 

Library configurations already allow multiple `include-dir` directories, but only allowed 1 `source-dir`. 
This patch extends fpm to specify multiple source dirs for library configurations: 

```toml
[library]
source-dir=["src","src2"]
include-dir=["include1","include2"]
```

I think it would make sense to also extend this to executable configurations? @fortran-lang/admins 
Or, it's better if we restrict all sources to be inside a single root directory, whichever named?
