### PR TITLE
filesystem_utilities.c: use INODE64 on 64-bit, but not on 32-bit

### DIFF
--- a/src/filesystem_utilities.c
+++ b/src/filesystem_utilities.c
@@ -1,7 +1,7 @@
 #include <sys/stat.h>
 #include <dirent.h>
 
-#if defined(__APPLE__) && !defined(__aarch64__) && !defined(__POWERPC__)
+#if defined(__APPLE__) && !defined(__aarch64__) && !defined(__ppc__) && !defined(__i386__)
 DIR * opendir$INODE64( const char * dirName );
 struct dirent * readdir$INODE64( DIR * dir );
 #define opendir opendir$INODE64


### PR DESCRIPTION
Closes: https://github.com/fortran-lang/fpm/issues/993

1. I have tested `fpm` on `i386` with this fix, it seems to work just fine (like it does on 32-bit `ppc`). I tried to build several ports that use `fpm`, everything worked as expected. (Without this it is just broken: there is no `_opendir$INODE64` for `i386`.)
2. While I cannot test anything on `ppc64` at the moment, the symbol is in fact available in `libSystem` for this arch, so presumably we do not need to disable this chunk there. (`__POWERPC__` is defined for `ppc` and `ppc64` both, while `__ppc__` – only for `ppc`.)