### PR TITLE
Implement `fpm publish`

### DIFF
--- a/app/main.f90
+++ b/app/main.f90
@@ -9,6 +9,7 @@ use fpm_command_line, only: &
         fpm_install_settings, &
         fpm_update_settings, &
         fpm_clean_settings, &
+        fpm_publish_settings, &
         get_command_line_settings
 use fpm_error, only: error_t
 use fpm_filesystem, only: exists, parent_dir, join_path
@@ -16,6 +17,7 @@ use fpm, only: cmd_build, cmd_run, cmd_clean
 use fpm_cmd_install, only: cmd_install
 use fpm_cmd_new, only: cmd_new
 use fpm_cmd_update, only : cmd_update
+use fpm_cmd_publish, only: cmd_publish
 use fpm_os,  only: change_directory, get_current_directory
 
 implicit none
@@ -80,6 +82,8 @@ type is (fpm_update_settings)
     call cmd_update(settings)
 type is (fpm_clean_settings)
     call cmd_clean(settings)
+type is (fpm_publish_settings)
+    call cmd_publish(settings)
 end select
 
 if (allocated(project_root)) then

--- a/fpm.toml
+++ b/fpm.toml
@@ -11,7 +11,7 @@ macros=["FPM_RELEASE_VERSION={version}"]
 
 [dependencies]
 toml-f.git = "https://github.com/toml-f/toml-f"
-toml-f.rev = "6290b0bc5f5ebeff231625a3b6685de85f33fc79"
+toml-f.rev = "d7b892b1d074b7cfc5d75c3e0eb36ebc1f7958c1"
 M_CLI2.git = "https://github.com/urbanjost/M_CLI2.git"
 M_CLI2.rev = "7264878cdb1baff7323cc48596d829ccfe7751b8"
 jonquil.git = "https://github.com/toml-f/jonquil"

--- a/fpm.toml
+++ b/fpm.toml
@@ -7,11 +7,11 @@ copyright = "2020 fpm contributors"
 
 [dependencies]
 toml-f.git = "https://github.com/toml-f/toml-f"
-toml-f.rev = "54686e45993f3a9a1d05d5c7419f39e7d5a4eb3f"
+toml-f.rev = "6290b0bc5f5ebeff231625a3b6685de85f33fc79"
 M_CLI2.git = "https://github.com/urbanjost/M_CLI2.git"
 M_CLI2.rev = "7264878cdb1baff7323cc48596d829ccfe7751b8"
 jonquil.git = "https://github.com/toml-f/jonquil"
-jonquil.rev = "05d30818bb12fb877226ce284b9a3a41b971a889"
+jonquil.rev = "4c27c8c1e411fa8790dffcf8c3fa7a27b6322273"
 
 [[test]]
 name = "cli-test"

--- a/src/fpm.f90
+++ b/src/fpm.f90
@@ -7,7 +7,6 @@ use fpm_command_line, only: fpm_build_settings, fpm_new_settings, &
                       fpm_run_settings, fpm_install_settings, fpm_test_settings, &
                       fpm_clean_settings
 use fpm_dependency, only : new_dependency_tree
-use fpm_environment, only: get_env
 use fpm_filesystem, only: is_dir, join_path, list_files, exists, &
                    basename, filewrite, mkdir, run, os_delete_dir
 use fpm_model, only: fpm_model_t, srcfile_t, show_model, fortran_features_t, &

--- a/src/fpm/cmd/publish.f90
+++ b/src/fpm/cmd/publish.f90
@@ -1,14 +1,12 @@
 !> Upload a package to the registry using the `publish` command.
 !>
 !> To upload a package you need to provide a token that will be linked to your username and will be created
-!> for a namespace. The token can be obtained from the registry website. It can be used as
-!> `fpm publish --token <token>`.
+!> for a namespace. The token can be obtained from the registry website. It can be used as `fpm publish --token <token>`.
 module fpm_cmd_publish
   use fpm_command_line, only: fpm_publish_settings
   use fpm_manifest, only: package_config_t, get_package_data
   use fpm_model, only: fpm_model_t
   use fpm_error, only: error_t, fpm_stop
-  use fpm, only: build_model
   use fpm_versioning, only: version_t
   use fpm_filesystem, only: exists, join_path, get_tmp_directory
   use fpm_git, only: git_archive, compressed_package_name
@@ -36,15 +34,10 @@ contains
     type(downloader_t) :: downloader
     integer :: i
 
