### PR TITLE
Fix Bug #1047 - rename implicit interface option for lfortran

### DIFF
--- a/src/fpm_compiler.F90
+++ b/src/fpm_compiler.F90
@@ -235,7 +235,7 @@ character(*), parameter :: &
     flag_lfortran_opt = " --fast", &
     flag_lfortran_openmp = " --openmp", &
     flag_lfortran_implicit_typing = " --implicit-typing", &
-    flag_lfortran_implicit_external = " --allow-implicit-interface", &
+    flag_lfortran_implicit_external = " --implicit-interface", &
     flag_lfortran_fixed_form = " --fixed-form"
 
 character(*), parameter :: &


### PR DESCRIPTION
- [bug]: rename flag_lfortran_implicit_external = " --allow-implicit-interface" into flag_lfortran_implicit_external = " --implicit-interface", according to lfortran [documentation](https://docs.lfortran.org/en/usage/)

Closes #1047