### PR TITLE
Fix `convert_to_absolute_path`

### DIFF
--- a/src/fpm_os.F90
+++ b/src/fpm_os.F90
@@ -246,7 +246,7 @@ contains
 
     !> Converts a path to an absolute, canonical path.
     subroutine convert_to_absolute_path(path, error)
-        character(len=*), intent(inout) :: path
+        character(len=:), allocatable, intent(inout) :: path
         type(error_t), allocatable, intent(out) :: error
 
         character(len=:), allocatable :: absolute_path


### PR DESCRIPTION
Hotfixing a bug in `convert_to_absolute_path`.

This doesn't work:

```fortran
  character(len=*), intent(inout) :: path
  ...
  path = absolute_path
```

Therefore using a deferred type parameter.

```fortran
  character(len=:), allocatable, intent(inout) :: path
  ...
  path = absolute_path
```