### PR TITLE
Add verbose printouts options to `git_archive` and `upload_form`

### DIFF
--- a/src/fpm/cmd/publish.f90
+++ b/src/fpm/cmd/publish.f90
@@ -65,7 +65,7 @@ contains
     end do
 
     tmp_file = get_temp_filename()
-    call git_archive('.', tmp_file, error)
+    call git_archive('.', tmp_file, 'HEAD', settings%verbose, error)
     if (allocated(error)) call fpm_stop(1, '*cmd_publish* Archive error: '//error%message)
 
     upload_data = [ &
@@ -91,7 +91,6 @@ contains
     end if
 
     if (settings%verbose) then
-      print *, ''
       call print_upload_data(upload_data)
       print *, ''
     end if

--- a/src/fpm/cmd/publish.f90
+++ b/src/fpm/cmd/publish.f90
@@ -101,7 +101,7 @@ contains
       print *, 'Dry run successful. Generated tarball: ', tmp_file; return
     end if
 
-    call downloader%upload_form(official_registry_base_url//'/packages', upload_data, error)
+    call downloader%upload_form(official_registry_base_url//'/packages', upload_data, settings%verbose, error)
     call delete_file(tmp_file)
     if (allocated(error)) call fpm_stop(1, '*cmd_publish* Upload error: '//error%message)
   end

--- a/src/fpm/downloader.f90
+++ b/src/fpm/downloader.f90
@@ -76,23 +76,30 @@ contains
   end
 
   !> Perform an http post request with form data.
-  subroutine upload_form(endpoint, form_data, error)
+  subroutine upload_form(endpoint, form_data, verbose, error)
+    !> Endpoint to upload to.
     character(len=*), intent(in) :: endpoint
+    !> Form data to upload.
     type(string_t), intent(in) :: form_data(:)
+    !> Print additional information when true.
+    logical, intent(in) :: verbose
+    !> Error handling.
     type(error_t), allocatable, intent(out) :: error
 
     integer :: stat, i
-    character(len=:), allocatable :: form_data_str
+    character(len=:), allocatable :: form_data_str, cmd
 
     form_data_str = ''
     do i = 1, size(form_data)
       form_data_str = form_data_str//"-F '"//form_data(i)%s//"' "
     end do
 
+    cmd = 'curl -X POST -H "Content-Type: multipart/form-data" '//form_data_str//endpoint
+
     if (which('curl') /= '') then
       print *, 'Uploading package ...'
-      call execute_command_line('curl -X POST -H "Content-Type: multipart/form-data" ' &
-      & //form_data_str//endpoint, exitstat=stat)
+      if (verbose) print *, ' + ', cmd
+      call execute_command_line(cmd, exitstat=stat)
     else
       call fatal_error(error, "'curl' not installed."); return
     end if
@@ -104,8 +111,11 @@ contains
 
   !> Unpack a tarball to a destination.
   subroutine unpack(tmp_pkg_file, destination, error)
+    !> Path to tarball.
     character(*), intent(in) :: tmp_pkg_file
+    !> Destination to unpack to.
     character(*), intent(in) :: destination
+    !> Error handling.
     type(error_t), allocatable, intent(out) :: error
 
     integer :: stat

--- a/src/fpm/downloader.f90
+++ b/src/fpm/downloader.f90
@@ -97,7 +97,7 @@ contains
     if (which('curl') /= '') then
       print *, 'Uploading package ...'
       call run('curl -X POST -H "Content-Type: multipart/form-data" '// &
-      & form_data_str//endpoint, exitstat=stat, verbose=verbose)
+      & form_data_str//endpoint, exitstat=stat, echo=verbose)
     else
       call fatal_error(error, "'curl' not installed."); return
     end if

--- a/src/fpm/git.f90
+++ b/src/fpm/git.f90
@@ -316,7 +316,7 @@ contains
     character(*), intent(in) :: destination
     !> (Symbolic) Reference to be archived.
     character(*), intent(in) :: ref
-    !> Print additional information when true.
+    !> Print additional information if true.
     logical, intent(in) :: verbose
     !> Error handling.
     type(error_t), allocatable, intent(out) :: error

--- a/src/fpm/git.f90
+++ b/src/fpm/git.f90
@@ -315,7 +315,7 @@ contains
     character(*), intent(in) :: destination
     !> (Symbolic) Reference to be archived.
     character(*), intent(in) :: ref
-    !> Whether to print verbose output.
+    !> Print additional information when true.
     logical, intent(in) :: verbose
     !> Error handling.
     type(error_t), allocatable, intent(out) :: error

--- a/src/fpm_filesystem.F90
+++ b/src/fpm_filesystem.F90
@@ -1152,7 +1152,7 @@ end subroutine os_delete_dir
         !> Print additional information if true.
         logical, intent(in), optional :: verbose
 
-        integer :: exitstat, unit, stat = 0
+        integer :: exitstat, unit, stat
         character(len=:), allocatable :: cmdmsg, tmp_file, output_line
         logical :: is_verbose
 
@@ -1175,7 +1175,7 @@ end subroutine os_delete_dir
            output = output//output_line//' '
         end do
         if (is_verbose) print *, output
-        close(unit, status='delete', iostat=stat)
+        close(unit, status='delete')
     end
 
     !> Ensure a windows path is converted to an 8.3 DOS path if it contains spaces

--- a/src/fpm_filesystem.F90
+++ b/src/fpm_filesystem.F90
@@ -1083,24 +1083,31 @@ end subroutine os_delete_dir
     end subroutine get_home
 
     !> Execute command line and return output as a string.
-    subroutine execute_and_read_output(cmd, output, error, exitstat)
+    subroutine execute_and_read_output(cmd, output, error, verbose)
         !> Command to execute.
         character(len=*), intent(in) :: cmd
         !> Command line output.
         character(len=:), allocatable, intent(out) :: output
         !> Error to handle.
         type(error_t), allocatable, intent(out) :: error
-        !> Can optionally used for error handling.
-        integer, intent(out), optional :: exitstat
+        !> Print additional information if true.
+        logical, intent(in), optional :: verbose
 
-        integer :: cmdstat, unit, stat = 0
+        integer :: exitstat, unit, stat = 0
         character(len=:), allocatable :: cmdmsg, tmp_file
         character(len=1000) :: output_line
+        logical :: is_verbose
+
+        if (present(verbose)) then
+          is_verbose = verbose
+        else
+          is_verbose = .false.
+        end if
 
         tmp_file = get_temp_filename()
 
-        call execute_command_line(cmd//' > '//tmp_file, exitstat=exitstat, cmdstat=cmdstat)
-        if (cmdstat /= 0) call fatal_error(error, '*run*: '//"Command failed: '"//cmd//"'. Message: '"//trim(cmdmsg)//"'.")
+        call run(cmd//' > '//tmp_file, exitstat=exitstat, echo=is_verbose)
+        if (exitstat /= 0) call fatal_error(error, '*run*: '//"Command failed: '"//cmd//"'. Message: '"//trim(cmdmsg)//"'.")
 
         open(newunit=unit, file=tmp_file, action='read', status='old')
         output = ''
@@ -1109,6 +1116,7 @@ end subroutine os_delete_dir
           if (stat /= 0) exit
           output = output//trim(output_line)//' '
         end do
+        if (is_verbose) print *, output
         close(unit, status='delete')
     end
 


### PR DESCRIPTION
Add verbose printout options to `git_archive` and `upload_form`.

Use `run` with `echo` option instead of `execute_command_line`.

**How to test**
- `fpm publish --token abc --verbose`
- `fpm publish --token abc --verbose --dry-run`
- `fpm publish --token abc --verbose --show-package-data`