### PR TITLE
Metapackage CI: macos-latest -> macos-12

### DIFF
--- a/.github/workflows/meta.yml
+++ b/.github/workflows/meta.yml
@@ -35,9 +35,9 @@ jobs:
             mpi: openmpi
           - os: ubuntu-latest
             mpi: mpich
-          - os: macos-latest
+          - os: macos-12
             mpi: openmpi
-          - os: macos-latest
+          - os: macos-12
             mpi: mpich
 
 


### PR DESCRIPTION
It looks like `macOS-latest` runners have arm architecture where gcc is not supported. 
For now, I suggest to limit the `macos` version to 12.

Fix #1025.