### PR TITLE
Dependency-level macro setting

### DIFF
--- a/ci/run_tests.sh
+++ b/ci/run_tests.sh
@@ -150,6 +150,10 @@ pushd preprocess_cpp_deps
 "$fpm" build
 popd
 
+pushd preprocess_per_dependency
+"$fpm" run
+popd
+
 pushd preprocess_hello
 "$fpm" build
 popd

--- a/example_packages/preprocess_per_dependency/app/main.f90
+++ b/example_packages/preprocess_per_dependency/app/main.f90
@@ -1,0 +1,8 @@
+program hello_fpm
+    use utils, only: say_hello
+    integer :: ierr
+
+    call say_hello(ierr)
+    stop ierr ! ierr==0 if DEPENDENCY_MACRO is defined
+
+end program hello_fpm

--- a/example_packages/preprocess_per_dependency/crate/utils/fpm.toml
+++ b/example_packages/preprocess_per_dependency/crate/utils/fpm.toml
@@ -1,0 +1,5 @@
+name = "utils"
+
+[preprocess]
+[preprocess.cpp]
+macros = ["X=1"]

--- a/example_packages/preprocess_per_dependency/crate/utils/src/say_hello.f90
+++ b/example_packages/preprocess_per_dependency/crate/utils/src/say_hello.f90
@@ -1,0 +1,19 @@
+module utils
+
+    implicit none
+    
+contains
+
+    subroutine say_hello(ierr)
+        integer, intent(out) :: ierr
+
+        ierr = -1
+#ifdef DEPENDENCY_MACRO
+        ierr = 0
+#endif
+
+        print *, "Dependency macro ", merge(" IS","NOT",ierr==0)," defined" 
+
+    end subroutine say_hello
+
+end module utils

--- a/example_packages/preprocess_per_dependency/fpm.toml
+++ b/example_packages/preprocess_per_dependency/fpm.toml
@@ -1,0 +1,4 @@
+name = "preprocess_cpp_deps"
+
+[dependencies]
+utils = { path = "crate/utils" , preprocess.cpp="DEPENDENCY_MACRO" }

--- a/example_packages/preprocess_per_dependency/fpm.toml
+++ b/example_packages/preprocess_per_dependency/fpm.toml
@@ -1,4 +1,4 @@
 name = "preprocess_cpp_deps"
 
 [dependencies]
-utils = { path = "crate/utils" , preprocess.cpp="DEPENDENCY_MACRO" }
+utils = { path = "crate/utils" , preprocess.cpp.macros=["DEPENDENCY_MACRO"] }

--- a/src/fpm.f90
+++ b/src/fpm.f90
@@ -127,7 +127,6 @@ subroutine build_model(model, settings, package, error)
             end if
 
             !> Add this dependency's package-level macros
-            print *, 'dep preprocess? ',allocated(dep%preprocess),' nam,e=',dep%name
             if (allocated(dep%preprocess)) then
                 do j = 1, size(dep%preprocess)
                     if (dep%preprocess(j)%name == "cpp") then

--- a/src/fpm.f90
+++ b/src/fpm.f90
@@ -109,12 +109,31 @@ subroutine build_model(model, settings, package, error)
             end associate
             model%packages(i)%version = package%version%s()
 
+            !> Add this dependency's manifest macros
+            allocate(model%packages(i)%macros(0))
+
             if (allocated(dependency%preprocess)) then
                 do j = 1, size(dependency%preprocess)
                     if (dependency%preprocess(j)%name == "cpp") then
                         if (.not. has_cpp) has_cpp = .true.
                         if (allocated(dependency%preprocess(j)%macros)) then
