### PR TITLE
`install.sh`: fallback to 0.8.0 if in trouble fetching github

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -73,9 +73,9 @@ fi
 
 LATEST_RELEASE=$(get_latest_release "fortran-lang/fpm" "$FETCH")
 
+# Fallback to a latest known release if network timeout
 if [ -z "$LATEST_RELEASE" ]; then
-  echo "Could not fetch the latest release from GitHub. Install curl or wget, and ensure network connectivity."
-  exit 3
+   LATEST_RELEASE="0.8.0"
 fi
 
 SOURCE_URL="https://github.com/fortran-lang/fpm/releases/download/v${LATEST_RELEASE}/fpm-${LATEST_RELEASE}.F90"


### PR DESCRIPTION
See #909. 

On network connectivity issues, it's safe to fallback to a release version that is known. 

This does not prevent the next step (download single-file source) to fail if the network is down though.

cc: @barracuda156 

