### PR TITLE
Fix unhandled error branch

### DIFF
--- a/src/fpm/toml.f90
+++ b/src/fpm/toml.f90
@@ -84,6 +84,8 @@ contains
         type(toml_array), pointer :: children
         character(len=:), allocatable :: str
 
+        if (.not.table%has_key(key)) return
+
         call get_value(table, key, children, requested=.false.)
         if (associated(children)) then
             nlist = len(children)


### PR DESCRIPTION
Since https://github.com/toml-f/toml-f/pull/123 the `get_value` interface of TOML Fortran will properly return an error if a value is not present. The `get_list` implementation relied on this bug and used the allocation status of the deferred length character variable to catch this case. This patch corrects the behavior on the fpm side and allows to upgrade to future versions of TOML Fortran.