### PR TITLE
Allow overriding metapackages with standard dependency syntax

### DIFF
--- a/src/fpm/manifest/dependency.f90
+++ b/src/fpm/manifest/dependency.f90
@@ -29,7 +29,8 @@ module fpm_manifest_dependency
     use fpm_toml, only: toml_table, toml_key, toml_stat, get_value, check_keys
     use fpm_filesystem, only: windows_path, join_path
     use fpm_environment, only: get_os_type, OS_WINDOWS
-    use fpm_manifest_metapackages, only: metapackage_config_t, is_meta_package, new_meta_config
+    use fpm_manifest_metapackages, only: metapackage_config_t, is_meta_package, new_meta_config, &
+            metapackage_request_t, new_meta_request
     use fpm_versioning, only: version_t, new_version
     implicit none
     private
@@ -223,45 +224,73 @@ contains
 
         type(toml_table), pointer :: node
         type(toml_key), allocatable :: list(:)
-        logical, allocatable :: non_meta(:)
+        type(dependency_config_t), allocatable :: all_deps(:)
+        type(metapackage_request_t) :: meta_request
+        logical, allocatable :: is_meta(:)
+        logical :: metapackages_allowed
         integer :: idep, stat, ndep
 
         call table%get_keys(list)
         ! An empty table is okay
         if (size(list) < 1) return
 
-        !> Count non-metapackage dependencies, and parse metapackage config
-        if (present(meta)) then
-            ndep = 0
-            do idep = 1, size(list)
-                if (is_meta_package(list(idep)%key)) cycle
-                ndep = ndep+1
-            end do
+        !> Flag dependencies that should be treated as metapackages
+        metapackages_allowed = present(meta)
+        allocate(is_meta(size(list)),source=.false.)
+        allocate(all_deps(size(list)))
 
-            !> Return metapackages config from this node
-            call new_meta_config(meta, table, error)
-            if (allocated(error)) return
-        else
-            ndep = size(list)
-        end if
-
-        ! Generate non-metapackage dependencies
-        allocate(deps(ndep))
-        ndep = 0
+        !> Parse all meta- and non-metapackage dependencies
         do idep = 1, size(list)
