### PR TITLE
Fix `--show-package-version`

### DIFF
--- a/src/fpm/cmd/publish.f90
+++ b/src/fpm/cmd/publish.f90
@@ -39,6 +39,10 @@ contains
     if (allocated(error)) call fpm_stop(1, '*cmd_build* Package error: '//error%message)
     version = package%version
 
+    if (settings%show_package_version) then
+      print *, version%s(); return
+    end if
+
     ! Build model to obtain dependency tree.
     call build_model(model, settings%fpm_build_settings, package, error)
     if (allocated(error)) call fpm_stop(1, '*cmd_build* Model error: '//error%message)


### PR DESCRIPTION
`fpm publish --show-package-version` isn't working because I accidentally deleted the relevent lines in https://github.com/fortran-lang/fpm/pull/876/commits/3b1bf31c1e7bc0472096dbdcee991a0e6422c830. This is being fixed here.

**How to test**

- [x] Install and run `fpm publish --show-package-version`.