### PR TITLE
Not get `tmp` folder from `env`

### DIFF
--- a/src/fpm/git.f90
+++ b/src/fpm/git.f90
@@ -5,10 +5,7 @@ module fpm_git
     implicit none
 
     public :: git_target_t, git_target_default, git_target_branch, git_target_tag, git_target_revision, git_revision, &
-            & git_archive, git_matches_manifest, operator(==), compressed_package_name
-    
-    !> Name of the compressed package that is generated temporarily.
-    character(len=*), parameter :: compressed_package_name = 'compressed_package'
+            & git_archive, git_matches_manifest, operator(==)
 
     !> Possible git target
     type :: enum_descriptor
@@ -326,8 +323,7 @@ contains
       call fatal_error(error, "Cannot find a suitable archive format for 'git archive'."); return
     end if
 
-    call execute_command_line('git archive HEAD --format='//archive_format//' -o '// &
-    & join_path(destination, compressed_package_name), exitstat=stat)
+    call execute_command_line('git archive HEAD --format='//archive_format//' -o '// destination, exitstat=stat)
     if (stat /= 0) then
       call fatal_error(error, "Error packing '"//source//"'."); return
     end if

--- a/src/fpm_filesystem.F90
+++ b/src/fpm_filesystem.F90
@@ -14,8 +14,7 @@ module fpm_filesystem
     public :: basename, canon_path, dirname, is_dir, join_path, number_of_rows, list_files, get_local_prefix, &
             mkdir, exists, get_temp_filename, windows_path, unix_path, getline, delete_file, fileopen, fileclose, &
             filewrite, warnwrite, parent_dir, is_hidden_file, read_lines, read_lines_expanded, which, run, &
-            LINE_BUFFER_LEN, os_delete_dir, is_absolute_path, env_variable, get_home, get_tmp_directory, &
-            execute_and_read_output
+            LINE_BUFFER_LEN, os_delete_dir, is_absolute_path, env_variable, get_home, execute_and_read_output
     integer, parameter :: LINE_BUFFER_LEN = 1000
 
 #ifndef FPM_BOOTSTRAP
@@ -1033,21 +1032,15 @@ end subroutine os_delete_dir
         integer, intent(out), optional :: exitstat
 
         integer :: cmdstat, unit, stat = 0
-        character(len=:), allocatable :: cmdmsg, tmp_path
+        character(len=:), allocatable :: cmdmsg, tmp_file
         character(len=1000) :: output_line
 
-        call get_tmp_directory(tmp_path, error)
-        if (allocated(error)) return
+        tmp_file = get_temp_filename()
 
-        if (.not. exists(tmp_path)) call mkdir(tmp_path)
-        tmp_path = join_path(tmp_path, 'command_line_output')
-        call delete_file(tmp_path)
-        call filewrite(tmp_path, [''])
+        call execute_command_line(cmd//' > '//tmp_file, exitstat=exitstat, cmdstat=cmdstat)
+        if (cmdstat /= 0) call fatal_error(error, '*run*: '//"Command failed: '"//cmd//"'. Message: '"//trim(cmdmsg)//"'.")
 
-        call execute_command_line(cmd//' > '//tmp_path, exitstat=exitstat, cmdstat=cmdstat)
-        if (cmdstat /= 0) call fpm_stop(1,'*run*: '//"Command failed: '"//cmd//"'. Message: '"//trim(cmdmsg)//"'.")
-
-        open(unit, file=tmp_path, action='read', status='old')
+        open(newunit=unit, file=tmp_file, action='read', status='old')
         output = ''
         do
           read(unit, *, iostat=stat) output_line
@@ -1056,30 +1049,4 @@ end subroutine os_delete_dir
         end do
         close(unit, status='delete')
     end
-
-    !> Get system-dependent tmp directory.
-    subroutine get_tmp_directory(tmp_dir, error)
-        !> System-dependant tmp directory.
-        character(len=:), allocatable, intent(out) :: tmp_dir
-        !> Error to handle.
-        type(error_t), allocatable, intent(out) :: error
-
-        tmp_dir = get_env('TMPDIR', '')
-        if (tmp_dir /= '') then
-          tmp_dir = tmp_dir//'fpm'; return
-        end if
-
-        tmp_dir = get_env('TMP', '')
-        if (tmp_dir /= '') then
-          tmp_dir = tmp_dir//'fpm'; return
-        end if
-
-        tmp_dir = get_env('TEMP', '')
-        if (tmp_dir /= '') then
-          tmp_dir = tmp_dir//'fpm'; return
-        end if
-
-        call fatal_error(error, "Couldn't determine system temporary directory.")
-    end
-
 end module fpm_filesystem


### PR DESCRIPTION
Closes https://github.com/fortran-lang/fpm/issues/905.

Not obtain the `tmp` folder from `env` but use the `get_temp_filename` routine.

**How to test**

Publish a package to the registry using `fpm publish`.