### PR TITLE
Remove unneeded `public :: operator(==)` which causes an error on ifx

### DIFF
--- a/src/fpm/git.f90
+++ b/src/fpm/git.f90
@@ -6,7 +6,7 @@ module fpm_git
     implicit none
 
     public :: git_target_t, git_target_default, git_target_branch, git_target_tag, git_target_revision, git_revision, &
-            & git_archive, git_matches_manifest, operator(==), compressed_package_name
+            & git_archive, git_matches_manifest, compressed_package_name
 
     !> Name of the compressed package that is generated temporarily.
     character(len=*), parameter :: compressed_package_name = 'compressed_package'


### PR DESCRIPTION
The commit 64093b1e60e3237ef87b6c5e4df5b7f7dea89127 removed the duplicate `==` operator on the `git_target_t` type. However the `public :: operator(==)` was left behind. `operator(==)` appearing on the `public` statement is not needed and causes an error when building with ifx. It causes a warning when building with nagfor.

(Note neither ifx nor nagfor will build with this fix alone, due to other issues. The one remaining issue preventing build with ifx is a compiler bug and has been reported and is being addressed. The one issue preventing build with nagfor is a preprocessor limitation compiling `fpm_release.F90`.)