### PR TITLE
DRAFT: Build with MPI wrappers only when --compiler is mpifort, mpif90, or mpif77

### DIFF
--- a/src/fpm_meta.f90
+++ b/src/fpm_meta.f90
@@ -467,7 +467,7 @@ subroutine resolve_metapackage_model(model,package,settings,error)
     end if
 
     ! MPI
-    if (package%meta%mpi%on) then
+    if (package%meta%mpi%on .and. any(model%compiler%fc==["mpifort","mpif90 ","mpif77 "])) then
         call add_metapackage_model(model,package,settings,"mpi",error)
         if (allocated(error)) return
     endif


### PR DESCRIPTION
When complete, this Pull Request (PR) will address #929 by making it possible for a project to build alternatively with or without the Message Passing Interface ([MPI]) wrappers.

To Do
------
Change `fpm`' behavior so that when the manifest [dependencies] block contains `mpi = "*"`, `fpm` builds with the MPI wrappers and links to the MPI bindings *only* when
the `--compiler` argument is `mpifort`, `mpif90`, or `mpif77`.

- [x] Use MPI compiler wrappers only when the above condition is met and
- [ ] Treat `mpi` as a metapackage only when the above condition is met.

The first commit in this PR accomplishes the first checked item above. To see this capability in action, one can start a new `fpm` project via `fpm new optional-mpi` and then adding the following lines to the manifest `optional-mpi/fpm.toml`:
```
[dependencies]
mpi = "*"
``` 

At the time of creating this daft PR, when the use of MPI is removed by a C-preprocessor macro such as in
```
#ifndef NO_MPI
use mpi_f08
#endif
```
building with the `mpi = '*"` terminates with an error 
```
<ERROR> *cmd_run* Targets error: Unable to find source for module dependency: "mpi_f08" used by "././src/optional.F90"
STOP 1
```
because `fpm` parses files for internal dependencies before running the preprocessor.