-                            model%packages(i)%macros = dependency%preprocess(j)%macros
+                            model%packages(i)%macros = [model%packages(i)%macros, dependency%preprocess(j)%macros]
+                        end if
+                    else
+                        write(stderr, '(a)') 'Warning: Preprocessor ' // package%preprocess(i)%name // &
+                            ' is not supported; will ignore it'
+                    end if
+                end do
+            end if
+
+            !> Add this dependency's package-level macros
+            print *, 'dep preprocess? ',allocated(dep%preprocess),' nam,e=',dep%name
+            if (allocated(dep%preprocess)) then
+                do j = 1, size(dep%preprocess)
+                    if (dep%preprocess(j)%name == "cpp") then
+                        if (.not. has_cpp) has_cpp = .true.
+                        if (allocated(dep%preprocess(j)%macros)) then
+                            model%packages(i)%macros = [model%packages(i)%macros, dep%preprocess(j)%macros]
                         end if
                     else
                         write(stderr, '(a)') 'Warning: Preprocessor ' // package%preprocess(i)%name // &

--- a/src/fpm/dependency.f90
+++ b/src/fpm/dependency.f90
@@ -1223,16 +1223,18 @@ contains
       if (verbosity > 1) write (iunit, out_fmt) "PROJECT DIR has changed presence "
     end if
     if (allocated(cached%preprocess) .eqv. allocated(manifest%preprocess)) then
-      if (size(cached%preprocess) /= size(manifest%preprocess)) then
-        if (verbosity > 1) write (iunit, out_fmt) "PREPROCESS has changed size"
-        return
-      end if
-      do ip=1,size(cached%preprocess)
-         if (.not.(cached%preprocess(ip) == manifest%preprocess(ip))) then
-            if (verbosity > 1) write (iunit, out_fmt) "PREPROCESS config has changed"
+      if (allocated(cached%preprocess)) then
+          if (size(cached%preprocess) /= size(manifest%preprocess)) then
+            if (verbosity > 1) write (iunit, out_fmt) "PREPROCESS has changed size"
             return
-         end if
-      end do
+          end if
+          do ip=1,size(cached%preprocess)
+             if (.not.(cached%preprocess(ip) == manifest%preprocess(ip))) then
+                if (verbosity > 1) write (iunit, out_fmt) "PREPROCESS config has changed"
+                return
+             end if
+          end do
+      endif
     else
       if (verbosity > 1) write (iunit, out_fmt) "PREPROCESS has changed presence "
       return

--- a/src/fpm/dependency.f90
+++ b/src/fpm/dependency.f90
@@ -63,6 +63,7 @@ module fpm_dependency
   use fpm_git, only: git_target_revision, git_target_default, git_revision, operator(==)
   use fpm_manifest, only: package_config_t, dependency_config_t, get_package_data
   use fpm_manifest_dependency, only: manifest_has_changed
+  use fpm_manifest_preprocess, only: operator(==)
   use fpm_strings, only: string_t, operator(.in.)
   use fpm_toml, only: toml_table, toml_key, toml_error, toml_serialize, &
                       get_value, set_value, add_table, toml_load, toml_stat
@@ -1227,13 +1228,14 @@ contains
         return
       end if
       do ip=1,size(cached%preprocess)
-         if (cached%preprocess(ip) /= manifest%preprocess(ip)) then
+         if (.not.(cached%preprocess(ip) == manifest%preprocess(ip))) then
             if (verbosity > 1) write (iunit, out_fmt) "PREPROCESS config has changed"
             return
          end if
       end do
     else
       if (verbosity > 1) write (iunit, out_fmt) "PREPROCESS has changed presence "
+      return
     end if
 
     !> All checks passed: the two dependencies have no differences

--- a/src/fpm/dependency.f90
+++ b/src/fpm/dependency.f90
@@ -1187,6 +1187,8 @@ contains
     !> Log verbosity
     integer, intent(in) :: verbosity, iunit
 
+    integer :: ip
+
     has_changed = .true.
 
     !> All the following entities must be equal for the dependency to not have changed
@@ -1218,6 +1220,20 @@ contains
       end if
     else
       if (verbosity > 1) write (iunit, out_fmt) "PROJECT DIR has changed presence "
