### PR TITLE
`install.sh`: always bootstrap with 0.8.0

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -71,14 +71,9 @@ if [ $? -ne 0 ]; then
   exit 2
 fi
 
-LATEST_RELEASE=$(get_latest_release "fortran-lang/fpm" "$FETCH")
-
-# Fallback to a latest known release if network timeout
-if [ -z "$LATEST_RELEASE" ]; then
-   LATEST_RELEASE="0.8.0"
-fi
-
-SOURCE_URL="https://github.com/fortran-lang/fpm/releases/download/v${LATEST_RELEASE}/fpm-${LATEST_RELEASE}.F90"
+# Use 0.8.0 too bootstrap
+BOOTSTRAP_RELEASE="0.8.0"
+SOURCE_URL="https://github.com/fortran-lang/fpm/releases/download/v${BOOTSTRAP_RELEASE}/fpm-${BOOTSTRAP_RELEASE}.F90"
 BOOTSTRAP_DIR="build/bootstrap"
 
 if [ -z ${FC+x} ]; then


### PR DESCRIPTION
Fix the flawed install script logic. 
Although more recent releases have more fixes, there is no need to use the latest release as a bootstrapping version: just use a solid version i.e. 0.8.0. 

Fix #1056.

cc: @henilp105 @arteevraina 