### PR TITLE
Add more infos to `fpm help publish`

### DIFF
--- a/src/fpm/cmd/publish.f90
+++ b/src/fpm/cmd/publish.f90
@@ -44,15 +44,15 @@ contains
       print *, version%s(); return
     end if
 
-    ! Build model to obtain dependency tree.
-    call build_model(model, settings%fpm_build_settings, package, error)
-    if (allocated(error)) call fpm_stop(1, '*cmd_build* Model error: '//error%message)
-
     !> Checks before uploading the package.
     if (.not. allocated(package%license)) call fpm_stop(1, 'No license specified in fpm.toml.')
     if (.not. allocated(version)) call fpm_stop(1, 'No version specified in fpm.toml.')
     if (version%s() == '0') call fpm_stop(1, 'Invalid version: "'//version%s()//'".')
     if (.not. exists('fpm.toml')) call fpm_stop(1, "Cannot find 'fpm.toml' file. Are you in the project root?")
+
+    ! Build model to obtain dependency tree.
+    call build_model(model, settings%fpm_build_settings, package, error)
+    if (allocated(error)) call fpm_stop(1, '*cmd_build* Model error: '//error%message)
 
     ! Check if package contains git dependencies. Only publish packages without git dependencies.
     do i = 1, model%deps%ndep

--- a/src/fpm/cmd/publish.f90
+++ b/src/fpm/cmd/publish.f90
@@ -46,6 +46,8 @@ contains
 
     !> Checks before uploading the package.
     if (.not. allocated(package%license)) call fpm_stop(1, 'No license specified in fpm.toml.')
+    if (.not. package%build%module_naming) call fpm_stop(1, 'The package does not meet the module naming requirements. '// &
+      & 'Please set "module_naming = true" in fpm.toml [build] or specify a custom module prefix.')
     if (.not. allocated(version)) call fpm_stop(1, 'No version specified in fpm.toml.')
     if (version%s() == '0') call fpm_stop(1, 'Invalid version: "'//version%s()//'".')
     if (.not. exists('fpm.toml')) call fpm_stop(1, "Cannot find 'fpm.toml' file. Are you in the project root?")

--- a/src/fpm/cmd/publish.f90
+++ b/src/fpm/cmd/publish.f90
@@ -30,7 +30,7 @@ contains
     type(fpm_model_t) :: model
     type(error_t), allocatable :: error
     type(version_t), allocatable :: version
-    type(string_t), allocatable :: form_data(:)
+    type(string_t), allocatable :: upload_data(:)
     character(len=:), allocatable :: tmp_file
     type(downloader_t) :: downloader
     integer :: i
@@ -61,22 +61,22 @@ contains
       end if
     end do
 
-    form_data = [ &
+    upload_data = [ &
       string_t('package_name="'//package%name//'"'), &
       string_t('package_license="'//package%license//'"'), &
       string_t('package_version="'//version%s()//'"') &
       & ]
 
-    if (allocated(settings%token)) form_data = [form_data, string_t('upload_token="'//settings%token//'"')]
+    if (allocated(settings%token)) upload_data = [upload_data, string_t('upload_token="'//settings%token//'"')]
 
     tmp_file = get_temp_filename()
     call git_archive('.', tmp_file, error)
     if (allocated(error)) call fpm_stop(1, '*cmd_publish* Pack error: '//error%message)
-    form_data = [form_data, string_t('tarball=@"'//tmp_file//'"')]
+    upload_data = [upload_data, string_t('tarball=@"'//tmp_file//'"')]
 
-    if (settings%show_form_data) then
-      do i = 1, size(form_data)
-        print *, form_data(i)%s
+    if (settings%show_upload_data) then
+      do i = 1, size(upload_data)
+        print *, upload_data(i)%s
       end do
       return
     end if
@@ -84,7 +84,7 @@ contains
     ! Make sure a token is provided for publishing.
     if (.not. allocated(settings%token)) call fpm_stop(1, 'No token provided.')
 
-    call downloader%upload_form(official_registry_base_url//'/packages', form_data, error)
+    call downloader%upload_form(official_registry_base_url//'/packages', upload_data, error)
     if (allocated(error)) call fpm_stop(1, '*cmd_publish* Upload error: '//error%message)
   end
 end

--- a/src/fpm/cmd/publish.f90
+++ b/src/fpm/cmd/publish.f90
@@ -82,7 +82,11 @@ contains
     end if
 
     ! Make sure a token is provided for publishing.
-    if (.not. allocated(settings%token)) call fpm_stop(1, 'No token provided.')
+    if (allocated(settings%token)) then
+      if (settings%token == '') call fpm_stop(1, 'No token provided.')
+    else
+      call fpm_stop(1, 'No token provided.')
+    end if
 
     call downloader%upload_form(official_registry_base_url//'/packages', upload_data, error)
     if (allocated(error)) call fpm_stop(1, '*cmd_publish* Upload error: '//error%message)

--- a/src/fpm/cmd/publish.f90
+++ b/src/fpm/cmd/publish.f90
@@ -57,7 +57,8 @@ contains
     ! Check if package contains git dependencies. Only publish packages without git dependencies.
     do i = 1, model%deps%ndep
       if (allocated(model%deps%dep(i)%git)) then
-        call fpm_stop(1, "Do not publish packages containing git dependencies. '"//model%deps%dep(i)%name//"' is a git dependency.")
+        call fpm_stop(1, 'Do not publish packages containing git dependencies. '// &
+        & "Please upload '"//model%deps%dep(i)%name//"' to the registry first.")
       end if
     end do
 

--- a/src/fpm_command_line.f90
+++ b/src/fpm_command_line.f90
@@ -120,7 +120,7 @@ end type
 
 type, extends(fpm_build_settings) :: fpm_publish_settings
     logical :: show_package_version = .false.
-    logical :: show_form_data = .false.
+    logical :: show_upload_data = .false.
     character(len=:), allocatable :: token
 end type
 
@@ -620,7 +620,7 @@ contains
         case('publish')
             call set_args(common_args // compiler_args //'&
             & --show-package-version F &
-            & --show-form-data F &
+            & --show-upload-data F &
             & --token " " &
             & --list F &
             & --show-model F &
@@ -637,7 +637,7 @@ contains
             allocate(fpm_publish_settings :: cmd_settings)
             cmd_settings = fpm_publish_settings( &
             & show_package_version = lget('show-package-version'), &
-            & show_form_data = lget('show-form-data'), &
+            & show_upload_data = lget('show-upload-data'), &
             & profile=val_profile,&
             & prune=.not.lget('no-prune'), &
             & compiler=val_compiler, &
@@ -754,7 +754,7 @@ contains
    ' install [--profile PROF] [--flag FFLAGS] [--no-rebuild] [--prefix PATH]        ', &
    '         [options]                                                              ', &
    ' clean [--skip] [--all]                                                         ', &
-   ' publish [--show-package-version] [--show-form-data] [--token TOKEN]            ', &
+   ' publish [--show-package-version] [--show-upload-data] [--token TOKEN]            ', &
    ' ']
     help_usage=[character(len=80) :: &
     '' ]
@@ -878,7 +878,7 @@ contains
     '    install [--profile PROF] [--flag FFLAGS] [--no-rebuild] [--prefix PATH]     ', &
     '            [options]                                                           ', &
     '    clean [--skip] [--all]                                                      ', &
-    '    publish [--show-package-version] [--show-form-data] [--token TOKEN]         ', &
+    '    publish [--show-package-version] [--show-upload-data] [--token TOKEN]       ', &
     '                                                                                ', &
     'SUBCOMMAND OPTIONS                                                              ', &
     ' -C, --directory PATH', &
@@ -1372,7 +1372,7 @@ contains
     '', &
     'OPTIONS', &
     ' --show-package-version   show package version without publishing', &
-    ' --show-form-data         show sent form data without publishing', &
+    ' --show-upload-data       show uploaded data without publishing', &
     ' --help                   print this help and exit', &
     ' --version                print program version information and exit', &
     '' ]

--- a/src/fpm_command_line.f90
+++ b/src/fpm_command_line.f90
@@ -958,7 +958,7 @@ contains
     ' list(1) - list summary of fpm(1) subcommands                          ', &
     '                                                                       ', &
     'SYNOPSIS                                                               ', &
-    ' fpm list [-list]                                                      ', &
+    ' fpm list                                                              ', &
     '                                                                       ', &
     ' fpm list --help|--version                                             ', &
     '                                                                       ', &

--- a/src/fpm_command_line.f90
+++ b/src/fpm_command_line.f90
@@ -1361,20 +1361,38 @@ contains
     ' publish(1) - publish package to the registry', &
     '', &
     'SYNOPSIS', &
-    ' fpm publish [--token TOKEN]', &
+    ' fpm publish [--token TOKEN] [--show-package-version] [--show-upload-data]', &
     '', &
     ' fpm publish --help|--version', &
     '', &
     'DESCRIPTION', &
-    ' Collect relevant source files and upload package to the registry.', &
-    ' It is mandatory to provide a token. The token can be generated on the', &
-    ' registry website and will be linked to your username and namespace.', &
+    ' Follow the steps to create a tarball and upload the package to the registry:', &
+    '', &
+    '  1. Register on the website (https://registry-frontend.vercel.app/).', &
+    '  2. Create a namespace. Uploaded packages must be assigned to a unique', &
+    '     namespace to avoid conflicts among packages with similar names. A', &
+    '     namespace can accommodate multiple packages.', &
+    '  3. Create a token for that namespace. A token is linked to your username', &
+    '     and is used to authenticate you during the upload process. Do not share', &
+    '     the token with others.', &
+    '  4. Run fpm publish --token TOKEN to upload the package to the registry.', &
+    '     But be aware that the upload is permanent. An uploaded package cannot be', &
+    '     deleted.', &
+    '', &
+    ' See documentation (https://fpm.fortran-lang.org/en/spec/publish.html) for', &
+    ' more information regarding the package upload.', &
     '', &
     'OPTIONS', &
     ' --show-package-version   show package version without publishing', &
     ' --show-upload-data       show uploaded data without publishing', &
     ' --help                   print this help and exit', &
     ' --version                print program version information and exit', &
+    '', &
+    'EXAMPLES', &
+    '', &
+    ' fpm publish --show-package-version # show package version without publishing', &
+    ' fpm publish --show-upload-data     # show upload data without publishing', &
+    ' fpm publish --token TOKEN          # upload package to the registry using TOKEN', &
     '' ]
      end subroutine set_help
 

--- a/src/fpm_command_line.f90
+++ b/src/fpm_command_line.f90
@@ -1366,7 +1366,7 @@ contains
     ' fpm publish --help|--version', &
     '', &
     'DESCRIPTION', &
-    ' Follow the steps to create a tarball and upload the package to the registry:', &
+    ' Follow the steps to create a tarball and upload a package to the registry:', &
     '', &
     '  1. Register on the website (https://registry-frontend.vercel.app/).', &
     '  2. Create a namespace. Uploaded packages must be assigned to a unique', &
@@ -1379,8 +1379,13 @@ contains
     '     But be aware that the upload is permanent. An uploaded package cannot be', &
     '     deleted.', &
     '', &
-    ' See documentation (https://fpm.fortran-lang.org/en/spec/publish.html) for', &
-    ' more information regarding the package upload.', &
+    ' See documentation for more information regarding the package upload and usage:', &
+    '', &
+    ' Package upload:', &
+    ' https://fpm.fortran-lang.org/en/spec/publish.html', &
+    '', &
+    ' Package usage:', &
+    ' https://fpm.fortran-lang.org/en/spec/manifest.html#dependencies-from-a-registry', &
     '', &
     'OPTIONS', &
     ' --show-package-version   show package version without publishing', &

--- a/src/fpm_command_line.f90
+++ b/src/fpm_command_line.f90
@@ -754,7 +754,7 @@ contains
    ' install [--profile PROF] [--flag FFLAGS] [--no-rebuild] [--prefix PATH]        ', &
    '         [options]                                                              ', &
    ' clean [--skip] [--all]                                                         ', &
-   ' publish [--show-package-version] [--show-upload-data] [--token TOKEN]            ', &
+   ' publish [--show-package-version] [--show-upload-data] [--token TOKEN]          ', &
    ' ']
     help_usage=[character(len=80) :: &
     '' ]

--- a/src/fpm_command_line.f90
+++ b/src/fpm_command_line.f90
@@ -1125,13 +1125,15 @@ contains
     help_new=[character(len=80) ::                                             &
     'NAME                                                                   ', &
     ' new(1) - the fpm(1) subcommand to initialize a new project            ', &
+    '                                                                       ', &
     'SYNOPSIS                                                               ', &
-    '  fpm new NAME [[--lib|--src] [--app] [--test] [--example]]|           ', &
-    '      [--full|--bare][--backfill]                                      ', &
+    ' fpm new NAME [[--lib|--src] [--app] [--test] [--example]]|            ', &
+    '              [--full|--bare][--backfill]                              ', &
     ' fpm new --help|--version                                              ', &
     '                                                                       ', &
     'DESCRIPTION                                                            ', &
     ' "fpm new" creates and populates a new programming project directory.  ', &
+    '                                                                       ', &
     ' It                                                                    ', &
     '   o creates a directory with the specified name                       ', &
     '   o runs the command "git init" in that directory                     ', &
@@ -1361,6 +1363,8 @@ contains
     'SYNOPSIS', &
     ' fpm publish [--token TOKEN]', &
     '', &
+    ' fpm publish --help|--version', &
+    '', &
     'DESCRIPTION', &
     ' Collect relevant source files and upload package to the registry.', &
     ' It is mandatory to provide a token. The token can be generated on the', &
@@ -1369,6 +1373,8 @@ contains
     'OPTIONS', &
     ' --show-package-version   show package version without publishing', &
     ' --show-form-data         show sent form data without publishing', &
+    ' --help                   print this help and exit', &
+    ' --version                print program version information and exit', &
     '' ]
      end subroutine set_help
 

--- a/test/cli_test/cli_test.f90
+++ b/test/cli_test/cli_test.f90
@@ -30,12 +30,12 @@ logical                              :: w_t,act_w_t          ; namelist/act_cli/
 logical                              :: c_s,act_c_s          ; namelist/act_cli/act_c_s
 logical                              :: c_a,act_c_a          ; namelist/act_cli/act_c_a
 logical                              :: show_v,act_show_v    ; namelist/act_cli/act_show_v
-logical                              :: show_f_d,act_show_f_d; namelist/act_cli/act_show_f_d
+logical                              :: show_u_d,act_show_u_d; namelist/act_cli/act_show_u_d
 character(len=:), allocatable        :: token, act_token     ; namelist/act_cli/act_token
 
 character(len=:), allocatable        :: profile,act_profile  ; namelist/act_cli/act_profile
 character(len=:), allocatable        :: args,act_args        ; namelist/act_cli/act_args
-namelist/expected/cmd,cstat,estat,w_e,w_t,c_s,c_a,name,profile,args,show_v,show_f_d,token
+namelist/expected/cmd,cstat,estat,w_e,w_t,c_s,c_a,name,profile,args,show_v,show_u_d,token
 integer                              :: lun
 logical,allocatable                  :: tally(:)
 logical,allocatable                  :: subtally(:)
@@ -75,7 +75,7 @@ character(len=*),parameter           :: tests(*)= [ character(len=256) :: &
 'CMD="clean --skip",                                        C_S=T, NAME=, ARGS="",', &
 'CMD="clean --all",                                         C_A=T, NAME=, ARGS="",', &
 'CMD="publish --token abc --show-package-version",       SHOW_V=T, NAME=, token="abc",ARGS="",', &
-'CMD="publish --token abc --show-form-data",           SHOW_F_D=T, NAME=, token="abc",ARGS="",', &
+'CMD="publish --token abc --show-upload-data",           SHOW_U_D=T, NAME=, token="abc",ARGS="",', &
 'CMD="publish --token abc",                                        NAME=, token="abc",ARGS="",', &
 ' ' ]
 character(len=256) :: readme(3)
@@ -110,7 +110,7 @@ if(command_argument_count()==0)then  ! assume if called with no arguments to do 
       c_s=.false.                    ! --skip
       c_a=.false.                    ! --all
       show_v=.false.                 ! --show-package-version
-      show_f_d=.false.               ! --show-form-data
+      show_u_d=.false.               ! --show-upload-data
       token=''                       ! --token TOKEN
       args=repeat(' ',132)           ! -- ARGS
       cmd=repeat(' ',132)            ! the command line arguments to test
@@ -132,7 +132,7 @@ if(command_argument_count()==0)then  ! assume if called with no arguments to do 
              act_c_s=.false.
              act_c_a=.false.
              act_show_v=.false.
-             act_show_f_d=.false.
+             act_show_u_d=.false.
              act_token=''
              act_args=repeat(' ',132)
              read(lun,nml=act_cli,iostat=ios,iomsg=message)
@@ -148,7 +148,7 @@ if(command_argument_count()==0)then  ! assume if called with no arguments to do 
              call test_test('WITH_TESTED',act_w_t.eqv.w_t)
              call test_test('WITH_TEST',act_w_t.eqv.w_t)
              call test_test('SHOW-PACKAGE-VERSION',act_show_v.eqv.show_v)
-             call test_test('SHOW-FORM-DATA',act_show_f_d.eqv.show_f_d)
+             call test_test('SHOW-UPLOAD-DATA',act_show_u_d.eqv.show_u_d)
              call test_test('TOKEN',act_token==token)
              call test_test('ARGS',act_args==args)
              if(all(subtally))then
@@ -237,7 +237,7 @@ act_w_t=.false.
 act_c_s=.false.
 act_c_a=.false.
 act_show_v=.false.
-act_show_f_d=.false.
+act_show_u_d=.false.
 act_token=''
 act_profile=''
 
@@ -262,7 +262,7 @@ type is (fpm_clean_settings)
 type is (fpm_install_settings)
 type is (fpm_publish_settings)
     act_show_v=settings%show_package_version
-    act_show_f_d=settings%show_form_data
+    act_show_u_d=settings%show_upload_data
     act_token=settings%token
 end select
 


### PR DESCRIPTION
Closes https://github.com/fortran-lang/fpm/issues/906.

- [x] Add more detailed information, a step-by-step guide and documentation links to `fpm help publish`.
- [x] Show error message for empty token.
- [x] Provide more detailed error messages when git dependencies are found.
- [x] Require `module-naming`.
- [x] Rename `--show-form-data` to `--show-upload-data`.