### PR TITLE
fix Windows bootstrap

### DIFF
--- a/src/fpm_filesystem.F90
+++ b/src/fpm_filesystem.F90
@@ -517,7 +517,7 @@ recursive subroutine list_files(dir, files, recurse)
         call fpm_stop(2,'*list_files*:directory listing failed')
     end if
 
-    files = read_lines(temp_file)
+    files = read_lines_expanded(temp_file)
     call delete_file(temp_file)
 
     do i=1,size(files)

--- a/src/fpm_filesystem.F90
+++ b/src/fpm_filesystem.F90
@@ -51,7 +51,9 @@ module fpm_filesystem
     end interface
 #endif
 
-    character(*), parameter :: eol = new_line('a')    !! End of line
+    character,    parameter :: CR = achar(13)
+    character,    parameter :: LF = new_line('A')
+    character(*), parameter :: eol = CR//LF
 
 contains
 

--- a/src/fpm_filesystem.F90
+++ b/src/fpm_filesystem.F90
@@ -517,7 +517,7 @@ recursive subroutine list_files(dir, files, recurse)
         call fpm_stop(2,'*list_files*:directory listing failed')
     end if
 
-    files = read_lines_expanded(temp_file)
+    files = read_lines(temp_file)
     call delete_file(temp_file)
 
     do i=1,size(files)

--- a/src/fpm_filesystem.F90
+++ b/src/fpm_filesystem.F90
@@ -7,7 +7,7 @@ module fpm_filesystem
                                OS_UNKNOWN, OS_LINUX, OS_MACOS, OS_WINDOWS, &
                                OS_CYGWIN, OS_SOLARIS, OS_FREEBSD, OS_OPENBSD
     use fpm_environment, only: separator, get_env, os_is_unix
-    use fpm_strings, only: f_string, replace, string_t, split, split_first_last, dilate, str_begins_with_str
+    use fpm_strings, only: f_string, replace, string_t, split, split_lines_first_last, dilate, str_begins_with_str
     use iso_c_binding, only: c_char, c_ptr, c_int, c_null_char, c_associated, c_f_pointer
     use fpm_error, only : fpm_stop, error_t, fatal_error
     implicit none
@@ -50,10 +50,6 @@ module fpm_filesystem
         end function c_is_dir
     end interface
 #endif
-
-    character,    parameter :: CR = achar(13)
-    character,    parameter :: LF = new_line('A')
-    character(*), parameter :: eol = CR//LF
 
 contains
 
@@ -321,7 +317,7 @@ function read_lines_expanded(filename) result(lines)
         return
     end if
 
-    call split_first_last(content, eol, first, last)  ! TODO: \r (< macOS X), \n (>=macOS X/Linux/Unix), \r\n (Windows)
+    call split_lines_first_last(content, first, last)  
 
     ! allocate lines from file content string
     allocate (lines(size(first)))
@@ -346,7 +342,7 @@ function read_lines(filename) result(lines)
         return
     end if
 
-    call split_first_last(content, eol, first, last)  ! TODO: \r (< macOS X), \n (>=macOS X/Linux/Unix), \r\n (Windows)
+    call split_lines_first_last(content, first, last) 
 
     ! allocate lines from file content string
     allocate (lines(size(first)))

--- a/src/fpm_strings.f90
+++ b/src/fpm_strings.f90
@@ -576,7 +576,7 @@ pure subroutine split_lines_first_last(string, first, last)
                 n = n + 1
                 istart(n) = p
                 do while (p <= slen)
