### PR TITLE
Feat: option to install test programs

### DIFF
--- a/src/fpm/cmd/install.f90
+++ b/src/fpm/cmd/install.f90
@@ -7,7 +7,7 @@ module fpm_cmd_install
   use fpm_filesystem, only : join_path, list_files
   use fpm_installer, only : installer_t, new_installer
   use fpm_manifest, only : package_config_t, get_package_data
-  use fpm_model, only : fpm_model_t, FPM_SCOPE_APP
+  use fpm_model, only : fpm_model_t, FPM_SCOPE_APP, FPM_SCOPE_TEST
   use fpm_targets, only: targets_from_sources, build_target_t, &
                          build_target_ptr, FPM_TARGET_EXECUTABLE, &
                          filter_library_targets, filter_executable_targets, filter_modules
@@ -34,7 +34,7 @@ contains
 
     call get_package_data(package, "fpm.toml", error, apply_defaults=.true.)
     call handle_error(error)
-
+    
     call build_model(model, settings, package, error)
     call handle_error(error)
 
@@ -57,7 +57,7 @@ contains
     end if
 
     call new_installer(installer, prefix=settings%prefix, &
-      bindir=settings%bindir, libdir=settings%libdir, &
+      bindir=settings%bindir, libdir=settings%libdir, testdir=settings%testdir, &
       includedir=settings%includedir, &
       verbosity=merge(2, 1, settings%verbose))
 
@@ -72,10 +72,17 @@ contains
         call handle_error(error)
       end if
     end if
-
+    
     if (allocated(package%executable) .or. ntargets>0) then
       call install_executables(installer, targets, error)
       call handle_error(error)
+    end if
+
+    if (allocated(package%test) .and. (package%install%test .or. model%include_tests)) then 
+        
+        call install_tests(installer, targets, error)
+        call handle_error(error)
+        
     end if
 
   end subroutine cmd_install
@@ -95,6 +102,9 @@ contains
     install_target = [install_target, temp]
 
     call filter_executable_targets(targets, FPM_SCOPE_APP, temp)
+    install_target = [install_target, temp]
+
+    call filter_executable_targets(targets, FPM_SCOPE_TEST, temp)
     install_target = [install_target, temp]
 
     ntargets = size(install_target)
@@ -143,6 +153,22 @@ contains
     if (allocated(error)) return
 
   end subroutine install_executables
+
+  subroutine install_tests(installer, targets, error)
+    type(installer_t), intent(inout) :: installer
+    type(build_target_ptr), intent(in) :: targets(:)
+    type(error_t), allocatable, intent(out) :: error
+    integer :: ii
+    
+    do ii = 1, size(targets)
+      if (targets(ii)%ptr%is_executable_target(FPM_SCOPE_TEST)) then
+        call installer%install_test(targets(ii)%ptr%output_file, error)
+        if (allocated(error)) exit
+      end if
+    end do
+    if (allocated(error)) return
+
+  end subroutine install_tests
 
   subroutine handle_error(error)
     type(error_t), intent(in), optional :: error

--- a/src/fpm/installer.f90
+++ b/src/fpm/installer.f90
@@ -42,6 +42,8 @@ module fpm_installer
     procedure :: install_library
     !> Install a header/module in its correct subdirectory
     procedure :: install_header
+    !> Install a test program in its correct subdirectory
+    procedure :: install_test
     !> Install a generic file into a subdirectory in the installation prefix
     procedure :: install
     !> Run an installation command, type-bound for unit testing purposes
@@ -198,6 +200,28 @@ contains
 
     call self%install(library, self%libdir, error)
   end subroutine install_library
