### PR TITLE
Add gcc versions 11,12,13 for CI validation

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-11, windows-latest]
-        gcc_v: [10] # Version of GFortran we want to use.
+        gcc_v: [10,11,12,13] # Version of GFortran we want to use.
         include:
         - os: ubuntu-latest
           os-arch: linux-x86_64


### PR DESCRIPTION
As fpm sees more adoption, I suggest to run the CI for more than one gcc version (currently `10`). 
3 last official versions could be a good rule of thumb moving forward.

cc #980 

@fortran-lang/fpm 