### PR TITLE
Add `--dry-run` option to `fpm publish`

### DIFF
--- a/src/fpm/cmd/publish.f90
+++ b/src/fpm/cmd/publish.f90
@@ -78,10 +78,7 @@ contains
     if (allocated(settings%token)) upload_data = [upload_data, string_t('upload_token="'//settings%token//'"')]
 
     if (settings%show_upload_data) then
-      do i = 1, size(upload_data)
-        print *, upload_data(i)%s
-      end do
-      return
+      call print_upload_data(upload_data); return
     end if
 
     ! Make sure a token is provided for publishing.
@@ -93,7 +90,13 @@ contains
       call delete_file(tmp_file); call fpm_stop(1, 'No token provided.')
     end if
 
-    ! Perform network request and validate package on the backend as soon as
+    if (settings%verbose) then
+      print *, ''
+      call print_upload_data(upload_data)
+      print *, ''
+    end if
+
+    ! Perform network request and validate package, token etc. on the backend once
     ! https://github.com/fortran-lang/registry/issues/41 is resolved.
     if (settings%is_dry_run) then
       print *, 'Dry run successful.'
@@ -105,5 +108,15 @@ contains
     call downloader%upload_form(official_registry_base_url//'/packages', upload_data, error)
     call delete_file(tmp_file)
     if (allocated(error)) call fpm_stop(1, '*cmd_publish* Upload error: '//error%message)
+  end
+
+  subroutine print_upload_data(upload_data)
+    type(string_t), intent(in) :: upload_data(:)
+    integer :: i
+
+    print *, 'Upload data:'
+    do i = 1, size(upload_data)
+      print *, upload_data(i)%s
+    end do
   end
 end

--- a/src/fpm/cmd/publish.f90
+++ b/src/fpm/cmd/publish.f90
@@ -81,7 +81,6 @@ contains
       do i = 1, size(upload_data)
         print *, upload_data(i)%s
       end do
-      call delete_file(tmp_file); return
     end if
 
     ! Make sure a token is provided for publishing.
@@ -91,6 +90,14 @@ contains
       end if
     else
       call delete_file(tmp_file); call fpm_stop(1, 'No token provided.')
+    end if
+
+    ! Perform network request and validate package on the backend as soon as
+    ! https://github.com/fortran-lang/registry/issues/41 is resolved.
+    if (settings%is_dry_run) then
+      print *, 'Dry run successful.'
+      print *, ''
+      print *, 'tarball generated for upload: ', tmp_file; return
     end if
 
     call downloader%upload_form(official_registry_base_url//'/packages', upload_data, error)

--- a/src/fpm/cmd/publish.f90
+++ b/src/fpm/cmd/publish.f90
@@ -99,10 +99,7 @@ contains
     ! Perform network request and validate package, token etc. on the backend once
     ! https://github.com/fortran-lang/registry/issues/41 is resolved.
     if (settings%is_dry_run) then
-      print *, 'Dry run successful.'
-      print *, ''
-      print *, 'tarball generated for upload: ', tmp_file
-      return
+      print *, 'Dry run successful. ', 'Generated tarball: ', tmp_file; return
     end if
 
     call downloader%upload_form(official_registry_base_url//'/packages', upload_data, error)

--- a/src/fpm/cmd/publish.f90
+++ b/src/fpm/cmd/publish.f90
@@ -99,7 +99,7 @@ contains
     ! Perform network request and validate package, token etc. on the backend once
     ! https://github.com/fortran-lang/registry/issues/41 is resolved.
     if (settings%is_dry_run) then
-      print *, 'Dry run successful. ', 'Generated tarball: ', tmp_file; return
+      print *, 'Dry run successful. Generated tarball: ', tmp_file; return
     end if
 
     call downloader%upload_form(official_registry_base_url//'/packages', upload_data, error)

--- a/src/fpm/cmd/publish.f90
+++ b/src/fpm/cmd/publish.f90
@@ -81,6 +81,7 @@ contains
       do i = 1, size(upload_data)
         print *, upload_data(i)%s
       end do
+      return
     end if
 
     ! Make sure a token is provided for publishing.
@@ -97,7 +98,8 @@ contains
     if (settings%is_dry_run) then
       print *, 'Dry run successful.'
       print *, ''
-      print *, 'tarball generated for upload: ', tmp_file; return
+      print *, 'tarball generated for upload: ', tmp_file
+      return
     end if
 
     call downloader%upload_form(official_registry_base_url//'/packages', upload_data, error)

--- a/src/fpm/cmd/publish.f90
+++ b/src/fpm/cmd/publish.f90
@@ -8,7 +8,7 @@ module fpm_cmd_publish
   use fpm_model, only: fpm_model_t
   use fpm_error, only: error_t, fpm_stop
   use fpm_versioning, only: version_t
-  use fpm_filesystem, only: exists, join_path, get_temp_filename
+  use fpm_filesystem, only: exists, join_path, get_temp_filename, delete_file
   use fpm_git, only: git_archive
   use fpm_downloader, only: downloader_t
   use fpm_strings, only: string_t
@@ -64,34 +64,37 @@ contains
       end if
     end do
 
-    upload_data = [ &
-      string_t('package_name="'//package%name//'"'), &
-      string_t('package_license="'//package%license//'"'), &
-      string_t('package_version="'//version%s()//'"') &
-      & ]
-
-    if (allocated(settings%token)) upload_data = [upload_data, string_t('upload_token="'//settings%token//'"')]
-
     tmp_file = get_temp_filename()
     call git_archive('.', tmp_file, error)
-    if (allocated(error)) call fpm_stop(1, '*cmd_publish* Pack error: '//error%message)
-    upload_data = [upload_data, string_t('tarball=@"'//tmp_file//'"')]
+    if (allocated(error)) call fpm_stop(1, '*cmd_publish* Archive error: '//error%message)
+
+    upload_data = [ &
+    & string_t('package_name="'//package%name//'"'), &
+    & string_t('package_license="'//package%license//'"'), &
+    & string_t('package_version="'//version%s()//'"'), &
+    & string_t('tarball=@"'//tmp_file//'"') &
+    & ]
+
+    if (allocated(settings%token)) upload_data = [upload_data, string_t('upload_token="'//settings%token//'"')]
 
     if (settings%show_upload_data) then
       do i = 1, size(upload_data)
         print *, upload_data(i)%s
       end do
-      return
+      call delete_file(tmp_file); return
     end if
 
     ! Make sure a token is provided for publishing.
     if (allocated(settings%token)) then
-      if (settings%token == '') call fpm_stop(1, 'No token provided.')
+      if (settings%token == '') then
+        call delete_file(tmp_file); call fpm_stop(1, 'No token provided.')
+      end if
     else
-      call fpm_stop(1, 'No token provided.')
+      call delete_file(tmp_file); call fpm_stop(1, 'No token provided.')
     end if
 
     call downloader%upload_form(official_registry_base_url//'/packages', upload_data, error)
+    call delete_file(tmp_file)
     if (allocated(error)) call fpm_stop(1, '*cmd_publish* Upload error: '//error%message)
   end
 end

--- a/src/fpm/git.f90
+++ b/src/fpm/git.f90
@@ -328,7 +328,7 @@ contains
       call fatal_error(error, "Cannot find a suitable archive format for 'git archive'."); return
     end if
 
-    call execute_command_line('git archive HEAD --format='//archive_format//' -o '// destination, exitstat=stat)
+    call execute_command_line('git archive HEAD --format='//archive_format//' -o '//destination, exitstat=stat)
     if (stat /= 0) then
       call fatal_error(error, "Error packing '"//source//"'."); return
     end if

--- a/src/fpm_command_line.f90
+++ b/src/fpm_command_line.f90
@@ -121,6 +121,7 @@ end type
 type, extends(fpm_build_settings) :: fpm_publish_settings
     logical :: show_package_version = .false.
     logical :: show_upload_data = .false.
+    logical :: is_dry_run = .false.
     character(len=:), allocatable :: token
 end type
 
@@ -621,6 +622,7 @@ contains
             call set_args(common_args // compiler_args //'&
             & --show-package-version F &
             & --show-upload-data F &
+            & --dry-run F &
             & --token " " &
             & --list F &
             & --show-model F &
@@ -638,6 +640,7 @@ contains
             cmd_settings = fpm_publish_settings( &
             & show_package_version = lget('show-package-version'), &
             & show_upload_data = lget('show-upload-data'), &
+            & is_dry_run = lget('dry-run'), &
             & profile=val_profile,&
             & prune=.not.lget('no-prune'), &
             & compiler=val_compiler, &
@@ -754,7 +757,8 @@ contains
    ' install [--profile PROF] [--flag FFLAGS] [--no-rebuild] [--prefix PATH]        ', &
    '         [options]                                                              ', &
    ' clean [--skip] [--all]                                                         ', &
-   ' publish [--show-package-version] [--show-upload-data] [--token TOKEN]          ', &
+   ' publish [--token TOKEN] [--show-package-version] [--show-upload-data]          ', &
+   '         [--dry-run]                                                            ', &
    ' ']
     help_usage=[character(len=80) :: &
     '' ]
@@ -878,7 +882,8 @@ contains
     '    install [--profile PROF] [--flag FFLAGS] [--no-rebuild] [--prefix PATH]     ', &
     '            [options]                                                           ', &
     '    clean [--skip] [--all]                                                      ', &
-    '    publish [--show-package-version] [--show-upload-data] [--token TOKEN]       ', &
+    '    publish [--token TOKEN] [--show-package-version] [--show-upload-data]       ', &
+    '            [--dry-run]                                                         ', &
     '                                                                                ', &
     'SUBCOMMAND OPTIONS                                                              ', &
     ' -C, --directory PATH', &
@@ -1362,6 +1367,7 @@ contains
     '', &
     'SYNOPSIS', &
     ' fpm publish [--token TOKEN] [--show-package-version] [--show-upload-data]', &
+    '             [--dry-run]                                                  ', &
     '', &
     ' fpm publish --help|--version', &
     '', &
@@ -1390,6 +1396,7 @@ contains
     'OPTIONS', &
     ' --show-package-version   show package version without publishing', &
     ' --show-upload-data       show uploaded data without publishing', &
+    ' --dry-run                create tarball for revision without publishing', &
     ' --help                   print this help and exit', &
     ' --version                print program version information and exit', &
     '', &
@@ -1397,6 +1404,7 @@ contains
     '', &
     ' fpm publish --show-package-version # show package version without publishing', &
     ' fpm publish --show-upload-data     # show upload data without publishing', &
+    ' fpm publish --dry-run              # create tarball without publishing', &
     ' fpm publish --token TOKEN          # upload package to the registry using TOKEN', &
     '' ]
      end subroutine set_help

--- a/src/fpm_command_line.f90
+++ b/src/fpm_command_line.f90
@@ -758,7 +758,7 @@ contains
    '         [options]                                                              ', &
    ' clean [--skip] [--all]                                                         ', &
    ' publish [--token TOKEN] [--show-package-version] [--show-upload-data]          ', &
-   '         [--dry-run]                                                            ', &
+   '         [--dry-run] [--verbose]                                                ', &
    ' ']
     help_usage=[character(len=80) :: &
     '' ]
@@ -883,7 +883,7 @@ contains
     '            [options]                                                           ', &
     '    clean [--skip] [--all]                                                      ', &
     '    publish [--token TOKEN] [--show-package-version] [--show-upload-data]       ', &
-    '            [--dry-run]                                                         ', &
+    '            [--dry-run] [--verbose]                                             ', &
     '                                                                                ', &
     'SUBCOMMAND OPTIONS                                                              ', &
     ' -C, --directory PATH', &
@@ -1367,7 +1367,7 @@ contains
     '', &
     'SYNOPSIS', &
     ' fpm publish [--token TOKEN] [--show-package-version] [--show-upload-data]', &
-    '             [--dry-run]                                                  ', &
+    '             [--dry-run] [--verbose]                                      ', &
     '', &
     ' fpm publish --help|--version', &
     '', &
@@ -1385,7 +1385,7 @@ contains
     '     But be aware that the upload is permanent. An uploaded package cannot be', &
     '     deleted.', &
     '', &
-    ' See documentation for more information regarding the package upload and usage:', &
+    ' See documentation for more information regarding package upload and usage:', &
     '', &
     ' Package upload:', &
     ' https://fpm.fortran-lang.org/en/spec/publish.html', &
@@ -1395,17 +1395,18 @@ contains
     '', &
     'OPTIONS', &
     ' --show-package-version   show package version without publishing', &
-    ' --show-upload-data       show uploaded data without publishing', &
-    ' --dry-run                create tarball for revision without publishing', &
+    ' --show-upload-data       show upload data without publishing', &
+    ' --dry-run                perform dry run without publishing', &
     ' --help                   print this help and exit', &
     ' --version                print program version information and exit', &
+    ' --verbose                print more information', &
     '', &
     'EXAMPLES', &
     '', &
-    ' fpm publish --show-package-version # show package version without publishing', &
-    ' fpm publish --show-upload-data     # show upload data without publishing', &
-    ' fpm publish --dry-run              # create tarball without publishing', &
-    ' fpm publish --token TOKEN          # upload package to the registry using TOKEN', &
+    ' fpm publish --show-package-version    # show package version without publishing', &
+    ' fpm publish --show-upload-data        # show upload data without publishing', &
+    ' fpm publish --token TOKEN --dry-run   # perform dry run without publishing', &
+    ' fpm publish --token TOKEN             # upload package to the registry', &
     '' ]
      end subroutine set_help
 

--- a/src/fpm_command_line.f90
+++ b/src/fpm_command_line.f90
@@ -169,7 +169,7 @@ character(len=80), parameter :: help_text_flag(*) = [character(len=80) :: &
     ' --flag  FFLAGS    selects compile arguments for the build, the default value is',&
     '                   set by the FPM_FFLAGS environment variable. These are added  ',&
     '                   to the profile options if --profile is specified, else these ',&
-    '                   these options override the defaults. Note object and .mod    ',&
+    '                   options override the defaults. Note object and .mod          ',&
     '                   directory locations are always built in.                     ',&
     ' --c-flag CFLAGS   selects compile arguments specific for C source in the build.',&
     '                   The default value is set by the FPM_CFLAGS environment       ',&

--- a/test/cli_test/cli_test.f90
+++ b/test/cli_test/cli_test.f90
@@ -31,11 +31,12 @@ logical                              :: c_s,act_c_s          ; namelist/act_cli/
 logical                              :: c_a,act_c_a          ; namelist/act_cli/act_c_a
 logical                              :: show_v,act_show_v    ; namelist/act_cli/act_show_v
 logical                              :: show_u_d,act_show_u_d; namelist/act_cli/act_show_u_d
+logical                              :: dry_run,act_dry_run  ; namelist/act_cli/act_dry_run
 character(len=:), allocatable        :: token, act_token     ; namelist/act_cli/act_token
 
 character(len=:), allocatable        :: profile,act_profile  ; namelist/act_cli/act_profile
 character(len=:), allocatable        :: args,act_args        ; namelist/act_cli/act_args
-namelist/expected/cmd,cstat,estat,w_e,w_t,c_s,c_a,name,profile,args,show_v,show_u_d,token
+namelist/expected/cmd,cstat,estat,w_e,w_t,c_s,c_a,name,profile,args,show_v,show_u_d,dry_run,token
 integer                              :: lun
 logical,allocatable                  :: tally(:)
 logical,allocatable                  :: subtally(:)
@@ -76,6 +77,7 @@ character(len=*),parameter           :: tests(*)= [ character(len=256) :: &
 'CMD="clean --all",                                         C_A=T, NAME=, ARGS="",', &
 'CMD="publish --token abc --show-package-version",       SHOW_V=T, NAME=, token="abc",ARGS="",', &
 'CMD="publish --token abc --show-upload-data",           SHOW_U_D=T, NAME=, token="abc",ARGS="",', &
+'CMD="publish --token abc --dry-run",                    DRY_RUN=T, NAME=, token="abc",ARGS="",', &
 'CMD="publish --token abc",                                        NAME=, token="abc",ARGS="",', &
 ' ' ]
 character(len=256) :: readme(3)
@@ -111,6 +113,7 @@ if(command_argument_count()==0)then  ! assume if called with no arguments to do 
       c_a=.false.                    ! --all
       show_v=.false.                 ! --show-package-version
       show_u_d=.false.               ! --show-upload-data
+      dry_run=.false.                ! --dry-run
       token=''                       ! --token TOKEN
       args=repeat(' ',132)           ! -- ARGS
       cmd=repeat(' ',132)            ! the command line arguments to test
@@ -133,6 +136,7 @@ if(command_argument_count()==0)then  ! assume if called with no arguments to do 
              act_c_a=.false.
              act_show_v=.false.
              act_show_u_d=.false.
+             act_dry_run=.false.
              act_token=''
              act_args=repeat(' ',132)
              read(lun,nml=act_cli,iostat=ios,iomsg=message)
@@ -149,6 +153,7 @@ if(command_argument_count()==0)then  ! assume if called with no arguments to do 
              call test_test('WITH_TEST',act_w_t.eqv.w_t)
              call test_test('SHOW-PACKAGE-VERSION',act_show_v.eqv.show_v)
              call test_test('SHOW-UPLOAD-DATA',act_show_u_d.eqv.show_u_d)
+             call test_test('DRY-RUN',act_dry_run.eqv.dry_run)
              call test_test('TOKEN',act_token==token)
              call test_test('ARGS',act_args==args)
              if(all(subtally))then
@@ -238,6 +243,7 @@ act_c_s=.false.
 act_c_a=.false.
 act_show_v=.false.
 act_show_u_d=.false.
+act_dry_run=.false.
 act_token=''
 act_profile=''
 
@@ -263,6 +269,7 @@ type is (fpm_install_settings)
 type is (fpm_publish_settings)
     act_show_v=settings%show_package_version
     act_show_u_d=settings%show_upload_data
+    act_dry_run=settings%is_dry_run
     act_token=settings%token
 end select
 


### PR DESCRIPTION
A `--dry-run` option enables the user to simulate the upload (and validate the package with the backend) without actually publishing the package to the registry. The user is provided with the locally created tarball for inspection.

Validation with the backend will be added after https://github.com/fortran-lang/registry/issues/41 was implemented.