-
-            if (present(meta) .and. is_meta_package(list(idep)%key)) cycle
-
-            ndep = ndep+1
 
             call get_value(table, list(idep)%key, node, stat=stat)
             if (stat /= toml_stat%success) then
                 call syntax_error(error, "Dependency "//list(idep)%key//" must be a table entry")
                 exit
             end if
-            call new_dependency(deps(ndep), node, root, error)
-            if (allocated(error)) exit
+
+            ! Try to parse as a standard dependency
+            call new_dependency(all_deps(idep), node, root, error)
+
+            is_standard_dependency: if (.not.allocated(error)) then
+
+                ! If a valid git/local config is found, use it always
+                is_meta(idep) = .false.
+
+            elseif (metapackages_allowed .and. is_meta_package(list(idep)%key)) then
+
+                !> Metapackage name: Check if this is a valid metapackage request
+                call new_meta_request(meta_request, list(idep)%key, table, error=error)
+
+                !> Neither a standard dep nor a metapackage
+                if (allocated(error)) return
+
+                !> Valid meta dependency
+                is_meta(idep) = .true.
+
+            else
+
+                !> Not a standard dependency and not a metapackage: dump an error
+                call syntax_error(error, "Dependency "//list(idep)%key//" cannot be parsed. Check input format")
+                return
+
+            endif is_standard_dependency
+
         end do
+
+        ! Non-meta dependencies
+        ndep = count(.not.is_meta)
+
+        ! Finalize standard dependencies
+        allocate(deps(ndep))
+        ndep = 0
+        do idep = 1, size(list)
+            if (is_meta(idep)) cycle
+            ndep = ndep+1
+            deps(ndep) = all_deps(idep)
+        end do
+
+        ! Finalize meta dependencies
+        if (metapackages_allowed) call new_meta_config(meta,table,is_meta,error)
 
     end subroutine new_dependencies
 

--- a/src/fpm/manifest/meta.f90
+++ b/src/fpm/manifest/meta.f90
@@ -147,7 +147,7 @@ contains
         do i=1,size(keys)
 
             ! Skip standard dependencies
-            if (.not.meta_allowed(i)) cycle
+            if (.not.allow_meta(i)) cycle
 
             if (keys(i)%key==key) then
                 call get_value(table, key, value)

--- a/test/fpm_test/test_package_dependencies.f90
+++ b/test/fpm_test/test_package_dependencies.f90
@@ -7,6 +7,8 @@ module test_package_dependencies
   use fpm_os, only: get_current_directory
   use fpm_dependency
   use fpm_manifest_dependency
+  use fpm_manifest_metapackages, only: metapackage_config_t
+  use fpm_manifest, only: package_config_t, get_package_data
   use fpm_toml
   use fpm_settings, only: fpm_global_settings, get_registry_settings, get_global_settings
   use fpm_downloader, only: downloader_t
@@ -45,10 +47,11 @@ contains
         & new_unittest("status-after-load", test_status), &
         & new_unittest("add-dependencies", test_add_dependencies), &
         & new_unittest("update-dependencies", test_update_dependencies), &
+        & new_unittest("metapackage-override", test_metapackage_override), &
         & new_unittest("do-not-update-dependencies", test_non_updated_dependencies), &
         & new_unittest("registry-dir-not-found", registry_dir_not_found, should_fail=.true.), &
         & new_unittest("no-versions-in-registry", no_versions_in_registry, should_fail=.true.), &
-     & new_unittest("local-registry-specified-version-not-found", local_registry_specified_version_not_found, should_fail=.true.), &
+  & new_unittest("local-registry-specified-version-not-found", local_registry_specified_version_not_found, should_fail=.true.), &
         & new_unittest("local-registry-specified-no-manifest", local_registry_specified_no_manifest, should_fail=.true.), &
         & new_unittest("local-registry-specified-has-manifest", local_registry_specified_has_manifest), &
         & new_unittest("local-registry-specified-not-a-dir", local_registry_specified_not_a_dir, should_fail=.true.), &
@@ -420,6 +423,70 @@ contains
     end if
 
   end subroutine test_update_dependencies
+
+
+  !> Test that a metapackage is overridden if a regular dependency is provided
+  subroutine test_metapackage_override(error)
+
+    !> Error handling
+    type(error_t), allocatable, intent(out) :: error
+
+    type(toml_table) :: manifest
+    type(toml_table), pointer :: ptr
+    type(dependency_config_t), allocatable :: deps(:)
+    type(metapackage_config_t) :: meta
+    logical :: found
+    integer :: i
+
+    ! Create a dummy manifest, with a standard git dependency for stdlib
+    manifest = toml_table()
+    call add_table(manifest, "stdlib", ptr)
+    call set_value(ptr, "git", "https://github.com/fortran-lang/stdlib")
+    call set_value(ptr, "branch", "stdlib-fpm")
+
+    ! Load dependencies from manifest
+    call new_dependencies(deps, manifest, meta=meta, error=error)
+    if (allocated(error)) return
+
+    ! Check that stdlib is in the regular dependency list
+    found = .false.
+    do i=1,size(deps)
+       if (deps(i)%name=="stdlib") found = .true.
+    end do
+
+    if (.not.found) then
+        call test_failed(error,"standard git-based dependency for stdlib not recognized")
+        return
+    end if
+    call manifest%destroy()
+
+
+    ! Create a dummy manifest, with a version-based metapackage dependency for stdlib
+    manifest = toml_table()
+    call set_value(manifest, "stdlib", "*")
+
+    ! Load dependencies from manifest
+    call new_dependencies(deps, manifest, meta=meta, error=error)
+    if (allocated(error)) return
+
+    ! Check that stdlib is in the metapackage config and not the standard dependencies
+    found = .false.
+    do i=1,size(deps)
+       if (deps(i)%name=="stdlib") found = .true.
+    end do
+
+    if (found) then
+        call test_failed(error,"metapackage dependency for stdlib should not be in the tree")
+        return
+    end if
+    call manifest%destroy()
+
+    if (.not.meta%stdlib%on) then
+        call test_failed(error,"metapackage dependency for stdlib should be in the metapackage config")
+        return
+    end if
+
+  end subroutine test_metapackage_override
 
   !> Directories for namespace and package name not found in path registry.
   subroutine registry_dir_not_found(error)


### PR DESCRIPTION
Address #926. See https://github.com/fortran-lang/stdlib/pull/715 

New logic: 

1) Is a valid standard dependency syntax? -> use that
2) Is a valid metapackage? -> use as metapackage
3) None of the above? error

- [x] implementation
- [x] tests 

@Carltoffel @minhqdao @arteevraina @henilp105 