-    call get_package_data(package, "fpm.toml", error, apply_defaults=.true.)
+    call get_package_data(package, 'fpm.toml', error, apply_defaults=.true.)
     if (allocated(error)) call fpm_stop(1, '*cmd_build* Package error: '//error%message)
 
-    call build_model(model, settings%fpm_build_settings, package, error)
-    if (allocated(error)) call fpm_stop(1, '*cmd_build* Model error: '//error%message)
-
-    ! Determine version of the root package after building the model.
-    if (size(model%deps%dep) < 1) call fpm_stop(1, 'Root package not found.')
-    version = model%deps%dep(1)%version
+    version = package%version
 
     if (settings%show_package_version) then
       print *, version%s(); return

--- a/src/fpm/cmd/publish.f90
+++ b/src/fpm/cmd/publish.f90
@@ -41,11 +41,13 @@ contains
     if (.not. allocated(package%license)) call fpm_stop(1, 'No license specified in fpm.toml.')
     if (.not. allocated(version)) call fpm_stop(1, 'No version specified in fpm.toml.')
     if (version%s() == '0') call fpm_stop(1, 'Invalid version: "'//version%s()//'".')
+    if (.not. allocated(settings%token)) call fpm_stop(1, 'No token provided.')
 
     if (settings%show_request) then
       call set_value(json, 'package_name', package%name)
       call set_value(json, 'package_license', package%license)
       call set_value(json, 'package_version', version%s())
+      call set_value(json, 'upload_token', settings%token)
       print *, json_serialize(json)
     else
       print *, 'Start publishing ...'

--- a/src/fpm/cmd/publish.f90
+++ b/src/fpm/cmd/publish.f90
@@ -1,6 +1,6 @@
 !> Upload a package to the registry using the `publish` command.
 !>
-!> To upload a package you need to provide a token that will be linked to your username and be created for a namespace.
+!> To upload a package you need to provide a token that will be linked to your username and created for a namespace.
 !> The token can be obtained from the registry website. It can be used as `fpm publish --token <token>`.
 module fpm_cmd_publish
   use fpm_command_line, only: fpm_publish_settings

--- a/src/fpm/cmd/publish.f90
+++ b/src/fpm/cmd/publish.f90
@@ -1,0 +1,33 @@
+module fpm_cmd_publish
+  use fpm_command_line, only: fpm_publish_settings
+  use fpm_manifest, only: package_config_t, get_package_data
+  use fpm_model, only: fpm_model_t
+  use fpm_error, only: error_t, fpm_stop
+  use fpm, only: build_model
+
+  implicit none
+  private
+  public :: cmd_publish
+
+contains
+
+  subroutine cmd_publish(settings)
+    type(fpm_publish_settings), intent(in) :: settings
+
+    type(package_config_t) :: package
+    type(fpm_model_t) :: model
+    type(error_t), allocatable :: error
+
+    call get_package_data(package, "fpm.toml", error, apply_defaults=.true.)
+    if (allocated(error)) call fpm_stop(1, '*cmd_build* Package error: '//error%message)
+
+    call build_model(model, settings%fpm_build_settings, package, error)
+    if (allocated(error)) call fpm_stop(1, '*cmd_build* Model error: '//error%message)
+
+    if (settings%print_request) then
+      print *, 'Print JSON ...'
+    else
+      print *, 'Start publishing ...'
+    end if
+  end
+end

--- a/src/fpm/cmd/publish.f90
+++ b/src/fpm/cmd/publish.f90
@@ -71,7 +71,7 @@ contains
         print *, form_data(i)%s
       end do
     else
-      call downloader%upload_form(official_registry_base_url//'packages', form_data, error)
+      call downloader%upload_form(official_registry_base_url//'/packages', form_data, error)
       if (allocated(error)) call fpm_stop(1, '*cmd_publish* Upload error: '//error%message)
     end if
   end

--- a/src/fpm/cmd/publish.f90
+++ b/src/fpm/cmd/publish.f90
@@ -30,8 +30,12 @@ contains
     if (size(model%deps%dep) < 1) call fpm_stop(1, 'Root package not found.')
     version = model%deps%dep(1)%version
 
+    if (settings%print_package_version) then
+      print *, version%s(); return
+    end if
+
     if (settings%print_request) then
-      print *, 'Print JSON ...'
+      print *, 'Print JSON fpm ...'
     else
       print *, 'Start publishing ...'
     end if

--- a/src/fpm/cmd/publish.f90
+++ b/src/fpm/cmd/publish.f90
@@ -30,12 +30,12 @@ contains
     if (size(model%deps%dep) < 1) call fpm_stop(1, 'Root package not found.')
     version = model%deps%dep(1)%version
 
-    if (settings%print_package_version) then
+    if (settings%show_package_version) then
       print *, version%s(); return
     end if
 
-    if (settings%print_request) then
-      print *, 'Print JSON fpm ...'
+    if (settings%show_request) then
+      print *, 'Show JSON ...'
     else
       print *, 'Start publishing ...'
     end if

--- a/src/fpm/cmd/publish.f90
+++ b/src/fpm/cmd/publish.f90
@@ -53,6 +53,13 @@ contains
       call fpm_stop(1, 'No "fpm.toml" file in "'//settings%source_path//'".')
     end if
 
+    ! Check if package contains git dependencies. Only publish packages without git dependencies.
+    do i = 1, model%deps%ndep
+      if (allocated(model%deps%dep(i)%git)) then
+        call fpm_stop(1, "Do not publish packages containing git dependencies. '"//model%deps%dep(i)%name//"' is a git dependency.")
+      end if
+    end do
+
     form_data = [ &
       string_t('package_name="'//package%name//'"'), &
       string_t('package_license="'//package%license//'"'), &

--- a/src/fpm/cmd/publish.f90
+++ b/src/fpm/cmd/publish.f90
@@ -9,6 +9,7 @@ module fpm_cmd_publish
   use fpm_git, only: git_archive, compressed_package_name
   use fpm_downloader, only: downloader_t
   use fpm_strings, only: string_t
+  use fpm_settings, only: official_registry_base_url
 
   implicit none
   private
@@ -70,7 +71,7 @@ contains
         print *, form_data(i)%s
       end do
     else
-      call downloader%upload_form(form_data, error)
+      call downloader%upload_form(official_registry_base_url//'packages', form_data, error)
       if (allocated(error)) call fpm_stop(1, '*cmd_publish* Upload error: '//error%message)
     end if
   end

--- a/src/fpm/cmd/publish.f90
+++ b/src/fpm/cmd/publish.f90
@@ -1,7 +1,7 @@
 !> Upload a package to the registry using the `publish` command.
 !>
-!> To upload a package you need to provide a token that will be linked to your username and will be created
-!> for a namespace. The token can be obtained from the registry website. It can be used as `fpm publish --token <token>`.
+!> To upload a package you need to provide a token that will be linked to your username and be created for a namespace.
+!> The token can be obtained from the registry website. It can be used as `fpm publish --token <token>`.
 module fpm_cmd_publish
   use fpm_command_line, only: fpm_publish_settings
   use fpm_manifest, only: package_config_t, get_package_data
@@ -20,7 +20,7 @@ module fpm_cmd_publish
 
 contains
 
-  !> The `publish` command first builds the model to obtain all the relevant information of the package such as the
+  !> The `publish` command first builds the root package to obtain all the relevant information such as the
   !> package version. It then creates a tarball of the package and uploads it to the registry.
   subroutine cmd_publish(settings)
     type(fpm_publish_settings), intent(inout) :: settings

--- a/src/fpm/cmd/publish.f90
+++ b/src/fpm/cmd/publish.f90
@@ -1,4 +1,8 @@
-!> Upload a package to the registry using the `publish` command (`fpm publish`).
+!> Upload a package to the registry using the `publish` command.
+!>
+!> To upload a package you need to provide a token that will be linked to your username and will be created
+!> for a namespace. The token can be obtained from the registry website. It can be used as
+!> `fpm publish --token <token>`.
 module fpm_cmd_publish
   use fpm_command_line, only: fpm_publish_settings
   use fpm_manifest, only: package_config_t, get_package_data

--- a/src/fpm/cmd/publish.f90
+++ b/src/fpm/cmd/publish.f90
@@ -1,3 +1,4 @@
+!> Upload a package to the registry using the `publish` command (`fpm publish`).
 module fpm_cmd_publish
   use fpm_command_line, only: fpm_publish_settings
   use fpm_manifest, only: package_config_t, get_package_data
@@ -17,6 +18,8 @@ module fpm_cmd_publish
 
 contains
 
+  !> The `publish` command first builds the model to obtain all the relevant information of the package such as the
+  !> package version. It then creates a tarball of the package and uploads it to the registry.
   subroutine cmd_publish(settings)
     type(fpm_publish_settings), intent(inout) :: settings
 
@@ -43,6 +46,7 @@ contains
       print *, version%s(); return
     end if
 
+    !> Checks before uploading the package.
     if (.not. allocated(package%license)) call fpm_stop(1, 'No license specified in fpm.toml.')
     if (.not. allocated(version)) call fpm_stop(1, 'No version specified in fpm.toml.')
     if (version%s() == '0') call fpm_stop(1, 'Invalid version: "'//version%s()//'".')

--- a/src/fpm/cmd/publish.f90
+++ b/src/fpm/cmd/publish.f90
@@ -4,6 +4,7 @@ module fpm_cmd_publish
   use fpm_model, only: fpm_model_t
   use fpm_error, only: error_t, fpm_stop
   use fpm, only: build_model
+  use fpm_versioning, only: version_t
 
   implicit none
   private
@@ -17,12 +18,17 @@ contains
     type(package_config_t) :: package
     type(fpm_model_t) :: model
     type(error_t), allocatable :: error
+    type(version_t) :: version
 
     call get_package_data(package, "fpm.toml", error, apply_defaults=.true.)
     if (allocated(error)) call fpm_stop(1, '*cmd_build* Package error: '//error%message)
 
     call build_model(model, settings%fpm_build_settings, package, error)
     if (allocated(error)) call fpm_stop(1, '*cmd_build* Model error: '//error%message)
+
+    ! Determine version of the root package after building the model.
+    if (size(model%deps%dep) < 1) call fpm_stop(1, 'Root package not found.')
+    version = model%deps%dep(1)%version
 
     if (settings%print_request) then
       print *, 'Print JSON ...'

--- a/src/fpm/cmd/publish.f90
+++ b/src/fpm/cmd/publish.f90
@@ -51,11 +51,7 @@ contains
     if (.not. allocated(version)) call fpm_stop(1, 'No version specified in fpm.toml.')
     if (version%s() == '0') call fpm_stop(1, 'Invalid version: "'//version%s()//'".')
     if (.not. allocated(settings%token)) call fpm_stop(1, 'No token provided.')
-    if (.not. allocated(settings%source_path)) settings%source_path = '.'
-    if (.not. exists(settings%source_path)) call fpm_stop(1, 'Source path does not exist: "'//settings%source_path//'".')
-    if (.not. exists(join_path(settings%source_path, 'fpm.toml'))) then
-      call fpm_stop(1, 'No "fpm.toml" file in "'//settings%source_path//'".')
-    end if
+    if (.not. exists('fpm.toml')) call fpm_stop(1, "Cannot find 'fpm.toml' file. Are you in your project root?")
 
     ! Check if package contains git dependencies. Only publish packages without git dependencies.
     do i = 1, model%deps%ndep
@@ -73,7 +69,7 @@ contains
 
     call get_tmp_directory(tmpdir, error)
     if (allocated(error)) call fpm_stop(1, '*cmd_publish* Tmp directory error: '//error%message)
-    call git_archive(settings%source_path, tmpdir, error)
+    call git_archive('.', tmpdir, error)
     if (allocated(error)) call fpm_stop(1, '*cmd_publish* Pack error: '//error%message)
     form_data = [form_data, string_t('tarball=@"'//join_path(tmpdir, compressed_package_name)//'"')]
 

--- a/src/fpm/cmd/publish.f90
+++ b/src/fpm/cmd/publish.f90
@@ -41,12 +41,14 @@ contains
     if (.not. allocated(package%license)) call fpm_stop(1, 'No license specified in fpm.toml.')
     if (.not. allocated(version)) call fpm_stop(1, 'No version specified in fpm.toml.')
     if (version%s() == '0') call fpm_stop(1, 'Invalid version: "'//version%s()//'".')
+    if (.not. allocated(settings%source_path)) call fpm_stop(1, 'No source path provided.')
     if (.not. allocated(settings%token)) call fpm_stop(1, 'No token provided.')
 
     if (settings%show_request) then
       call set_value(json, 'package_name', package%name)
       call set_value(json, 'package_license', package%license)
       call set_value(json, 'package_version', version%s())
+      call set_value(json, 'tarball', settings%source_path)
       call set_value(json, 'upload_token', settings%token)
       print *, json_serialize(json)
     else

--- a/src/fpm/cmd/publish.f90
+++ b/src/fpm/cmd/publish.f90
@@ -13,6 +13,7 @@ module fpm_cmd_publish
   use fpm_downloader, only: downloader_t
   use fpm_strings, only: string_t
   use fpm_settings, only: official_registry_base_url
+  use fpm, only: build_model
 
   implicit none
   private
@@ -36,12 +37,11 @@ contains
 
     call get_package_data(package, 'fpm.toml', error, apply_defaults=.true.)
     if (allocated(error)) call fpm_stop(1, '*cmd_build* Package error: '//error%message)
-
     version = package%version
 
-    if (settings%show_package_version) then
-      print *, version%s(); return
-    end if
+    ! Build model to obtain dependency tree.
+    call build_model(model, settings%fpm_build_settings, package, error)
+    if (allocated(error)) call fpm_stop(1, '*cmd_build* Model error: '//error%message)
 
     !> Checks before uploading the package.
     if (.not. allocated(package%license)) call fpm_stop(1, 'No license specified in fpm.toml.')

--- a/src/fpm/dependency.f90
+++ b/src/fpm/dependency.f90
@@ -668,8 +668,8 @@ contains
 
     ! Define location of the temporary folder and file.
     tmp_pkg_path = join_path(global_settings%path_to_config_folder, 'tmp')
-    tmp_pkg_file = join_path(tmp_pkg_path, 'package_data.tmp')
     if (.not. exists(tmp_pkg_path)) call mkdir(tmp_pkg_path)
+    tmp_pkg_file = join_path(tmp_pkg_path, 'package_data.tmp')
     open (newunit=unit, file=tmp_pkg_file, action='readwrite', iostat=stat)
     if (stat /= 0) then
       call fatal_error(error, "Error creating temporary file for downloading package '"//self%name//"'."); return
@@ -697,7 +697,6 @@ contains
       if (is_dir(cache_path)) call os_delete_dir(os_is_unix(), cache_path)
       call mkdir(cache_path)
 
-      print *, "Downloading '"//join_path(self%namespace, self%name, version%s())//"' ..."
       call downloader%get_file(target_url, tmp_pkg_file, error)
       if (allocated(error)) then
         close (unit, status='delete'); return
@@ -782,7 +781,7 @@ contains
       call fatal_error(error, "Failed to read download url for '"//join_path(node%namespace, node%name)//"'."); return
     end if
 
-    download_url = official_registry_base_url//'/'//download_url
+    download_url = official_registry_base_url//download_url
 
     if (.not. q%has_key('version')) then
       call fatal_error(error, "Failed to download '"//join_path(node%namespace, node%name)//"': No version found."); return

--- a/src/fpm/downloader.f90
+++ b/src/fpm/downloader.f90
@@ -91,7 +91,7 @@ contains
     if (which('curl') /= '') then
       print *, 'Uploading package ...'
       call execute_command_line('curl -X POST -H "Content-Type: multipart/form-data" ' &
-      & //form_data_str//' '//endpoint, exitstat=stat)
+      & //form_data_str//endpoint, exitstat=stat)
     else
       call fatal_error(error, "'curl' not installed."); return
     end if

--- a/src/fpm/downloader.f90
+++ b/src/fpm/downloader.f90
@@ -79,6 +79,26 @@ contains
     character(len=*), intent(in) :: endpoint
     type(string_t), intent(in) :: form_data(:)
     type(error_t), allocatable, intent(out) :: error
+
+    integer :: stat, i
+    character(len=:), allocatable :: form_data_str
+
+    form_data_str = ''
+    do i = 1, size(form_data)
+      form_data_str = form_data_str//"-F '"//form_data(i)%s//"' "
+    end do
+
+    if (which('curl') /= '') then
+      print *, 'Uploading package ...'
+      call execute_command_line('curl -X POST -H "Content-Type: multipart/form-data" ' &
+      & //form_data_str//' '//endpoint, exitstat=stat)
+    else
+      call fatal_error(error, "'curl' not installed."); return
+    end if
+
+    if (stat /= 0) then
+      call fatal_error(error, "Error uploading package to registry."); return
+    end if
   end
 
   !> Unpack a tarball to a destination.

--- a/src/fpm/downloader.f90
+++ b/src/fpm/downloader.f90
@@ -75,7 +75,8 @@ contains
   end
 
   !> Perform an http post request with form data.
-  subroutine upload_form(form_data, error)
+  subroutine upload_form(endpoint, form_data, error)
+    character(len=*), intent(in) :: endpoint
     type(string_t), intent(in) :: form_data(:)
     type(error_t), allocatable, intent(out) :: error
   end

--- a/src/fpm/downloader.f90
+++ b/src/fpm/downloader.f90
@@ -18,7 +18,7 @@ module fpm_downloader
 
 contains
 
-  !> Perform an http get request and save output to file.
+  !> Perform an http get request, save output to file, and parse json.
   subroutine get_pkg_data(url, version, tmp_pkg_file, json, error)
     character(*), intent(in) :: url
     type(version_t), allocatable, intent(in) :: version
@@ -52,6 +52,7 @@ contains
     json = ptr
   end
 
+  !> Download a file from a url using either curl or wget.
   subroutine get_file(url, tmp_pkg_file, error)
     character(*), intent(in) :: url
     character(*), intent(in) :: tmp_pkg_file
@@ -60,10 +61,10 @@ contains
     integer :: stat
 
     if (which('curl') /= '') then
-      print *, "Downloading package data from '"//url//"' ..."
+      print *, "Downloading '"//url//"' -> '"//tmp_pkg_file//"'"
       call execute_command_line('curl '//url//' -s -o '//tmp_pkg_file, exitstat=stat)
     else if (which('wget') /= '') then
-      print *, "Downloading package data from '"//url//"' ..."
+      print *, "Downloading '"//url//"' -> '"//tmp_pkg_file//"'"
       call execute_command_line('wget '//url//' -q -O '//tmp_pkg_file, exitstat=stat)
     else
       call fatal_error(error, "Neither 'curl' nor 'wget' installed."); return

--- a/src/fpm/downloader.f90
+++ b/src/fpm/downloader.f90
@@ -12,7 +12,7 @@ module fpm_downloader
   !> This type could be entirely avoided but it is quite practical because it can be mocked for testing.
   type downloader_t
   contains
-    procedure, nopass :: get_pkg_data, get_file, unpack
+    procedure, nopass :: get_pkg_data, get_file, upload_form, unpack
   end type
 
 contains
@@ -71,6 +71,12 @@ contains
     if (stat /= 0) then
       call fatal_error(error, "Error downloading package from '"//url//"'."); return
     end if
+  end
+
+  !> Perform an http post request with form data.
+  subroutine upload_form(json, error)
+    type(json_object), intent(in) :: json
+    type(error_t), allocatable, intent(out) :: error
   end
 
   !> Unpack a tarball to a destination.

--- a/src/fpm/downloader.f90
+++ b/src/fpm/downloader.f90
@@ -3,6 +3,7 @@ module fpm_downloader
   use fpm_filesystem, only: which
   use fpm_versioning, only: version_t
   use jonquil, only: json_object, json_value, json_error, json_load, cast_to_object
+  use fpm_strings, only: string_t
 
   implicit none
   private
@@ -74,8 +75,8 @@ contains
   end
 
   !> Perform an http post request with form data.
-  subroutine upload_form(json, error)
-    type(json_object), intent(in) :: json
+  subroutine upload_form(form_data, error)
+    type(string_t), intent(in) :: form_data(:)
     type(error_t), allocatable, intent(out) :: error
   end
 

--- a/src/fpm/error.f90
+++ b/src/fpm/error.f90
@@ -171,7 +171,7 @@ contains
            flush(unit=stderr,iostat=iostat)
            flush(unit=stdout,iostat=iostat)
            if(value>0)then
-              write(stderr,'("<ERROR>",a)')trim(message)
+              write(stderr,'("<ERROR> ",a)')trim(message)
            else
               write(stderr,'("<INFO> ",a)')trim(message)
            endif

--- a/src/fpm/git.f90
+++ b/src/fpm/git.f90
@@ -5,7 +5,10 @@ module fpm_git
     implicit none
 
     public :: git_target_t, git_target_default, git_target_branch, git_target_tag, git_target_revision, git_revision, &
-            & git_archive, git_matches_manifest, operator(==)
+            & git_archive, git_matches_manifest, operator(==), compressed_package_name
+    
+    !> Name of the compressed package that is generated temporarily.
+    character(len=*), parameter :: compressed_package_name = 'compressed_package'
 
     !> Possible git target
     type :: enum_descriptor
@@ -324,7 +327,7 @@ contains
     end if
 
     call execute_command_line('git archive HEAD --format='//archive_format//' -o '// &
-    & join_path(destination, 'compressed_package'), exitstat=stat)
+    & join_path(destination, compressed_package_name), exitstat=stat)
     if (stat /= 0) then
       call fatal_error(error, "Error packing '"//source//"'."); return
     end if

--- a/src/fpm/git.f90
+++ b/src/fpm/git.f90
@@ -307,23 +307,23 @@ contains
 
   !> Archive a folder using `git archive`.
   subroutine git_archive(source, destination, error)
-    !> Directory to pack.
+    !> Directory to archive.
     character(*), intent(in) :: source
-    !> Destination to pack to.
+    !> Destination of the archive.
     character(*), intent(in) :: destination
     !> Error handling.
     type(error_t), allocatable, intent(out) :: error
 
     integer :: stat
-    character(len=:), allocatable :: output, archive_format
+    character(len=:), allocatable :: cmd_output, archive_format
 
-    call execute_and_read_output('git archive -l', output, error)
+    call execute_and_read_output('git archive -l', cmd_output, error)
     if (allocated(error)) return
 
-    if (index(output, 'tar.gz') /= 0) then
+    if (index(cmd_output, 'tar.gz') /= 0) then
       archive_format = 'tar.gz'
     else
-      call fatal_error(error, "Cannot find a suitable archive format for 'git archive'.")
+      call fatal_error(error, "Cannot find a suitable archive format for 'git archive'."); return
     end if
 
     call execute_command_line('git archive HEAD --format='//archive_format//' -o '// &

--- a/src/fpm/manifest/package.f90
+++ b/src/fpm/manifest/package.f90
@@ -80,6 +80,9 @@ module fpm_manifest_package
         !> Fortran meta data
         type(fortran_config_t) :: fortran
 
+        !> License meta data
+        character(len=:), allocatable :: license
+
         !> Library meta data
         type(library_config_t), allocatable :: library
 
@@ -150,6 +153,8 @@ contains
         if (bad_name_error(error,'package',self%name))then
            return
         endif
+
+        call get_value(table, "license", self%license)
 
         if (len(self%name) <= 0) then
             call syntax_error(error, "Package name must be a non-empty string")

--- a/src/fpm/manifest/test.f90
+++ b/src/fpm/manifest/test.f90
@@ -15,7 +15,7 @@
 !>[test.dependencies]
 !>```
 module fpm_manifest_test
-    use fpm_manifest_dependency, only : dependency_config_t, new_dependencies
+    use fpm_manifest_dependency, only : new_dependencies
     use fpm_manifest_executable, only : executable_config_t
     use fpm_error, only : error_t, syntax_error, bad_name_error
     use fpm_toml, only : toml_table, toml_key, toml_stat, get_value, get_list

--- a/src/fpm_command_line.f90
+++ b/src/fpm_command_line.f90
@@ -118,6 +118,7 @@ type, extends(fpm_cmd_settings)   :: fpm_clean_settings
 end type
 
 type, extends(fpm_build_settings) :: fpm_publish_settings
+    logical :: print_package_version = .false.
     logical :: print_request = .false.
 end type
 
@@ -610,6 +611,7 @@ contains
 
         case('publish')
             call set_args(common_args // compiler_args //'&
+            & --print-package-version F &
             & --print-request F &
             & --list F &
             & --show-model F &
@@ -623,6 +625,7 @@ contains
             archiver = sget('archiver')
 
             cmd_settings = fpm_publish_settings( &
+            & print_package_version = lget('print-package-version'), &
             & print_request = lget('print-request'), &
             & profile=val_profile,&
             & prune=.not.lget('no-prune'), &
@@ -739,7 +742,7 @@ contains
    ' install [--profile PROF] [--flag FFLAGS] [--no-rebuild] [--prefix PATH]        ', &
    '         [options]                                                              ', &
    ' clean [--skip] [--all]                                                         ', &
-   ' publish [--print-request]                                                      ', &
+   ' publish [--print-package-version] [--print-request]                            ', &
    ' ']
     help_usage=[character(len=80) :: &
     '' ]
@@ -1348,6 +1351,7 @@ contains
     ' Collect relevant source files and upload package to the registry.', &
     '', &
     'OPTIONS', &
+    ' --print-package-version   print package version to console without publishing', &
     ' --print-request           print request to console without publishing', &
     '' ]
      end subroutine set_help

--- a/src/fpm_command_line.f90
+++ b/src/fpm_command_line.f90
@@ -118,8 +118,8 @@ type, extends(fpm_cmd_settings)   :: fpm_clean_settings
 end type
 
 type, extends(fpm_build_settings) :: fpm_publish_settings
-    logical :: print_package_version = .false.
-    logical :: print_request = .false.
+    logical :: show_package_version = .false.
+    logical :: show_request = .false.
 end type
 
 character(len=:),allocatable :: name
@@ -611,8 +611,8 @@ contains
 
         case('publish')
             call set_args(common_args // compiler_args //'&
-            & --print-package-version F &
-            & --print-request F &
+            & --show-package-version F &
+            & --show-request F &
             & --list F &
             & --show-model F &
             & --tests F &
@@ -625,8 +625,8 @@ contains
             archiver = sget('archiver')
 
             cmd_settings = fpm_publish_settings( &
-            & print_package_version = lget('print-package-version'), &
-            & print_request = lget('print-request'), &
+            & show_package_version = lget('show-package-version'), &
+            & show_request = lget('show-request'), &
             & profile=val_profile,&
             & prune=.not.lget('no-prune'), &
             & compiler=val_compiler, &
@@ -742,7 +742,7 @@ contains
    ' install [--profile PROF] [--flag FFLAGS] [--no-rebuild] [--prefix PATH]        ', &
    '         [options]                                                              ', &
    ' clean [--skip] [--all]                                                         ', &
-   ' publish [--print-package-version] [--print-request]                            ', &
+   ' publish [--show-package-version] [--show-request]                            ', &
    ' ']
     help_usage=[character(len=80) :: &
     '' ]
@@ -1351,8 +1351,8 @@ contains
     ' Collect relevant source files and upload package to the registry.', &
     '', &
     'OPTIONS', &
-    ' --print-package-version   print package version to console without publishing', &
-    ' --print-request           print request to console without publishing', &
+    ' --show-package-version   show package version without publishing', &
+    ' --show-request           show request without publishing', &
     '' ]
      end subroutine set_help
 

--- a/src/fpm_command_line.f90
+++ b/src/fpm_command_line.f90
@@ -1366,7 +1366,7 @@ contains
     '', &
     'OPTIONS', &
     ' --show-package-version   show package version without publishing', &
-    ' --show-form-data         show request without publishing', &
+    ' --show-form-data         show sent form data without publishing', &
     '' ]
      end subroutine set_help
 

--- a/src/fpm_command_line.f90
+++ b/src/fpm_command_line.f90
@@ -121,7 +121,6 @@ type, extends(fpm_build_settings) :: fpm_publish_settings
     logical :: show_package_version = .false.
     logical :: show_form_data = .false.
     character(len=:), allocatable :: token
-    character(len=:), allocatable :: source_path
 end type
 
 character(len=:),allocatable :: name
@@ -617,7 +616,6 @@ contains
             & --show-package-version F &
             & --show-form-data F &
             & --token " " &
-            & --source-path " " &
             & --list F &
             & --show-model F &
             & --tests F &
@@ -647,7 +645,6 @@ contains
             & build_tests=lget('tests'),&
             & verbose=lget('verbose')))
             call get_char_arg(publish_settings%token, 'token')
-            call get_char_arg(publish_settings%source_path, 'source-path')
             call move_alloc(publish_settings, cmd_settings)
 
         case default
@@ -750,8 +747,7 @@ contains
    ' install [--profile PROF] [--flag FFLAGS] [--no-rebuild] [--prefix PATH]        ', &
    '         [options]                                                              ', &
    ' clean [--skip] [--all]                                                         ', &
-   ' publish [--show-package-version] [--show-form-data] [--token TOKEN]              ', &
-   '         [--source-path PATH]                                                   ', &
+   ' publish [--show-package-version] [--show-form-data] [--token TOKEN]            ', &
    ' ']
     help_usage=[character(len=80) :: &
     '' ]
@@ -875,8 +871,7 @@ contains
     '    install [--profile PROF] [--flag FFLAGS] [--no-rebuild] [--prefix PATH]     ', &
     '            [options]                                                           ', &
     '    clean [--skip] [--all]                                                      ', &
-    '    publish [--show-package-version] [--show-form-data] [--token TOKEN]           ', &
-    '            [--source-path PATH]                                                ', &
+    '    publish [--show-package-version] [--show-form-data] [--token TOKEN]         ', &
     '                                                                                ', &
     'SUBCOMMAND OPTIONS                                                              ', &
     ' -C, --directory PATH', &
@@ -1357,7 +1352,7 @@ contains
     ' publish(1) - publish package to the registry', &
     '', &
     'SYNOPSIS', &
-    ' fpm publish [--token TOKEN] [--source-path PATH]', &
+    ' fpm publish [--token TOKEN]', &
     '', &
     'DESCRIPTION', &
     ' Collect relevant source files and upload package to the registry.', &

--- a/src/fpm_command_line.f90
+++ b/src/fpm_command_line.f90
@@ -121,6 +121,7 @@ type, extends(fpm_build_settings) :: fpm_publish_settings
     logical :: show_package_version = .false.
     logical :: show_request = .false.
     character(len=:), allocatable :: token
+    character(len=:), allocatable :: source_path
 end type
 
 character(len=:),allocatable :: name
@@ -616,6 +617,7 @@ contains
             & --show-package-version F &
             & --show-request F &
             & --token " " &
+            & --source-path " " &
             & --list F &
             & --show-model F &
             & --tests F &
@@ -645,6 +647,7 @@ contains
             & build_tests=lget('tests'),&
             & verbose=lget('verbose')))
             call get_char_arg(publish_settings%token, 'token')
+            call get_char_arg(publish_settings%source_path, 'source-path')
             call move_alloc(publish_settings, cmd_settings)
 
         case default
@@ -748,6 +751,7 @@ contains
    '         [options]                                                              ', &
    ' clean [--skip] [--all]                                                         ', &
    ' publish [--show-package-version] [--show-request] [--token TOKEN]              ', &
+   '         [--source-path PATH]                                                   ', &
    ' ']
     help_usage=[character(len=80) :: &
     '' ]
@@ -872,6 +876,7 @@ contains
     '            [options]                                                           ', &
     '    clean [--skip] [--all]                                                      ', &
     '    publish [--show-package-version] [--show-request] [--token TOKEN]           ', &
+    '            [--source-path PATH]                                                ', &
     '                                                                                ', &
     'SUBCOMMAND OPTIONS                                                              ', &
     ' -C, --directory PATH', &
@@ -1352,7 +1357,7 @@ contains
     ' publish(1) - publish package to the registry', &
     '', &
     'SYNOPSIS', &
-    ' fpm publish [--token TOKEN]', &
+    ' fpm publish [--token TOKEN] [--source-path PATH]', &
     '', &
     'DESCRIPTION', &
     ' Collect relevant source files and upload package to the registry.', &

--- a/src/fpm_command_line.f90
+++ b/src/fpm_command_line.f90
@@ -119,7 +119,7 @@ end type
 
 type, extends(fpm_build_settings) :: fpm_publish_settings
     logical :: show_package_version = .false.
-    logical :: show_request = .false.
+    logical :: show_form_data = .false.
     character(len=:), allocatable :: token
     character(len=:), allocatable :: source_path
 end type
@@ -615,7 +615,7 @@ contains
         case('publish')
             call set_args(common_args // compiler_args //'&
             & --show-package-version F &
-            & --show-request F &
+            & --show-form-data F &
             & --token " " &
             & --source-path " " &
             & --list F &
@@ -631,7 +631,7 @@ contains
 
             allocate(publish_settings, source=fpm_publish_settings( &
             & show_package_version = lget('show-package-version'), &
-            & show_request = lget('show-request'), &
+            & show_form_data = lget('show-form-data'), &
             & profile=val_profile,&
             & prune=.not.lget('no-prune'), &
             & compiler=val_compiler, &
@@ -750,7 +750,7 @@ contains
    ' install [--profile PROF] [--flag FFLAGS] [--no-rebuild] [--prefix PATH]        ', &
    '         [options]                                                              ', &
    ' clean [--skip] [--all]                                                         ', &
-   ' publish [--show-package-version] [--show-request] [--token TOKEN]              ', &
+   ' publish [--show-package-version] [--show-form-data] [--token TOKEN]              ', &
    '         [--source-path PATH]                                                   ', &
    ' ']
     help_usage=[character(len=80) :: &
@@ -875,7 +875,7 @@ contains
     '    install [--profile PROF] [--flag FFLAGS] [--no-rebuild] [--prefix PATH]     ', &
     '            [options]                                                           ', &
     '    clean [--skip] [--all]                                                      ', &
-    '    publish [--show-package-version] [--show-request] [--token TOKEN]           ', &
+    '    publish [--show-package-version] [--show-form-data] [--token TOKEN]           ', &
     '            [--source-path PATH]                                                ', &
     '                                                                                ', &
     'SUBCOMMAND OPTIONS                                                              ', &
@@ -1366,7 +1366,7 @@ contains
     '', &
     'OPTIONS', &
     ' --show-package-version   show package version without publishing', &
-    ' --show-request           show request without publishing', &
+    ' --show-form-data         show request without publishing', &
     '' ]
      end subroutine set_help
 

--- a/src/fpm_filesystem.F90
+++ b/src/fpm_filesystem.F90
@@ -1023,9 +1023,13 @@ end subroutine os_delete_dir
 
     !> Execute command line and return output as a string.
     subroutine execute_and_read_output(cmd, output, error, exitstat)
+        !> Command to execute.
         character(len=*), intent(in) :: cmd
+        !> Command line output.
         character(len=:), allocatable, intent(out) :: output
+        !> Error to handle.
         type(error_t), allocatable, intent(out) :: error
+        !> Can optionally used for error handling.
         integer, intent(out), optional :: exitstat
 
         integer :: cmdstat, unit, stat = 0
@@ -1058,7 +1062,9 @@ end subroutine os_delete_dir
 
     !> Get system-dependent tmp directory.
     subroutine get_tmp_directory(tmp_dir, error)
+        !> System-dependant tmp directory.
         character(len=:), allocatable, intent(out) :: tmp_dir
+        !> Error to handle.
         type(error_t), allocatable, intent(out) :: error
 
         tmp_dir = get_env('TMPDIR', '')

--- a/src/fpm_filesystem.F90
+++ b/src/fpm_filesystem.F90
@@ -1063,17 +1063,17 @@ end subroutine os_delete_dir
 
         tmp_dir = get_env('TMPDIR', '')
         if (tmp_dir /= '') then
-          tmp_dir = join_path(tmp_dir, 'fpm'); return
+          tmp_dir = tmp_dir//'fpm'; return
         end if
 
         tmp_dir = get_env('TMP', '')
         if (tmp_dir /= '') then
-          tmp_dir = join_path(tmp_dir, 'fpm'); return
+          tmp_dir = tmp_dir//'fpm'; return
         end if
 
         tmp_dir = get_env('TEMP', '')
         if (tmp_dir /= '') then
-          tmp_dir = join_path(tmp_dir, 'fpm'); return
+          tmp_dir = tmp_dir//'fpm'; return
         end if
 
         call fatal_error(error, "Couldn't retrieve system temporary directory.")

--- a/src/fpm_filesystem.F90
+++ b/src/fpm_filesystem.F90
@@ -14,7 +14,8 @@ module fpm_filesystem
     public :: basename, canon_path, dirname, is_dir, join_path, number_of_rows, list_files, get_local_prefix, &
             mkdir, exists, get_temp_filename, windows_path, unix_path, getline, delete_file, fileopen, fileclose, &
             filewrite, warnwrite, parent_dir, is_hidden_file, read_lines, read_lines_expanded, which, run, &
-            LINE_BUFFER_LEN, os_delete_dir, is_absolute_path, env_variable, get_home
+            LINE_BUFFER_LEN, os_delete_dir, is_absolute_path, env_variable, get_home, get_tmp_directory, &
+            execute_and_read_output
     integer, parameter :: LINE_BUFFER_LEN = 1000
 
 #ifndef FPM_BOOTSTRAP
@@ -1019,5 +1020,63 @@ end subroutine os_delete_dir
             end if
         end if
     end subroutine get_home
+
+    !> Execute command line and return output as a string.
+    subroutine execute_and_read_output(cmd, output, error, exitstat)
+        character(len=*), intent(in) :: cmd
+        character(len=:), allocatable, intent(out) :: output
+        type(error_t), allocatable, intent(out) :: error
+        integer, intent(out), optional :: exitstat
+
+        integer :: cmdstat, unit, stat = 0
+        character(len=:), allocatable :: cmdmsg, tmp_path
+        character(len=1000) :: output_line
+
+        call get_tmp_directory(tmp_path, error=error)
+        if (allocated(error)) return
+
+        if (.not. exists(tmp_path)) call mkdir(tmp_path)
+        tmp_path = join_path(tmp_path, 'command_line_output')
+        call delete_file(tmp_path)
+        call filewrite(tmp_path, [''])
+
+        call execute_command_line(cmd//' > '//tmp_path, exitstat=exitstat, cmdstat=cmdstat)
+        if (cmdstat /= 0) then
+          print *, 'Command failed: "', cmd, '"'
+          call fpm_stop(1,'*run*:'//trim(cmdmsg))
+        end if
+
+        open(unit, file=tmp_path, action='read', status='old')
+        output = ''
+        do
+          read(unit, *, iostat=stat) output_line
+          if (stat /= 0) exit
+          output = output//trim(output_line)//' '
+        end do
+        close(unit, status='delete')
+    end
+
+    !> Get system-dependent tmp directory.
+    subroutine get_tmp_directory(tmp_dir, error)
+        character(len=:), allocatable, intent(out) :: tmp_dir
+        type(error_t), allocatable, intent(out) :: error
+
+        tmp_dir = get_env('TMPDIR', '')
+        if (tmp_dir /= '') then
+          tmp_dir = join_path(tmp_dir, 'fpm'); return
+        end if
+
+        tmp_dir = get_env('TMP', '')
+        if (tmp_dir /= '') then
+          tmp_dir = join_path(tmp_dir, 'fpm'); return
+        end if
+
+        tmp_dir = get_env('TEMP', '')
+        if (tmp_dir /= '') then
+          tmp_dir = join_path(tmp_dir, 'fpm'); return
+        end if
+
+        call fatal_error(error, "Couldn't retrieve system temporary directory.")
+    end
 
 end module fpm_filesystem

--- a/src/fpm_filesystem.F90
+++ b/src/fpm_filesystem.F90
@@ -1036,7 +1036,7 @@ end subroutine os_delete_dir
         character(len=:), allocatable :: cmdmsg, tmp_path
         character(len=1000) :: output_line
 
-        call get_tmp_directory(tmp_path, error=error)
+        call get_tmp_directory(tmp_path, error)
         if (allocated(error)) return
 
         if (.not. exists(tmp_path)) call mkdir(tmp_path)
@@ -1045,10 +1045,7 @@ end subroutine os_delete_dir
         call filewrite(tmp_path, [''])
 
         call execute_command_line(cmd//' > '//tmp_path, exitstat=exitstat, cmdstat=cmdstat)
-        if (cmdstat /= 0) then
-          print *, 'Command failed: "', cmd, '"'
-          call fpm_stop(1,'*run*:'//trim(cmdmsg))
-        end if
+        if (cmdstat /= 0) call fpm_stop(1,'*run*: '//"Command failed: '"//cmd//"'. Message: '"//trim(cmdmsg)//"'.")
 
         open(unit, file=tmp_path, action='read', status='old')
         output = ''
@@ -1082,7 +1079,7 @@ end subroutine os_delete_dir
           tmp_dir = tmp_dir//'fpm'; return
         end if
 
-        call fatal_error(error, "Couldn't retrieve system temporary directory.")
+        call fatal_error(error, "Couldn't determine system temporary directory.")
     end
 
 end module fpm_filesystem

--- a/src/fpm_settings.f90
+++ b/src/fpm_settings.f90
@@ -10,7 +10,7 @@ module fpm_settings
   private
   public :: fpm_global_settings, get_global_settings, get_registry_settings, official_registry_base_url
 
-  character(*), parameter :: official_registry_base_url = 'https://fpm-registry.onrender.com'
+  character(*), parameter :: official_registry_base_url = 'https://fpm-registry.vercel.app'
 
   type :: fpm_global_settings
     !> Path to the global config file excluding the file name.

--- a/src/fpm_settings.f90
+++ b/src/fpm_settings.f90
@@ -10,7 +10,7 @@ module fpm_settings
   private
   public :: fpm_global_settings, get_global_settings, get_registry_settings, official_registry_base_url
 
-  character(*), parameter :: official_registry_base_url = 'https://fpm-registry.vercel.app'
+  character(*), parameter :: official_registry_base_url = 'https://registry-apis.vercel.app'
 
   type :: fpm_global_settings
     !> Path to the global config file excluding the file name.

--- a/src/fpm_targets.f90
+++ b/src/fpm_targets.f90
@@ -146,7 +146,7 @@ subroutine targets_from_sources(targets,model,prune,error)
 
     !> Enable tree-shaking/pruning of module dependencies
     logical, intent(in) :: prune
-    
+
     !> Error structure
     type(error_t), intent(out), allocatable :: error
 

--- a/test/help_test/help_test.f90
+++ b/test/help_test/help_test.f90
@@ -34,6 +34,7 @@ character(len=*),parameter     :: cmds(*) = [character(len=80) :: &
 'help list    >> fpm_scratch_help.txt',&
 'help help    >> fpm_scratch_help.txt',&
 'help clean   >> fpm_scratch_help.txt',&
+'help publish >> fpm_scratch_help.txt',&
 '--version    >> fpm_scratch_help.txt',&
 ! generate manual
 ' help manual   > fpm_scratch_manual.txt']


### PR DESCRIPTION
Implement api for publishing a package to the registry.

- [x] Add new `fpm_publish_settings` and `fpm_cmd_publish` module.
- [x] Add procedure to find system tmp folder.
- [x] Add procedure to execute command line and read output.
- [x] Optionally show request with `--show-form-data` instead of publishing.
- [x] Optionally show package version with `--show-version` instead of publishing.
- [x] Parse license from the manifest.
- [x] Parse token from command.
- [x] Validate data.
- [x] Reject packages containing `git` dependencies.
- [x] Pack and archive using `git archive`.
- [x] Determine available archive methods with `git archive -l` and use available method.
- [x] Send request with form data using `curl`.
- [x] Add tests.

### How to test

1) Run `fpm publish --show-package-version` to print the package version to the console.

2) Run `fpm publish --show-form-data` to print the form data to the console that would otherwise be sent through `fpm publish --token <token>`. If you include the token (`fpm publish --token <token> --show-form-data`), the token will be included in the form data.

3) Get a (test) token from the registry website and run `fpm publish --token <token>` to publish a package to the (test) registry.