### PR TITLE
Update TOML Fortran to latest version

### DIFF
--- a/fpm.toml
+++ b/fpm.toml
@@ -6,13 +6,10 @@ maintainer = ""
 copyright = "2020 fpm contributors"
 
 [dependencies]
-[dependencies.toml-f]
-git = "https://github.com/toml-f/toml-f"
-rev = "aee54c5a480d623af99828c76df0447a15ce90dc"
-
-[dependencies.M_CLI2]
-git = "https://github.com/urbanjost/M_CLI2.git"
-rev = "7264878cdb1baff7323cc48596d829ccfe7751b8"
+toml-f.git = "https://github.com/toml-f/toml-f"
+toml-f.rev = "54686e45993f3a9a1d05d5c7419f39e7d5a4eb3f"
+M_CLI2.git = "https://github.com/urbanjost/M_CLI2.git"
+M_CLI2.rev = "7264878cdb1baff7323cc48596d829ccfe7751b8"
 
 [[test]]
 name = "cli-test"

--- a/src/fpm/cmd/new.f90
+++ b/src/fpm/cmd/new.f90
@@ -627,17 +627,17 @@ end function git_metadata
 
 subroutine create_verified_basic_manifest(filename)
 !> create a basic but verified default manifest file
-use fpm_toml, only : toml_table, toml_serializer, set_value
+use fpm_toml, only : toml_table, toml_serialize, set_value
 use fpm_manifest_package, only : package_config_t, new_package
 use fpm_error, only : error_t
 implicit none
 character(len=*),intent(in) :: filename
    type(toml_table)            :: table
-   type(toml_serializer)       :: ser
    type(package_config_t)      :: package
    type(error_t), allocatable  :: error
    integer                     :: lun
    character(len=8)            :: date
+   character(:), allocatable   :: output
 
     if(exists(filename))then
        write(stderr,'(*(g0,1x))')'<INFO>  ',filename,&
@@ -647,7 +647,6 @@ character(len=*),intent(in) :: filename
     !> get date to put into metadata in manifest file "fpm.toml"
     call date_and_time(DATE=date)
     table = toml_table()
-    ser = toml_serializer()
     call fileopen(filename,lun) ! fileopen stops on error
 
     call set_value(table, "name",       BNAME)
@@ -660,11 +659,11 @@ character(len=*),intent(in) :: filename
     ! ...
     call new_package(package, table, error=error)
     if (allocated(error)) call fpm_stop( 3,'')
+    output = toml_serialize(table)
     if(settings%verbose)then
-       call table%accept(ser)
+       print '(a)', output
     endif
-    ser%unit=lun
-    call table%accept(ser)
+    write(lun, '(a)') output
     call fileclose(lun) ! fileopen stops on error
 
 end subroutine create_verified_basic_manifest
@@ -673,27 +672,25 @@ end subroutine create_verified_basic_manifest
 subroutine validate_toml_data(input)
 !> verify a string array is a valid fpm.toml file
 !
-use tomlf, only : toml_parse
-use fpm_toml, only : toml_table, toml_serializer
+use tomlf, only : toml_load
+use fpm_toml, only : toml_table, toml_serialize
 implicit none
 character(kind=tfc,len=:),intent(in),allocatable :: input(:)
 character(len=1), parameter                      :: nl = new_line('a')
 type(toml_table), allocatable                    :: table
 character(kind=tfc, len=:), allocatable          :: joined_string
-type(toml_serializer)                            :: ser
 
 ! you have to add a newline character by using the intrinsic
 ! function `new_line("a")` to get the lines processed correctly.
 joined_string = join(input,right=nl)
 
 if (allocated(table)) deallocate(table)
-call toml_parse(table, joined_string)
+call toml_load(table, joined_string)
 if (allocated(table)) then
    if(settings%verbose)then
       ! If the TOML file is successfully parsed the table will be allocated and
-      ! can be written to the standard output by passing the `toml_serializer`
-      ! as visitor to the table.
-      call table%accept(ser)
+      ! can be written by `toml_serialize` to the standard output
+      print '(a)', toml_serialize(table)
    endif
    call table%destroy
 endif

--- a/src/fpm/dependency.f90
+++ b/src/fpm/dependency.f90
@@ -64,8 +64,8 @@ module fpm_dependency
     get_package_data
   use fpm_manifest_dependency, only: manifest_has_changed
   use fpm_strings, only : string_t, operator(.in.)
-  use fpm_toml, only : toml_table, toml_key, toml_error, toml_serializer, &
-    toml_parse, get_value, set_value, add_table
+  use fpm_toml, only : toml_table, toml_key, toml_error, toml_serialize, &
+    toml_load, get_value, set_value, add_table
   use fpm_versioning, only : version_t, new_version, char
   implicit none
   private
@@ -720,7 +720,7 @@ contains
     type(toml_error), allocatable :: parse_error
     type(toml_table), allocatable :: table
 
-    call toml_parse(table, unit, parse_error)
+    call toml_load(table, unit, error=parse_error)
 
     if (allocated(parse_error)) then
       allocate(error)
@@ -830,14 +830,11 @@ contains
     type(error_t), allocatable, intent(out) :: error
 
     type(toml_table) :: table
-    type(toml_serializer) :: ser
 
     table = toml_table()
-    ser = toml_serializer(unit)
-
     call self%dump(table, error)
 
-    call table%accept(ser)
+    write(unit, '(a)') toml_serialize(table)
 
   end subroutine dump_to_unit
 

--- a/src/fpm/toml.f90
+++ b/src/fpm/toml.f90
@@ -16,15 +16,15 @@ module fpm_toml
     use fpm_error, only : error_t, fatal_error, file_not_found_error
     use fpm_strings, only : string_t
     use tomlf, only : toml_table, toml_array, toml_key, toml_stat, get_value, &
-        & set_value, toml_parse, toml_error, new_table, add_table, add_array, &
-        & toml_serializer, len
+        & set_value, toml_load, toml_error, new_table, add_table, add_array, &
+        & toml_serialize, len
     implicit none
     private
 
     public :: read_package_file
     public :: toml_table, toml_array, toml_key, toml_stat, get_value, set_value, get_list
     public :: new_table, add_table, add_array, len
-    public :: toml_error, toml_serializer, toml_parse
+    public :: toml_error, toml_serialize, toml_load
 
 
 contains
@@ -54,7 +54,7 @@ contains
         end if
 
         open(file=manifest, newunit=unit)
-        call toml_parse(table, unit, parse_error)
+        call toml_load(table, unit, error=parse_error)
         close(unit)
 
         if (allocated(parse_error)) then


### PR DESCRIPTION
- replace deprecated `toml_parse` with `toml_load`
- update from using `toml_serializer` visitor to `toml_serialize` function
- use more readable syntax in manifest (previous syntax was used due to https://github.com/kowainik/tomland/issues/336 in Haskell version)