### PR TITLE
Manifest: do not allow path lists in `library.source-dir` 

### DIFF
--- a/src/fpm/manifest/library.f90
+++ b/src/fpm/manifest/library.f90
@@ -12,7 +12,7 @@ module fpm_manifest_library
     use fpm_error, only : error_t, syntax_error
     use fpm_strings, only: string_t, string_cat, operator(==)
     use fpm_toml, only : toml_table, toml_key, toml_stat, get_value, get_list, serializable_t, set_value, &
-                          set_list, set_string, get_value, get_list
+                          set_list, set_string, get_value, has_list
     implicit none
     private
 
@@ -63,6 +63,11 @@ contains
 
         call check(table, error)
         if (allocated(error)) return
+        
+        if (has_list(table, "source-dir")) then 
+            call syntax_error(error, "Manifest key [library.source-dir] does not allow list input")
+            return
+        end if
 
         call get_value(table, "source-dir", self%source_dir, "src")
         call get_value(table, "build-script", self%build_script)

--- a/src/fpm/toml.f90
+++ b/src/fpm/toml.f90
@@ -28,7 +28,7 @@ module fpm_toml
     public :: read_package_file, toml_table, toml_array, toml_key, toml_stat, &
               get_value, set_value, get_list, new_table, add_table, add_array, len, &
               toml_error, toml_serialize, toml_load, check_keys, set_list, set_string, &
-              name_is_json
+              name_is_json, has_list
 
     !> An abstract interface for any fpm class that should be fully serializable to/from TOML/JSON
     type, abstract, public :: serializable_t
@@ -337,6 +337,29 @@ contains
         end if
 
     end subroutine read_package_file
+    
+    !> Check if an instance of the TOML data structure contains a list
+    logical function has_list(table, key)
+    
+        !> Instance of the TOML data structure
+        type(toml_table), intent(inout) :: table
+
+        !> Key to read from
+        character(len=*), intent(in) :: key
+
+        type(toml_array), pointer :: children
+        
+        has_list = .false.
+
+        if (.not.table%has_key(key)) return
+
+        call get_value(table, key, children, requested=.false.)
+        
+        ! There is an allocated list
+        has_list = associated(children)
+        
+    end function has_list
+    
 
     subroutine get_list(table, key, list, error)
 

--- a/test/fpm_test/test_manifest.f90
+++ b/test/fpm_test/test_manifest.f90
@@ -47,7 +47,6 @@ contains
             & new_unittest("library-empty", test_library_empty), &
             & new_unittest("library-wrongkey", test_library_wrongkey, should_fail=.true.), &
             & new_unittest("library-list", test_library_list, should_fail=.true.), &
-            & new_unittest("library-list-one", test_library_listone, should_fail=.true.), &
             & new_unittest("package-simple", test_package_simple), &
             & new_unittest("package-empty", test_package_empty, should_fail=.true.), &
             & new_unittest("package-typeerror", test_package_typeerror, should_fail=.true.), &


### PR DESCRIPTION
Address #1071. 

Sebastian @awvwgk: I've tried to address your suggestion in #1071 but I believe toml-f does not differentiate between a 1-sized list input and a scalar string input: both are loaded into the structure as scalars (there is no `associated(children)` array to the key). 

Do you have ideas how to handle this case? Otherwise, the current refactored implementation falls back exactly to what we deprecated in #1071. 