### PR TITLE
Only update dependencies between cached build and manifest

### DIFF
--- a/ci/run_tests.sh
+++ b/ci/run_tests.sh
@@ -203,8 +203,7 @@ popd
 
 # test dependency priority
 pushd dependency_priority
-  "$fpm" run || EXIT_CODE=$?
-  test $EXIT_CODE -eq 0
+"$fpm" run 
 popd
 
 # Cleanup

--- a/ci/run_tests.sh
+++ b/ci/run_tests.sh
@@ -201,6 +201,11 @@ EXIT_CODE=0
 test $EXIT_CODE -eq 1
 popd
 
+# test dependency priority
+pushd dependency_priority
+  "$fpm" run || EXIT_CODE=$?
+  test $EXIT_CODE -eq 0
+popd
 
 # Cleanup
 rm -rf ./*/build

--- a/example_packages/dependency_priority/README.md
+++ b/example_packages/dependency_priority/README.md
@@ -1,0 +1,4 @@
+# dependency_tree
+Check dependency tree cascade. "Standard" fpm dependencies feature that the highest-priority one wins
+(i.e., top-level dependencies in the manifest, or the first time it's found down the dependency tree)
+Check this behavior is confirmed.

--- a/example_packages/dependency_priority/app/main.f90
+++ b/example_packages/dependency_priority/app/main.f90
@@ -1,0 +1,14 @@
+program main
+  use tomlf_version, only: tomlf_version_string
+  implicit none
+
+  print *, 'using version =',tomlf_version_string
+  print *, 'should be     =0.3.1'
+
+  if (tomlf_version_string=="0.3.1") then 
+     stop 0
+  else
+     stop 1
+  endif
+
+end program main

--- a/example_packages/dependency_priority/fpm.toml
+++ b/example_packages/dependency_priority/fpm.toml
@@ -1,5 +1,7 @@
 name = "dependency_tree"
 version = "0.1.0"
+[build]
+auto-executables=true
 [dependencies]
 # Request toml-f v0.3.1. 
 toml-f.git = "https://github.com/toml-f/toml-f"

--- a/example_packages/dependency_priority/fpm.toml
+++ b/example_packages/dependency_priority/fpm.toml
@@ -1,0 +1,10 @@
+name = "dependency_tree"
+version = "0.1.0"
+[dependencies]
+# Request toml-f v0.3.1. 
+toml-f.git = "https://github.com/toml-f/toml-f"
+toml-f.tag = "v0.3.1"
+# jonquil 0.2.0 requires toml-f v0.4.0. 
+# Because 0.4.0 is a derived dependency, it should not be used
+jonquil.git = "https://github.com/toml-f/jonquil"
+jonquil.tag = "v0.2.0"

--- a/src/fpm/dependency.f90
+++ b/src/fpm/dependency.f90
@@ -308,8 +308,7 @@ contains
     call self%add(package, root, .true., error)
     if (allocated(error)) return
 
-    ! Before resolving all dependencies, check if we have cached ones
-    ! Do that after the package node dependencies are already sorted out into a tree
+    ! After resolving all dependencies, check if we have cached ones to avoid updates
     if (allocated(self%cache)) then
       call new_dependency_tree(cached, cache=self%cache)
       call cached%load(self%cache, error)

--- a/src/fpm/dependency.f90
+++ b/src/fpm/dependency.f90
@@ -1196,7 +1196,6 @@ contains
     !> will always have this metadata; a dependency from fpm.toml which has not been fetched yet
     !> may not have it
     if (allocated(cached%version) .and. allocated(manifest%version)) then
-      print *, cached%version%s(),' ',manifest%version%s()
       if (cached%version /= manifest%version) return
     end if
     if (allocated(cached%revision) .and. allocated(manifest%revision)) then

--- a/src/fpm/git.f90
+++ b/src/fpm/git.f90
@@ -8,6 +8,7 @@ module fpm_git
     public :: git_target_default, git_target_branch, git_target_tag, &
         & git_target_revision
     public :: git_revision
+    public :: git_matches_manifest
     public :: operator(==)
 
 
@@ -36,7 +37,7 @@ module fpm_git
     type :: git_target_t
 
         !> Kind of the git target
-        integer, private :: descriptor = git_descriptor%default
+        integer :: descriptor = git_descriptor%default
 
         !> Target URL of the git repository
         character(len=:), allocatable :: url
@@ -144,6 +145,23 @@ contains
                    this%object     == that%object
 
     end function git_target_eq
+
+    !> Check that a cached dependency matches a manifest request
+    logical function git_matches_manifest(cached,manifest)
+
+        !> Two input git targets
+        type(git_target_t), intent(in) :: cached,manifest
+
+        git_matches_manifest = cached%url == manifest%url
+        if (.not.git_matches_manifest) return
+
+        !> The manifest dependency only contains partial information (what's requested),
+        !> while the cached dependency always stores a commit hash because it's built
+        !> after the repo is available (saved as git_descriptor%revision==revision).
+        !> So, comparing against the descriptor is not reliable
+        git_matches_manifest = cached%object == manifest%object
+
+    end function git_matches_manifest
 
 
     subroutine checkout(self, local_path, error)

--- a/src/fpm/manifest/dependency.f90
+++ b/src/fpm/manifest/dependency.f90
@@ -25,7 +25,7 @@
 module fpm_manifest_dependency
     use fpm_error, only: error_t, syntax_error
     use fpm_git, only: git_target_t, git_target_tag, git_target_branch, &
-        & git_target_revision, git_target_default, operator(==)
+        & git_target_revision, git_target_default, operator(==), git_matches_manifest
     use fpm_toml, only: toml_table, toml_key, toml_stat, get_value, check_keys
     use fpm_filesystem, only: windows_path
     use fpm_environment, only: get_os_type, OS_WINDOWS
@@ -274,19 +274,17 @@ contains
     end subroutine info
 
     !> Check if two dependency configurations are different
-    logical function manifest_has_changed(this, that) result(has_changed)
+    logical function manifest_has_changed(cached, manifest) result(has_changed)
 
         !> Two instances of the dependency configuration
-        class(dependency_config_t), intent(in) :: this, that
+        class(dependency_config_t), intent(in) :: cached, manifest
 
         has_changed = .true.
 
         !> Perform all checks
-        if (this%name/=that%name) return
-        if (this%path/=that%path) return
-        if (allocated(this%git).neqv.allocated(that%git)) return
-        if (allocated(this%git)) then
-            if (.not.(this%git==that%git)) return
+        if (allocated(cached%git).neqv.allocated(manifest%git)) return
+        if (allocated(cached%git)) then
+            if (.not.git_matches_manifest(cached%git,manifest%git)) return
         end if
 
         !> All checks passed! The two instances are equal

--- a/test/fpm_test/test_package_dependencies.f90
+++ b/test/fpm_test/test_package_dependencies.f90
@@ -262,7 +262,7 @@ contains
     type(toml_table) :: cache, manifest
     type(toml_table), pointer :: ptr
     type(toml_key), allocatable :: list(:)
-    type(dependency_tree_t) :: deps, cached_deps
+    type(dependency_tree_t) :: deps, manifest_deps
     integer :: ii
 
     ! Create a dummy cache
@@ -283,10 +283,14 @@ contains
     call set_value(ptr, "proj-dir", "fpm-tmp1-dir")
 
     ! Load into a dependency tree
-    call new_dependency_tree(cached_deps)
-    call cached_deps%load(cache, error)
-    call cache%destroy()
+    call new_dependency_tree(deps)
+    call deps%load(cache, error)
     if (allocated(error)) return
+    ! Mark all dependencies as "cached"
+    do ii=1,deps%ndep
+        deps%dep(ii)%cached = .true.
+    end do
+    call cache%destroy()
 
     ! Create a dummy manifest, with different version
     manifest = toml_table()
@@ -303,14 +307,14 @@ contains
     call set_value(ptr, "proj-dir", "fpm-tmp1-dir")
 
     ! Load dependencies from manifest
-    call new_dependency_tree(deps)
-    call deps%load(manifest, error)
+    call new_dependency_tree(manifest_deps)
+    call manifest_deps%load(manifest, error)
     call manifest%destroy()
     if (allocated(error)) return
 
     ! Add manifest dependencies
-    do ii = 1, cached_deps%ndep
-      call deps%add(cached_deps%dep(ii), error)
+    do ii = 1, manifest_deps%ndep
+      call deps%add(manifest_deps%dep(ii), error)
       if (allocated(error)) return
     end do
 


### PR DESCRIPTION
Addressing #870. 

This update restricts the dependency update to the comparison between a _cached build_ (i.e., cache.toml) and the manifest. This still addresses the issue #837 which originated #843, but solves #870, i.e., dependencies are not replaced/marked for update when duplicates are found down the dependency tree. 

@everythingfunctional please let me know if this is the intended behavior.
@awvwgk @certik @urbanjost @minhqdao I would like to also kindly request your opinions especially as far as how this behavior should fit into the upcoming version constraint resolution mechanism. 

Happy Easter everyone!
