### PR TITLE
update jonquil version

### DIFF
--- a/fpm.toml
+++ b/fpm.toml
@@ -17,7 +17,7 @@ M_CLI2.rev = "7264878cdb1baff7323cc48596d829ccfe7751b8"
 fortran-regex.git  = "https://github.com/perazz/fortran-regex"
 fortran-regex.tag  = "1.1.2"
 jonquil.git = "https://github.com/toml-f/jonquil"
-jonquil.rev = "4c27c8c1e411fa8790dffcf8c3fa7a27b6322273"
+jonquil.rev = "4fbd4cf34d577c0fd25e32667ee9e41bf231ece8"
 
 [[test]]
 name = "cli-test"


### PR DESCRIPTION
The jonquil dependency has been updated with a change that prevents the array bound errors encountered in such places as using registry packages when building a version of fpm(1) with debug mode on.  Changing to the new version of jobquil allows using a debug version of fpm(1) again. 

fixes  #934