### PR TITLE
fix macOS CI for fpm-bootstrap executables built with gcc-9

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -56,8 +56,6 @@ jobs:
         ln -fs /usr/local/opt/gcc@${GCC_V}/lib/gcc/${GCC_V}/libgfortran.5.dylib /usr/local/opt/gcc@9/lib/gcc/9/libgfortran.5.dylib
         ln -fs /usr/local/lib/gcc/${GCC_V}/libgcc_s.1.dylib /usr/local/lib/gcc/9/libgcc_s.1.dylib
 
-/usr/local/opt/gcc@9/lib/gcc/9/libquadmath.0.dylib
-
     - name: Install GFortran Linux
       if: contains(matrix.os, 'ubuntu')
       run: |

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -51,7 +51,9 @@ jobs:
         ln -s /usr/local/bin/gfortran-${GCC_V} /usr/local/bin/gfortran
         which gfortran-${GCC_V}
         which gfortran
-        # Backport gfortran shared libraries to version 9 folder (hardcoded in fpm 0.3.0 executable)
+        # Backport gfortran shared libraries to version 9 folder. This is necessary because all macOS releases of fpm 
+        # have these paths hardcoded in the executable (no PIC?). As the gcc ABIs have not changed from 9 to 10, we 
+        # can just create symbolic links for now. This can be removed when an updated fpm release is built with gcc-10  
         mkdir /usr/local/opt/gcc@9
         mkdir /usr/local/opt/gcc@9/lib
         mkdir /usr/local/opt/gcc@9/lib/gcc

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -51,6 +51,12 @@ jobs:
         ln -s /usr/local/bin/gfortran-${GCC_V} /usr/local/bin/gfortran
         which gfortran-${GCC_V}
         which gfortran
+        # Backport gfortran shared libraries to version 9 folder (hardcoded in fpm 0.3.0 executable)
+        ln -fs /usr/local/opt/gcc@${GCC_V}/lib/gcc/${GCC_V}/libquadmath.0.dylib /usr/local/opt/gcc@9/lib/gcc/9/libquadmath.0.dylib 
+        ln -fs /usr/local/opt/gcc@${GCC_V}/lib/gcc/${GCC_V}/libgfortran.5.dylib /usr/local/opt/gcc@9/lib/gcc/9/libgfortran.5.dylib
+        ln -fs /usr/local/lib/gcc/${GCC_V}/libgcc_s.1.dylib /usr/local/lib/gcc/9/libgcc_s.1.dylib
+
+/usr/local/opt/gcc@9/lib/gcc/9/libquadmath.0.dylib
 
     - name: Install GFortran Linux
       if: contains(matrix.os, 'ubuntu')

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -52,6 +52,11 @@ jobs:
         which gfortran-${GCC_V}
         which gfortran
         # Backport gfortran shared libraries to version 9 folder (hardcoded in fpm 0.3.0 executable)
+        mkdir /usr/local/opt/gcc@9
+        mkdir /usr/local/opt/gcc@9/lib
+        mkdir /usr/local/opt/gcc@9/lib/gcc
+        mkdir /usr/local/opt/gcc@9/lib/gcc/9
+        mkdir /usr/local/lib/gcc/9
         ln -fs /usr/local/opt/gcc@${GCC_V}/lib/gcc/${GCC_V}/libquadmath.0.dylib /usr/local/opt/gcc@9/lib/gcc/9/libquadmath.0.dylib 
         ln -fs /usr/local/opt/gcc@${GCC_V}/lib/gcc/${GCC_V}/libgfortran.5.dylib /usr/local/opt/gcc@9/lib/gcc/9/libgfortran.5.dylib
         ln -fs /usr/local/lib/gcc/${GCC_V}/libgcc_s.1.dylib /usr/local/lib/gcc/9/libgcc_s.1.dylib


### PR DESCRIPTION
- Fixes #860.

The approach to statically link fpm on macOS seems [far more complicated](https://github.com/NREL/EnergyPlus/pull/9676), 
so I suggest we keep it simple for now, and create gcc-10 => dummy gcc-9 symbolic links to keep fpm-bootstrap executables 0.3.0 to 0.7.0 working on the new macOS images: 

https://github.com/perazz/fpm/blob/5a74d581cbdfa8e86f183d35e54d707bf076b865/.github/workflows/CI.yml#L54-L64

This is tested working now.