### PR TITLE
replace `unix` with `is_unix` to avoid intel fpp collisions

### DIFF
--- a/src/fpm.f90
+++ b/src/fpm.f90
@@ -641,9 +641,9 @@ subroutine cmd_run(settings,test)
 
 end subroutine cmd_run
 
-subroutine delete_skip(unix)
+subroutine delete_skip(is_unix)
     !> delete directories in the build folder, skipping dependencies
-    logical, intent(in) :: unix
+    logical, intent(in) :: is_unix
     character(len=:), allocatable :: dir
     type(string_t), allocatable :: files(:)
     integer :: i
@@ -651,7 +651,7 @@ subroutine delete_skip(unix)
     do i = 1, size(files)
         if (is_dir(files(i)%s)) then
             dir = files(i)%s
-            if (.not.str_ends_with(dir,'dependencies')) call os_delete_dir(unix, dir)
+            if (.not.str_ends_with(dir,'dependencies')) call os_delete_dir(is_unix, dir)
         end if
     end do
 end subroutine delete_skip
@@ -665,18 +665,18 @@ subroutine cmd_clean(settings)
     if (is_dir('build')) then
         ! remove the entire build directory
         if (settings%clean_call) then
-            call os_delete_dir(settings%unix, 'build')
+            call os_delete_dir(settings%is_unix, 'build')
             return
         end if
         ! remove the build directory but skip dependencies
         if (settings%clean_skip) then
-            call delete_skip(settings%unix)
+            call delete_skip(settings%is_unix)
             return
         end if
         ! prompt to remove the build directory but skip dependencies
         write(stdout, '(A)', advance='no') "Delete build, excluding dependencies (y/n)? "
         read(stdin, '(A1)') response
-        if (lower(response) == 'y') call delete_skip(settings%unix)
+        if (lower(response) == 'y') call delete_skip(settings%is_unix)
     else
         write (stdout, '(A)') "fpm: No build directory found."
     end if

--- a/src/fpm/dependency.f90
+++ b/src/fpm/dependency.f90
@@ -1013,7 +1013,7 @@ contains
     type(error_t), allocatable, intent(out) :: error
 
     integer :: ndep, ii
-    logical :: unix
+    logical :: is_unix
     character(len=:), allocatable :: version, url, obj, rev, proj_dir
     type(toml_key), allocatable :: list(:)
     type(toml_table), pointer :: ptr
@@ -1025,7 +1025,7 @@ contains
       call resize(self%dep, ndep + ndep/2 + size(list))
     end if
 
-    unix = get_os_type() /= OS_WINDOWS
+    is_unix = get_os_type() /= OS_WINDOWS
 
     do ii = 1, size(list)
       call get_value(table, list(ii)%key, ptr)
@@ -1038,7 +1038,7 @@ contains
       self%ndep = self%ndep + 1
       associate (dep => self%dep(self%ndep))
         dep%name = list(ii)%key
-        if (unix) then
+        if (is_unix) then
           dep%proj_dir = proj_dir
         else
           dep%proj_dir = windows_path(proj_dir)

--- a/src/fpm_command_line.f90
+++ b/src/fpm_command_line.f90
@@ -112,7 +112,7 @@ type, extends(fpm_cmd_settings)  :: fpm_update_settings
 end type
 
 type, extends(fpm_cmd_settings)   :: fpm_clean_settings
-    logical                       :: unix
+    logical                       :: is_unix
     character(len=:), allocatable :: calling_dir  ! directory clean called from
     logical                       :: clean_skip=.false.
     logical                       :: clean_call=.false.
@@ -216,7 +216,7 @@ contains
         character(len=4096)           :: cmdarg
         integer                       :: i
         integer                       :: os
-        logical                       :: unix
+        logical                       :: is_unix
         type(fpm_install_settings), allocatable :: install_settings
         type(fpm_publish_settings), allocatable :: publish_settings
         type(version_t) :: version
@@ -243,7 +243,7 @@ contains
             case (OS_UNKNOWN); os_type =  "OS Type:     Unknown"
             case default     ; os_type =  "OS Type:     UNKNOWN"
         end select
-        unix = os_is_unix(os)
+        is_unix = os_is_unix(os)
 
         ! Get current release version
         version = fpm_version()
@@ -613,7 +613,7 @@ contains
             allocate(fpm_clean_settings :: cmd_settings)
             call get_current_directory(working_dir, error)
             cmd_settings=fpm_clean_settings( &
-            &   unix=unix,                   &
+            &   is_unix=is_unix,             &
             &   calling_dir=working_dir,     &
             &   clean_skip=lget('skip'),     &
                 clean_call=lget('all'))

--- a/src/fpm_environment.f90
+++ b/src/fpm_environment.f90
@@ -145,7 +145,7 @@ contains
     !> Compare the output of [[get_os_type]] or the optional
     !! passed INTEGER value to the value for OS_WINDOWS
     !! and return .TRUE. if they match and .FALSE. otherwise
-    logical function os_is_unix(os) result(unix)
+    logical function os_is_unix(os)
         integer, intent(in), optional :: os
         integer :: build_os
         if (present(os)) then
@@ -153,7 +153,7 @@ contains
         else
             build_os = get_os_type()
         end if
-        unix = build_os /= OS_WINDOWS
+        os_is_unix = build_os /= OS_WINDOWS
     end function os_is_unix
 
     !> get named environment variable value. It it is blank or

--- a/src/fpm_filesystem.F90
+++ b/src/fpm_filesystem.F90
@@ -928,12 +928,12 @@ subroutine run(cmd,echo,exitstat,verbose,redirect)
 end subroutine run
 
 !> Delete directory using system OS remove directory commands
-subroutine os_delete_dir(unix, dir, echo)
-    logical, intent(in) :: unix
+subroutine os_delete_dir(is_unix, dir, echo)
+    logical, intent(in) :: is_unix
     character(len=*), intent(in) :: dir
     logical, intent(in), optional :: echo
 
-    if (unix) then
+    if (is_unix) then
         call run('rm -rf ' // dir, echo=echo,verbose=.false.)
     else
         call run('rmdir /s/q ' // dir, echo=echo,verbose=.false.)


### PR DESCRIPTION
Straightforward variable name change to solve #893. 

Builds fine now: 

```
root@7ce4928f525f:~/fpm# fpmx build --verbose
 <INFO> BUILD_NAME: build/ifort
 <INFO> COMPILER:  ifort
 <INFO> C COMPILER:  icc
 <INFO> CXX COMPILER: icpc
 <INFO> COMPILER OPTIONS:
 -fpp -warn all -check all -error-limit 1 -O0 -g -assume byterecl -traceback
 <INFO> C COMPILER OPTIONS:
 <INFO> CXX COMPILER OPTIONS:
 <INFO> LINKER OPTIONS:
 <INFO> INCLUDE DIRECTORIES:  []
[100%] Project compiled successfully.
root@7ce4928f525f:~/fpm#
```