### PR TITLE
return program's exit code

### DIFF
--- a/ci/run_tests.sh
+++ b/ci/run_tests.sh
@@ -158,5 +158,42 @@ pushd cpp_files
 "$fpm" test
 popd
 
+# Test app exit codes
+pushd fpm_test_exit_code
+"$fpm" build
+
+# odd number -> return 0
+EXIT_CODE=0
+"$fpm" run -- 1 || EXIT_CODE=$?
+test $EXIT_CODE -eq 0
+
+# even number -> return 3
+EXIT_CODE=0
+"$fpm" run -- 512 || EXIT_CODE=$?
+test $EXIT_CODE -eq 3
+
+# even number -> return 3
+EXIT_CODE=0
+"$fpm" run -- 0 || EXIT_CODE=$?
+test $EXIT_CODE -eq 3
+
+# not an integer -> return 3
+EXIT_CODE=0
+"$fpm" run -- 3.1415 || EXIT_CODE=$?
+test $EXIT_CODE -eq 2
+
+# not a number
+EXIT_CODE=0
+"$fpm" run -- notanumber || EXIT_CODE=$?
+test $EXIT_CODE -eq 2
+
+# no arguments
+EXIT_CODE=0
+"$fpm" run || EXIT_CODE=$?
+test $EXIT_CODE -eq 1
+
+popd
+
+
 # Cleanup
 rm -rf ./*/build

--- a/ci/run_tests.sh
+++ b/ci/run_tests.sh
@@ -162,32 +162,32 @@ popd
 pushd fpm_test_exit_code
 "$fpm" build
 
-# odd number -> return 0
+# odd number -> success!
 EXIT_CODE=0
 "$fpm" run -- 1 || EXIT_CODE=$?
 test $EXIT_CODE -eq 0
 
-# even number -> return 3
+# even number -> error 3
 EXIT_CODE=0
 "$fpm" run -- 512 || EXIT_CODE=$?
 test $EXIT_CODE -eq 3
 
-# even number -> return 3
+# even number -> error 3
 EXIT_CODE=0
 "$fpm" run -- 0 || EXIT_CODE=$?
 test $EXIT_CODE -eq 3
 
-# not an integer -> return 3
+# not an integer -> error 2
 EXIT_CODE=0
 "$fpm" run -- 3.1415 || EXIT_CODE=$?
 test $EXIT_CODE -eq 2
 
-# not a number
+# not a number -> error 2
 EXIT_CODE=0
 "$fpm" run -- notanumber || EXIT_CODE=$?
 test $EXIT_CODE -eq 2
 
-# no arguments
+# no arguments -> error 1
 EXIT_CODE=0
 "$fpm" run || EXIT_CODE=$?
 test $EXIT_CODE -eq 1

--- a/ci/run_tests.sh
+++ b/ci/run_tests.sh
@@ -191,7 +191,6 @@ test $EXIT_CODE -eq 2
 EXIT_CODE=0
 "$fpm" run || EXIT_CODE=$?
 test $EXIT_CODE -eq 1
-
 popd
 
 

--- a/example_packages/fpm_test_exit_code/README.md
+++ b/example_packages/fpm_test_exit_code/README.md
@@ -1,0 +1,6 @@
+# fpm_test_exit_code
+Test program for application exit codes
+see https://github.com/fortran-lang/fpm/issues/848
+
+This app expects to receive an integer command line argument, to check whether it is odd or even.
+It returns 0 on success (odd input), or among a few error codes otherwise.

--- a/example_packages/fpm_test_exit_code/app/main.f90
+++ b/example_packages/fpm_test_exit_code/app/main.f90
@@ -5,38 +5,38 @@
 ! It returns 0 on success (odd input), or among a few error codes otherwise.
 
 program check_odd_number
-  implicit none
+    implicit none
 
-  integer, parameter :: SUCCESS          = 0
-  integer, parameter :: INVALID_ARGUMENT = 1
-  integer, parameter :: NOT_AN_INTEGER   = 2
-  integer, parameter :: NOT_ODD          = 3
+    integer, parameter :: SUCCESS          = 0
+    integer, parameter :: INVALID_ARGUMENT = 1
+    integer, parameter :: NOT_AN_INTEGER   = 2
+    integer, parameter :: NOT_ODD          = 3
 
-  character(len=1024) :: buffer
-  integer :: ierr,ln,the_number
+    character(len=1024) :: buffer
+    integer :: ierr,ln,the_number
 
-  ! If the argument is missing or not an integer, return an error flag
-  if (command_argument_count()/=1) stop INVALID_ARGUMENT
+    ! If the argument is missing or not an integer, return an error flag
+    if (command_argument_count()/=1) stop INVALID_ARGUMENT
 
-  ! Get command argument
-  call get_command_argument(1,value=buffer,length=ln,status=ierr)
+    ! Get command argument
+    call get_command_argument(1,value=buffer,length=ln,status=ierr)
 
-  ! On invalid string
-  if (ln<1 .or. ierr/=0) stop INVALID_ARGUMENT
+    ! On invalid string
+    if (ln<1 .or. ierr/=0) stop INVALID_ARGUMENT
 
-  ! Read to int
-  read(buffer(:ln),*,iostat=ierr) the_number
+    ! Read to int
+    read(buffer(:ln),*,iostat=ierr) the_number
 
-  ! On invalid integer
-  if (ierr/=0) stop NOT_AN_INTEGER
+    ! On invalid integer
+    if (ierr/=0) stop NOT_AN_INTEGER
 
-  ! Check if it is odd or even
-  if (mod(the_number,2)==0) then
-      ! Is even
-      stop NOT_ODD
-  else
-      ! Is odd
-      stop SUCCESS
-  end if
+    ! Check if it is odd or even
+    if (mod(the_number,2)==0) then
+        ! Is even
+        stop NOT_ODD
+    else
+        ! Is odd
+        stop SUCCESS
+    end if
 
 end program check_odd_number

--- a/example_packages/fpm_test_exit_code/app/main.f90
+++ b/example_packages/fpm_test_exit_code/app/main.f90
@@ -1,0 +1,42 @@
+! Test program for application exit codes
+! see https://github.com/fortran-lang/fpm/issues/848
+
+! This app expects to receive an integer command line argument, to check whether it is odd or even.
+! It returns 0 on success (odd input), or among a few error codes otherwise.
+
+program check_odd_number
+  implicit none
+
+  integer, parameter :: SUCCESS          = 0
+  integer, parameter :: INVALID_ARGUMENT = 1
+  integer, parameter :: NOT_AN_INTEGER   = 2
+  integer, parameter :: NOT_ODD          = 3
+
+  character(len=1024) :: buffer
+  integer :: ierr,ln,the_number
+
+  ! If the argument is missing or not an integer, return an error flag
+  if (command_argument_count()/=1) stop INVALID_ARGUMENT
+
+  ! Get command argument
+  call get_command_argument(1,value=buffer,length=ln,status=ierr)
+
+  ! On invalid string
+  if (ln<1 .or. ierr/=0) stop INVALID_ARGUMENT
+
+  ! Read to int
+  read(buffer(:ln),*,iostat=ierr) the_number
+
+  ! On invalid integer
+  if (ierr/=0) stop NOT_AN_INTEGER
+
+  ! Check if it is odd or even
+  if (mod(the_number,2)==0) then
+      ! Is even
+      stop NOT_ODD
+  else
+      ! Is odd
+      stop SUCCESS
+  end if
+
+end program check_odd_number

--- a/example_packages/fpm_test_exit_code/fpm.toml
+++ b/example_packages/fpm_test_exit_code/fpm.toml
@@ -1,0 +1,10 @@
+name = "fpm_test_exit_code"
+version = "0.1.0"
+license = "license"
+author = "Jane Doe"
+maintainer = "jane.doe@example.com"
+copyright = "Copyright 2023, Jane Doe"
+[build]
+auto-executables = true
+[install]
+library = false

--- a/example_packages/fpm_test_exit_code/fpm.toml
+++ b/example_packages/fpm_test_exit_code/fpm.toml
@@ -1,7 +1,7 @@
 name = "fpm_test_exit_code"
 version = "0.1.0"
 license = "license"
-author = "Jane Doe"
+author = "Federico Perini"
 maintainer = "jane.doe@example.com"
 copyright = "Copyright 2023, Jane Doe"
 [build]

--- a/src/fpm.f90
+++ b/src/fpm.f90
@@ -441,7 +441,7 @@ subroutine cmd_run(settings,test)
     type(string_t), allocatable :: executables(:)
     type(build_target_t), pointer :: exe_target
     type(srcfile_t), pointer :: exe_source
-    integer :: run_scope
+    integer :: run_scope,firsterror
     integer, allocatable :: stat(:)
     character(len=:),allocatable :: line
     logical :: toomany
@@ -586,10 +586,12 @@ subroutine cmd_run(settings,test)
         if (any(stat /= 0)) then
             do i=1,size(stat)
                 if (stat(i) /= 0) then
-                    write(stderr,'(*(g0:,1x))') '<ERROR> Execution failed for object "',basename(executables(i)%s),'"'
+                    write(stderr,'(*(g0:,1x))') '<ERROR> Execution for object "',basename(executables(i)%s),&
+                                                '" returned exit code ',stat(i)
                 end if
             end do
-            call fpm_stop(1,'*cmd_run*:stopping due to failed executions')
+            firsterror = findloc(stat/=0,value=.true.,dim=1)
+            call fpm_stop(stat(firsterror),'*cmd_run*:stopping due to failed executions')
         end if
 
     endif

--- a/src/fpm_filesystem.F90
+++ b/src/fpm_filesystem.F90
@@ -924,10 +924,8 @@ subroutine run(cmd,echo,exitstat,verbose,redirect)
 
     if (present(exitstat)) then
         exitstat = stat
-    else
-        if (stat /= 0) then
-            call fpm_stop(1,'*run*:Command failed')
-        end if
+    elseif (stat /= 0) then
+        call fpm_stop(stat,'*run*: Command '//cmd//redirect_str//' returned a non-zero status code')
     end if
 
 end subroutine run


### PR DESCRIPTION
Address #848: `fpm_stop` with the same code as the program's exit code when a command is successful, but the program returns a non-zero exit state