### PR TITLE
ci: GCC-13 has been removed from GA runners

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-11, windows-latest]
-        gcc_v: [10,11,12,13] # Version of GFortran we want to use.
+        gcc_v: [10,11,12] # Version of GFortran we want to use.
         include:
         - os: ubuntu-latest
           os-arch: linux-x86_64


### PR DESCRIPTION
See https://github.com/actions/runner-images/issues/9866

If we want to use GCC-13 then I suggest we either use the `setup-fortran` GA or manually download from the PPA.
