### PR TITLE
fix issue #375 : a small qol change 

### DIFF
--- a/src/fpm.f90
+++ b/src/fpm.f90
@@ -511,7 +511,7 @@ subroutine cmd_run(settings,test)
     ! Enumerate executable targets to run
     col_width = -1
     found(:) = .false.
-    allocate(executables(0))
+    allocate(executables(size(settings%name)))
     do i=1,size(targets)
 
         exe_target => targets(i)%ptr
@@ -538,7 +538,7 @@ subroutine cmd_run(settings,test)
 
                             found(j) = .true.
                             exe_cmd%s = exe_target%output_file
-                            executables = [executables, exe_cmd]
+                            executables(j) = exe_cmd
 
                         end if
 

--- a/src/fpm.f90
+++ b/src/fpm.f90
@@ -534,7 +534,8 @@ subroutine cmd_run(settings,test)
 
                     do j=1,size(settings%name)
 
-                        if (glob(trim(exe_source%exe_name),trim(settings%name(j)))) then
+                        if (glob(trim(exe_source%exe_name),trim(settings%name(j))) .and. .not.found(j)) then
+
 
                             found(j) = .true.
                             exe_cmd%s = exe_target%output_file


### PR DESCRIPTION
I found this old issue #375 and implemented this small quality of life change.
Now, the tests will run in the order specified in the arguments of the command. It is a small change, so it won't have consequences on other parts of the code base.