### PR TITLE
Fix return type in `c_realpath`

### DIFF
--- a/src/fpm_os.c
+++ b/src/fpm_os.c
@@ -5,7 +5,7 @@
 /// @param resolved_path
 /// @param maxLength
 /// @return
-int c_realpath(char* path, char* resolved_path, int maxLength) {
+char* c_realpath(char* path, char* resolved_path, int maxLength) {
 // Checking macro in C because it doesn't work with gfortran on Windows, even
 // when exported manually.
 #ifndef _WIN32


### PR DESCRIPTION
Closes https://github.com/fortran-lang/fpm/issues/907.

Fix return type of `c_realpath` by changing it from `int` to `char*`.