+
+  !> Install a test program in its correct subdirectory
+  subroutine install_test(self, test, error)
+    !> Instance of the installer
+    class(installer_t), intent(inout) :: self
+    !> Path to the test executable
+    character(len=*), intent(in) :: test
+    !> Error handling
+    type(error_t), allocatable, intent(out) :: error
+    integer :: ll
+
+    if (.not.os_is_unix(self%os)) then
+        ll = len(test)
+        if (test(max(1, ll-3):ll) /= ".exe") then
+            call self%install(test//".exe", self%testdir, error)
+            return
+        end if
+    end if
+
+    call self%install(test, self%testdir, error)
+
+  end subroutine install_test
 
   !> Install a header/module in its correct subdirectory
   subroutine install_header(self, header, error)

--- a/src/fpm/installer.f90
+++ b/src/fpm/installer.f90
@@ -21,6 +21,8 @@ module fpm_installer
     character(len=:), allocatable :: bindir
     !> Library directory relative to the installation prefix
     character(len=:), allocatable :: libdir
+    !> Test program directory relative to the installation prefix
+    character(len=:), allocatable :: testdir
     !> Include directory relative to the installation prefix
     character(len=:), allocatable :: includedir
     !> Output unit for informative printout
@@ -53,6 +55,9 @@ module fpm_installer
 
   !> Default name of the library subdirectory
   character(len=*), parameter :: default_libdir = "lib"
+  
+  !> Default name of the test subdirectory
+  character(len=*), parameter :: default_testdir = "test"
 
   !> Default name of the include subdirectory
   character(len=*), parameter :: default_includedir = "include"
@@ -78,7 +83,7 @@ module fpm_installer
 contains
 
   !> Create a new instance of an installer
-  subroutine new_installer(self, prefix, bindir, libdir, includedir, verbosity, &
+  subroutine new_installer(self, prefix, bindir, libdir, includedir, testdir, verbosity, &
           copy, move)
     !> Instance of the installer
     type(installer_t), intent(out) :: self
@@ -90,6 +95,8 @@ contains
     character(len=*), intent(in), optional :: libdir
     !> Include directory relative to the installation prefix
     character(len=*), intent(in), optional :: includedir
+    !> Test directory relative to the installation prefix
+    character(len=*), intent(in), optional :: testdir    
     !> Verbosity of the installer
     integer, intent(in), optional :: verbosity
     !> Copy command
@@ -124,6 +131,12 @@ contains
       self%includedir = includedir
     else
       self%includedir = default_includedir
+    end if
+    
+    if (present(testdir)) then 
+      self%testdir = testdir
+    else
+      self%testdir = default_testdir  
     end if
 
     if (present(prefix)) then

--- a/src/fpm/manifest/install.f90
+++ b/src/fpm/manifest/install.f90
@@ -54,7 +54,7 @@ contains
     if (allocated(error)) return
 
     call get_value(table, "library", self%library, .false.)
-    call get_value(table, "test", self%library, .false.)
+    call get_value(table, "test", self%test, .false.)
 
   end subroutine new_install_config
 
@@ -172,7 +172,7 @@ contains
 
     call get_value(table, "library", self%library, error, class_name)
     if (allocated(error)) return
-    call get_value(table, "library", self%test, error, class_name)
+    call get_value(table, "test", self%test, error, class_name)
     if (allocated(error)) return
 
   end subroutine load_from_toml

--- a/src/fpm/manifest/install.f90
+++ b/src/fpm/manifest/install.f90
@@ -18,6 +18,9 @@ module fpm_manifest_install
 
     !> Install library with this project
     logical :: library = .false.
+    
+    !> Install tests with this project
+    logical :: test = .false.
 
   contains
 
@@ -51,6 +54,7 @@ contains
     if (allocated(error)) return
 
     call get_value(table, "library", self%library, .false.)
+    call get_value(table, "test", self%library, .false.)
 
   end subroutine new_install_config
 
@@ -75,8 +79,8 @@ contains
       case default
         call syntax_error(error, "Key "//list(ikey)%key//" is not allowed in install table")
         exit
-      case("library")
-        continue
+      case("library","test")
+        continue    
       end select
     end do
     if (allocated(error)) return
@@ -107,8 +111,8 @@ contains
     if (pr < 1) return
 
     write(unit, fmt) "Install configuration"
-    write(unit, fmt) " - library install", &
-      & trim(merge("enabled ", "disabled", self%library))
+    write(unit, fmt) " - library install", trim(merge("enabled ", "disabled", self%library))
+    write(unit, fmt) " - test    install", trim(merge("enabled ", "disabled", self%test))
 
   end subroutine info
 
@@ -121,6 +125,7 @@ contains
     select type (other=>that)
        type is (install_config_t)
           if (this%library.neqv.other%library) return
+          if (this%test.neqv.other%test) return
        class default
           ! Not the same type
           return
@@ -144,6 +149,10 @@ contains
     type(error_t), allocatable, intent(out) :: error
 
     call set_value(table, "library", self%library, error, class_name)
+    if (allocated(error)) return
+    
+    call set_value(table, "test", self%test, error, class_name)
+    if (allocated(error)) return
 
   end subroutine dump_to_toml
 
@@ -162,6 +171,8 @@ contains
     integer :: stat
 
     call get_value(table, "library", self%library, error, class_name)
+    if (allocated(error)) return
+    call get_value(table, "library", self%test, error, class_name)
     if (allocated(error)) return
 
   end subroutine load_from_toml

--- a/src/fpm_command_line.f90
+++ b/src/fpm_command_line.f90
@@ -1421,6 +1421,7 @@ contains
     help_text_build_common,&
     help_text_flag, &
     ' --no-rebuild      do not rebuild project before installation', &
+    ' --test            also install test programs', &
     ' --prefix DIR      path to installation directory (requires write access),', &
     '                   the default prefix on Unix systems is $HOME/.local', &
     '                   and %APPDATA%\local on Windows', &
@@ -1429,6 +1430,7 @@ contains
     '                   (default: lib)', &
     ' --includedir DIR  subdirectory to place headers and module files in', &
     '                   (default: include)', &
+    ' --testdir DIR     subdirectory to place test programs in (default: test)', & 
     ' --verbose         print more information', &
     '', &
     help_text_environment, &
@@ -1445,6 +1447,9 @@ contains
     ' 3. Install executables to a custom prefix into the exe directory:', &
     '', &
     '    fpm install --prefix $PWD --bindir exe', &
+    ' 4. Install executables and test programs into the same "exe" directory:', &
+    '', &
+    '    fpm install --prefix $PWD --test --bindir exe --testdir exe', &
     '' ]
     help_clean=[character(len=80) :: &
     'NAME', &

--- a/src/fpm_command_line.f90
+++ b/src/fpm_command_line.f90
@@ -108,6 +108,7 @@ type, extends(fpm_build_settings) :: fpm_install_settings
     character(len=:), allocatable :: prefix
     character(len=:), allocatable :: bindir
     character(len=:), allocatable :: libdir
+    character(len=:), allocatable :: testdir
     character(len=:), allocatable :: includedir
     logical :: no_rebuild
 end type
@@ -533,8 +534,8 @@ contains
         case('install')
             call set_args(common_args // compiler_args // '&
                 & --no-rebuild F --prefix " " &
-                & --list F &
-                & --libdir "lib" --bindir "bin" --includedir "include"', &
+                & --list F --test F &
+                & --libdir "lib" --bindir "bin" --testdir "test" --includedir "include"', &
                 help_install, version_text)
 
             call check_build_vals()
@@ -544,6 +545,7 @@ contains
             archiver = sget('archiver')
             allocate(install_settings, source=fpm_install_settings(&
                 list=lget('list'), &
+                build_tests=lget('test'), &
                 profile=val_profile,&
                 prune=.not.lget('no-prune'), &
                 compiler=val_compiler, &
@@ -558,6 +560,7 @@ contains
                 verbose=lget('verbose')))
             call get_char_arg(install_settings%prefix, 'prefix')
             call get_char_arg(install_settings%libdir, 'libdir')
+            call get_char_arg(install_settings%testdir, 'testdir')
             call get_char_arg(install_settings%bindir, 'bindir')
             call get_char_arg(install_settings%includedir, 'includedir')
             call move_alloc(install_settings, cmd_settings)

--- a/test/fpm_test/test_installer.f90
+++ b/test/fpm_test/test_installer.f90
@@ -35,7 +35,9 @@ contains
             & new_unittest("install-sitepackages", test_install_sitepackages), &
             & new_unittest("install-mod", test_install_mod), &
             & new_unittest("install-exe-unix", test_install_exe_unix), &
-            & new_unittest("install-exe-win", test_install_exe_win)]
+            & new_unittest("install-exe-win", test_install_exe_win), &
+            & new_unittest("install-test-unix", test_install_tests_unix), &
+            & new_unittest("install-test-win", test_install_tests_win)]
 
     end subroutine collect_installer
 
@@ -72,6 +74,40 @@ contains
         call mock%install_executable("name", error)
 
     end subroutine test_install_exe_win
+
+    subroutine test_install_tests_unix(error)
+        !> Error handling
+        type(error_t), allocatable, intent(out) :: error
+
+        type(mock_installer_t) :: mock
+        type(installer_t) :: installer
+
+        call new_installer(installer, prefix="PREFIX", testdir="tdir", verbosity=0, copy="mock")
+        mock%installer_t = installer
+        mock%os = OS_LINUX
+        mock%expected_dir = "PREFIX/tdir"
+        mock%expected_run = 'mock "name" "'//mock%expected_dir//'"'
+
+        call mock%install_test("name", error)
+
+    end subroutine test_install_tests_unix
+
+    subroutine test_install_tests_win(error)
+        !> Error handling
+        type(error_t), allocatable, intent(out) :: error
+
+        type(mock_installer_t) :: mock
+        type(installer_t) :: installer
+
+        call new_installer(installer, prefix="PREFIX", testdir="tdir", verbosity=0, copy="mock")
+        mock%installer_t = installer
+        mock%os = OS_WINDOWS
+        mock%expected_dir = "PREFIX\tdir"
+        mock%expected_run = 'mock "name.exe" "'//mock%expected_dir//'"'
+
+        call mock%install_test("name", error)
+
+    end subroutine test_install_tests_win
 
     subroutine test_install_lib(error)
         !> Error handling


### PR DESCRIPTION
Address #1070 @everythingfunctional. 

This PR proposes to add the option to also install the test programs in the installation directory. 
Two methods are made possible, similar to what can be done for a `library` install: 

1. Via manifest 

User can now specify a `test` boolean key in `fpm.toml` to request that test programs are installed as well

```toml
[install]
library = true
test = true
```

2. Via CLI

User can request tests to be installed via the `--test` flag. 

The default installation subdirectory is `test/`, but the user can request a custom subdirectory via `--testdir "testdir"`.
In both cases, this is a subdirectory created within the installation `$PREFIX`.

```shell
fpm install --prefix=/path --test --testdir "my_test_dir"
```

Full description is reported in `fpm help install`.

cc: @everythingfunctional @urbanjost @fortran-lang/fpm 