-                    if (index(CR//LF, string(p:p)) == 0) exit
+                    if (index(CR//LF, string(p:p)) /= 0) exit
                     p = p + 1
                 end do
                 iend(n) = p - 1

--- a/src/fpm_strings.f90
+++ b/src/fpm_strings.f90
@@ -575,7 +575,8 @@ pure subroutine split_lines_first_last(string, first, last)
             if (index(CR//LF, string(p:p)) == 0) then
                 n = n + 1
                 istart(n) = p
-                do while (p <= slen .and. index(CR//LF, string(p:p)) == 0)
+                do while (p <= slen)
+                    if (index(CR//LF, string(p:p)) == 0) exit
                     p = p + 1
                 end do
                 iend(n) = p - 1

--- a/test/fpm_test/test_filesystem.f90
+++ b/test/fpm_test/test_filesystem.f90
@@ -299,9 +299,10 @@ contains
         !> Error handling
         type(error_t), allocatable, intent(out) :: error
 
-        character, parameter :: CR = achar(13)
-        character, parameter :: LF = new_line('A')
-        integer, allocatable :: first(:), last(:)
+        character,    parameter :: CR = achar(13)
+        character,    parameter :: LF = new_line('A')
+        character(*), parameter :: CRLF = CR//LF
+        integer, allocatable    :: first(:), last(:)
         
         call split_lines_first_last(CR//LF//'line1'//CR//'line2'//LF//'line3'//CR//LF//'hello', first, last)
         if (.not.(all(first==[3,9,15,22]) .and. all(last==[7,13,19,26]))) then 
@@ -330,6 +331,17 @@ contains
         call split_lines_first_last('', first, last)
         if (.not.(size(first) == 0 .and. size(last) == 0)) then 
             call test_failed(error, "Test split_lines_first_last #5 failed")
+            return
+        end if
+        
+        call split_lines_first_last('build.f90'//CRLF//&
+                                    'dependency.f90'//CRLF//&
+                                    'example.f90'//CRLF//&
+                                    'executable.f90'//CRLF//&
+                                    'fortran.f90'//CRLF, first, last))
+
+        if (.not.(all(first == [1,12,28,41,57]) .and. all(last == [9,25,38,54,67]))) then 
+            call test_failed(error, "Test split_lines_first_last #6 failed")
             return
         end if
 

--- a/test/fpm_test/test_filesystem.f90
+++ b/test/fpm_test/test_filesystem.f90
@@ -4,6 +4,7 @@ module test_filesystem
                               join_path, is_absolute_path, get_home, &
                               delete_file, read_lines, get_temp_filename
     use fpm_environment, only: OS_WINDOWS, get_os_type, os_is_unix
+    use fpm_strings, only: string_t
     implicit none
     private
 

--- a/test/fpm_test/test_filesystem.f90
+++ b/test/fpm_test/test_filesystem.f90
@@ -304,7 +304,7 @@ contains
         integer, allocatable :: first(:), last(:)
         
         call split_lines_first_last(CR//LF//'line1'//CR//'line2'//LF//'line3'//CR//LF//'hello', first, last)
-        if (.not.(all(first==[3,9,15,23]) .and. all(last==[7,13,21,27]))) then 
+        if (.not.(all(first==[3,9,15,21]) .and. all(last==[7,13,18,25]))) then 
             call test_failed(error, "Test split_lines_first_last #1 failed")
             return
         end if
@@ -351,6 +351,7 @@ contains
                                                
         type(string_t), allocatable :: lines(:)
         character(len=:), allocatable :: temp_file
+        character(256) :: msg
         integer :: unit, i, ios
         
         temp_file = get_temp_filename()
@@ -376,12 +377,14 @@ contains
         lines = read_lines(temp_file) 
         
         if (.not.allocated(lines)) then 
-            call test_failed(error, "Failed reading file with CRLF: no output")
+            write(msg, 1) 'no output'
+            call test_failed(error, msg)
             return
         end if
         
         if (size(lines)/=5) then 
-            call test_failed(error, "Failed reading file with CRLF: wrong number of lines")
+            write(msg, 1) 'wrong number of lines: expected ',5,', actual ',size(lines)
+            call test_failed(error, msg)
             return
         end if
         
@@ -407,6 +410,8 @@ contains
         end if                                
         
         call delete_file(temp_file)
+        
+        1 format("Failed reading file with CRLF: ",a,:,i0,:,a,:,i0)
         
     end subroutine test_dir_with_crlf
     

--- a/test/fpm_test/test_filesystem.f90
+++ b/test/fpm_test/test_filesystem.f90
@@ -338,7 +338,8 @@ contains
                                     'dependency.f90'//CRLF//&
                                     'example.f90'//CRLF//&
                                     'executable.f90'//CRLF//&
-                                    'fortran.f90'//CRLF, first, last))
+                                    'fortran.f90'//CRLF, &
+                                    first, last)
 
         if (.not.(all(first == [1,12,28,41,57]) .and. all(last == [9,25,38,54,67]))) then 
             call test_failed(error, "Test split_lines_first_last #6 failed")

--- a/test/fpm_test/test_filesystem.f90
+++ b/test/fpm_test/test_filesystem.f90
@@ -302,31 +302,36 @@ contains
         character, parameter :: CR = achar(13)
         character, parameter :: LF = new_line('A')
         integer, allocatable :: first(:), last(:)
+        
+        call split_lines_first_last(CR//LF//'line1'//CR//'line2'//LF//'line3'//CR//LF//'hello', first, last)
+        if (.not.(all(first==[3,9,15,23]) .and. all(last==[7,13,21,27]))) then 
+            call test_failed(error, "Test split_lines_first_last #1 failed")
+            return
+        end if
 
-        call check_array(error, &
-            & split_lines_first_last(CR//LF//'line1'//CR//'line2'//LF//'line3'//CR//LF//'hello', first, last), &
-            & [3, 9, 15, 23], [7, 13, 21, 27])
-        if (allocated(error)) return
+        call split_lines_first_last('single_line', first, last)
+        if (.not.(all(first==[1]) .and. all(last==[11]))) then 
+            call test_failed(error, "Test split_lines_first_last #2 failed")
+            return
+        end if
 
-        call check_array(error, &
-            & split_lines_first_last('single_line', first, last), &
-            & [1], [11])
-        if (allocated(error)) return
+        call split_lines_first_last(CR//LF//CR//LF//'test', first, last)
+        if (.not.(all(first == [5]) .and. all(last == [8]))) then 
+            call test_failed(error, "Test split_lines_first_last #3 failed")
+            return
+        end if
 
-        call check_array(error, &
-            & split_lines_first_last(CR//LF//CR//LF//'test', first, last), &
-            & [5], [8])
-        if (allocated(error)) return
+        call split_lines_first_last('a'//CR//'b'//LF//'c'//CR//LF//'d', first, last)
+        if (.not.(all(first == [1, 3, 5, 8]) .and. all(last == [1, 3, 5, 8]))) then 
+            call test_failed(error, "Test split_lines_first_last #4 failed")
+            return
+        end if
 
-        call check_array(error, &
-            & split_lines_first_last('a'//CR//'b'//LF//'c'//CR//LF//'d', first, last), &
-            & [1, 3, 5, 8], [1, 3, 5, 8])
-        if (allocated(error)) return
-
-        call check_array(error, &
-            & split_lines_first_last('', first, last), &
-            & [], [])
-        if (allocated(error)) return
+        call split_lines_first_last('', first, last)
+        if (.not.(size(first) == 0 .and. size(last) == 0)) then 
+            call test_failed(error, "Test split_lines_first_last #5 failed")
+            return
+        end if
 
     end subroutine test_split_lines_first_last    
     

--- a/test/fpm_test/test_filesystem.f90
+++ b/test/fpm_test/test_filesystem.f90
@@ -304,7 +304,7 @@ contains
         integer, allocatable :: first(:), last(:)
         
         call split_lines_first_last(CR//LF//'line1'//CR//'line2'//LF//'line3'//CR//LF//'hello', first, last)
-        if (.not.(all(first==[3,9,15,21]) .and. all(last==[7,13,18,25]))) then 
+        if (.not.(all(first==[3,9,15,22]) .and. all(last==[7,13,19,26]))) then 
             call test_failed(error, "Test split_lines_first_last #1 failed")
             return
         end if

--- a/test/fpm_test/test_filesystem.f90
+++ b/test/fpm_test/test_filesystem.f90
@@ -343,28 +343,28 @@ contains
             return
         end if
         
-        if (lines(1)/='build.f90') then 
+        if (lines(1)%s/='build.f90') then 
             call test_failed(error, "Failed reading file with CRLF: at build.f90")
             return
         end if
-        if (lines(2)/='dependency.f90') then 
+        if (lines(2)%s/='dependency.f90') then 
             call test_failed(error, "Failed reading file with CRLF: at dependency.f90")
             return
         end if
-        if (lines(3)/='example.f90') then 
+        if (lines(3)%s/='example.f90') then 
             call test_failed(error, "Failed reading file with CRLF: at example.f90")
             return
         end if
-        if (lines(4)/='executable.f90') then 
+        if (lines(4)%s/='executable.f90') then 
             call test_failed(error, "Failed reading file with CRLF: at executable.f90")
             return
         end if
-        if (lines(5)/='fortran.f90') then 
+        if (lines(5)%s/='fortran.f90') then 
             call test_failed(error, "Failed reading file with CRLF: at fortran.f90")
             return
         end if                                
         
-        call delete_dile(temp_file)
+        call delete_file(temp_file)
         
     end subroutine test_dir_with_crlf
     

--- a/test/fpm_test/test_filesystem.f90
+++ b/test/fpm_test/test_filesystem.f90
@@ -348,7 +348,8 @@ contains
 
     end subroutine test_split_lines_first_last    
     
-    ! On MS windows, 
+    ! On MS windows, directory listings are printed to files with CR//LF endings. 
+    ! Check that the lines can be properly read back from such files.
     subroutine test_dir_with_crlf(error)
         type(error_t), allocatable, intent(out) :: error
         


### PR DESCRIPTION
Fix #1105. 

fpm v0.11.0 does not work on Windows as reported by @zoziha. 

A breaking change was introduced by PR #961: the `read_lines` returns wrong values on Windows due to failure to capture CR//LF ending properly. 

- Fix `read_lines` 
- Add tests for CRLF line endings