### PR TITLE
fix: #1023 gfortran-specific backslash line continuations

### DIFF
--- a/src/fpm/git.f90
+++ b/src/fpm/git.f90
@@ -441,11 +441,12 @@ contains
     endif
 
     call run('git archive '//ref//' &
-        --format='//archive_format// &
-        add_files//' \
-        -o '//destination, \
-        echo=verbose, \
-        exitstat=stat)
+        & --format='//archive_format// &
+        & add_files//' &
+        & -o '//destination, &
+        & echo=verbose, &
+        & exitstat=stat)
+        
     if (stat /= 0) then
       call fatal_error(error, "Error packing '"//source//"'."); return
     end if


### PR DESCRIPTION
This PR fixes #1023. remove gfortran-specific backslash line continuations.

Thanks and Regards,
Henil