### PR TITLE
Improve error message for `[build]` structure errors

### DIFF
--- a/src/fpm/manifest/build.f90
+++ b/src/fpm/manifest/build.f90
@@ -52,7 +52,7 @@ contains
 
 
     !> Construct a new build configuration from a TOML data structure
-    subroutine new_build_config(self, table, error)
+    subroutine new_build_config(self, table, package_name, error)
 
         !> Instance of the build configuration
         type(build_config_t), intent(out) :: self
@@ -60,12 +60,15 @@ contains
         !> Instance of the TOML data structure
         type(toml_table), intent(inout) :: table
 
+        !> Package name
+        character(len=*), intent(in) :: package_name
+
         !> Error handling
         type(error_t), allocatable, intent(out) :: error
 
         integer :: stat
 
-        call check(table, error)
+        call check(table, package_name, error)
         if (allocated(error)) return
 
         call get_value(table, "auto-executables", self%auto_executables, .true., stat=stat)
@@ -128,10 +131,13 @@ contains
     end subroutine new_build_config
 
     !> Check local schema for allowed entries
-    subroutine check(table, error)
+    subroutine check(table, package_name, error)
 
         !> Instance of the TOML data structure
         type(toml_table), intent(inout) :: table
+
+        !> Package name
+        character(len=*), intent(in) :: package_name
 
         !> Error handling
         type(error_t), allocatable, intent(out) :: error
@@ -154,7 +160,8 @@ contains
                 continue
 
             case default
-                call syntax_error(error, "Key "//list(ikey)%key//" is not allowed in [build]")
+                call syntax_error(error, "Key "//list(ikey)%key//" is not allowed in [build]"//&
+                                         " building package "//package_name)
                 exit
 
             end select

--- a/src/fpm/manifest/build.f90
+++ b/src/fpm/manifest/build.f90
@@ -160,8 +160,9 @@ contains
                 continue
 
             case default
-                call syntax_error(error, "Key "//list(ikey)%key//" is not allowed in [build]"//&
-                                         " building package "//package_name)
+
+                call syntax_error(error, 'Manifest file syntax error: key "'//list(ikey)%key//'" found in the [build] '//&
+                                         'section of package/dependency "'//package_name//'" fpm.toml is not allowed')
                 exit
 
             end select

--- a/src/fpm/manifest/package.f90
+++ b/src/fpm/manifest/package.f90
@@ -172,7 +172,7 @@ contains
             call fatal_error(error, "Type mismatch for build entry, must be a table")
             return
         end if
-        call new_build_config(self%build, child, error)
+        call new_build_config(self%build, child, self%name, error)
         if (allocated(error)) return
 
         call get_value(table, "install", child, requested=.true., stat=stat)
@@ -232,7 +232,7 @@ contains
             call new_library(self%library, child, error)
             if (allocated(error)) return
         end if
-        
+
         call get_value(table, "profiles", child, requested=.false.)
         if (associated(child)) then
             call new_profiles(self%profiles, child, error)
@@ -442,7 +442,7 @@ contains
                 call self%dev_dependency(ii)%info(unit, pr - 1)
             end do
         end if
-        
+
         if (allocated(self%profiles)) then
             if (size(self%profiles) > 1 .or. pr > 2) then
                 write(unit, fmti) "- profiles", size(self%profiles)


### PR DESCRIPTION
Address #889. 
See [discussion](https://fortran-lang.discourse.group/t/fpm-error-during-compilation/5643/4) on the Fortran Discourse. 

Solution: return package name on the error message triggered when an invalid [build] structure is detected. 

John @urbanjost, can I ask you to give me a review of this change? (and edit the branch if you think this needs to be improved further). Thank you in advance.