### PR TITLE
Ensure no empty dependencies in dependency tree

### DIFF
--- a/src/fpm/dependency.f90
+++ b/src/fpm/dependency.f90
@@ -406,6 +406,9 @@ contains
       end if
     end if
 
+    !> Ensure allocation fits
+    call resize(self%dep,self%ndep)
+
   end subroutine add_project_dependencies
 
   !> Add a list of dependencies to the dependency tree
@@ -429,6 +432,9 @@ contains
       if (allocated(error)) exit
     end do
     if (allocated(error)) return
+
+    !> Ensure allocation fits ndep
+    call resize(self%dep,self%ndep)
 
   end subroutine add_dependencies
 
@@ -464,6 +470,10 @@ contains
         end if
       end if
     else
+
+      !> Safety: reallocate if necessary
+      if (size(self%dep)==self%ndep) call resize(self%dep,self%ndep+1)
+
       ! New dependency: add from scratch
       self%ndep = self%ndep + 1
       self%dep(self%ndep) = dependency


### PR DESCRIPTION
Address #1000: 
- [x] resize dependency array to `tree%ndep` (only after build to not incur in performance penalty)

@henilp105 @fortran-lang/fpm 