+    end if
+    if (allocated(cached%preprocess) .eqv. allocated(manifest%preprocess)) then
+      if (size(cached%preprocess) /= size(manifest%preprocess)) then
+        if (verbosity > 1) write (iunit, out_fmt) "PREPROCESS has changed size"
+        return
+      end if
+      do ip=1,size(cached%preprocess)
+         if (cached%preprocess(ip) /= manifest%preprocess(ip)) then
+            if (verbosity > 1) write (iunit, out_fmt) "PREPROCESS config has changed"
+            return
+         end if
+      end do
+    else
+      if (verbosity > 1) write (iunit, out_fmt) "PREPROCESS has changed presence "
     end if
 
     !> All checks passed: the two dependencies have no differences

--- a/src/fpm/manifest/dependency.f90
+++ b/src/fpm/manifest/dependency.f90
@@ -109,10 +109,8 @@ contains
 
         !> Get optional preprocessor directives
         call get_value(table, "preprocess", child, requested=.false.)
-        print *, 'has preprocess? ',associated(child)
         if (associated(child)) then
             call new_preprocessors(self%preprocess, child, error)
-            print *, 'size preprocess ',size(self%preprocess),' error? =',allocated(error)
             if (allocated(error)) return
         endif
 
@@ -292,7 +290,6 @@ contains
                 ! Parse as a standard dependency
                 is_meta(idep) = .false.
 
-                print *, 'new dependency ',all_deps(idep)%name
                 call new_dependency(all_deps(idep), node, root, error)
                 if (allocated(error)) return
 

--- a/src/fpm/toml.f90
+++ b/src/fpm/toml.f90
@@ -123,6 +123,7 @@ contains
         type(error_t), allocatable, intent(out) :: error
 
         type(toml_key), allocatable :: keys(:)
+        type(toml_table), pointer :: child
         character(:), allocatable :: name, value, valid_keys_string
         integer :: ikey, ivalid
 
@@ -143,12 +144,18 @@ contains
             end if
 
             ! Check if value can be mapped or else (wrong type) show error message with the error location.
-            ! Right now, it can only be mapped to a string, but this can be extended in the future.
+            ! Right now, it can only be mapped to a string or to a child node, but this can be extended in the future.
             call get_value(table, keys(ikey)%key, value)
             if (.not. allocated(value)) then
-                allocate (error)
-                error%message = "'"//name//"' has an invalid '"//keys(ikey)%key//"' entry."
-                return
+
+                ! If value is not a string, check if it is a child node
+                call get_value(table, keys(ikey)%key, child)
+
+                if (.not.associated(child)) then
+                    allocate (error)
+                    error%message = "'"//name//"' has an invalid '"//keys(ikey)%key//"' entry."
+                    return
+                endif
             end if
         end do
 

--- a/test/fpm_test/test_package_dependencies.f90
+++ b/test/fpm_test/test_package_dependencies.f90
@@ -334,7 +334,6 @@ contains
       return
     end if
 
-
     ! Test that dependency 3 is flagged as "not update"
     if (manifest_deps%dep(3)%update) then
       call test_failed(error, "Updated dependency (git rev) detected, should not be")


### PR DESCRIPTION
I'm opening a PR to address #950. 

The request is to enable dependencies to have user-specified pre-processor macros. 

I suggest to do it via the package manifest, under the `[dependencies]` section: each dependency can have an _optional_`preprocess` node with the same contents and structure as the one in the package manifest: 

```toml
[dependencies]
utils = { path = "crate/utils" , preprocess.cpp.macros=["DEPENDENCY_MACRO"] }
```

Seems a bit verbose, but I think it's important that the same syntax for preprocessing is used here or in the package manifest (BTW - cpp is the only supported thus far...)                                                                                                                

Of course, it is the user's responsibility to ensure that user-enabled macros do not clash with package-level macros, there is no way to check that.

CC @zoziha @awvwgk @certik @arteevraina @henilp105 @minhqdao 