### PR TITLE
Documentation fixes: help text and manifest URL

### DIFF
--- a/manifest-reference.md
+++ b/manifest-reference.md
@@ -1,3 +1,3 @@
 # 301 - Moved
 
-This document now lives at https://fpm.fortran-lang.org/en/spec/manifest.html.
+This document now lives at https://fpm.fortran-lang.org/spec/manifest.html

--- a/src/fpm_command_line.f90
+++ b/src/fpm_command_line.f90
@@ -170,7 +170,8 @@ character(len=80), parameter :: help_text_flag(*) = [character(len=80) :: &
     ' --flag  FFLAGS    selects compile arguments for the build, the default value is',&
     '                   set by the FPM_FFLAGS environment variable. These are added  ',&
     '                   to the profile options if --profile is specified, else these ',&
-    '                   options override the defaults. Note object and .mod          ',&
+    '                   are added to the defaults. To override the defaults, use the ',&
+    '                   keyword [fortran] in the manifest. Note object and .mod      ',&
     '                   directory locations are always built in.                     ',&
     ' --c-flag CFLAGS   selects compile arguments specific for C source in the build.',&
     '                   The default value is set by the FPM_CFLAGS environment       ',&

--- a/src/fpm_command_line.f90
+++ b/src/fpm_command_line.f90
@@ -972,7 +972,7 @@ contains
     ' + The fpm(1) home page is at https://github.com/fortran-lang/fpm               ', &
     ' + Registered fpm(1) packages are at https://fortran-lang.org/packages          ', &
     ' + The fpm(1) TOML file format is described at                                  ', &
-    '   https://fpm.fortran-lang.org/en/spec/manifest.html                           ', &
+    '   https://fpm.fortran-lang.org/spec/manifest.html                              ', &
     '']
     help_list=[character(len=80) :: &
     'NAME                                                                   ', &
@@ -1404,10 +1404,10 @@ contains
     ' See documentation for more information regarding package upload and usage:', &
     '', &
     ' Package upload:', &
-    ' https://fpm.fortran-lang.org/en/spec/publish.html', &
+    ' https://fpm.fortran-lang.org/spec/publish.html', &
     '', &
     ' Package usage:', &
-    ' https://fpm.fortran-lang.org/en/spec/manifest.html#dependencies-from-a-registry', &
+    ' https://fpm.fortran-lang.org/spec/manifest.html#dependencies-from-a-registry', &
     '', &
     'OPTIONS', &
     ' --show-package-version   show package version without publishing', &


### PR DESCRIPTION
Since version 0.8.0, fpm adds the `--flag` arguments to the default arguments.  Overriding the defaults requires using the "fortran" keyword in the manifest.  Also, the URL cited for the manifest documentation in several places generates a "404 File not found" error in browsers.

This commit 
1. Fixes the text returned by `--help` to match current behavior and
2. Fixes the manifest URL in
   - manifest-reference.md
   - src/fpm_command_line.f90
