### PR TITLE
[openmp] add `flang-new` syntax

### DIFF
--- a/src/fpm_compiler.F90
+++ b/src/fpm_compiler.F90
@@ -248,6 +248,9 @@ character(*), parameter :: &
     flag_cray_fixed_form = " -ffixed", &
     flag_cray_free_form = " -ffree"
 
+character(*), parameter :: &
+    flag_flang_new_openmp = " -fopenmp"
+
 contains
 
 

--- a/src/fpm_meta.f90
+++ b/src/fpm_meta.f90
@@ -223,6 +223,10 @@ subroutine init_openmp(this,compiler,error)
        case (id_lfortran)
             this%flags      = string_t(flag_lfortran_openmp)
             this%link_flags = string_t(flag_lfortran_openmp)
+            
+       case (id_flang, id_flang_new)
+            this%flags      = string_t(flag_flang_new_openmp)
+            this%link_flags = string_t(flag_flang_new_openmp)
 
        case default
 


### PR DESCRIPTION
- Add flang-new syntax for openmp https://flang.llvm.org/docs/FlangCommandLineReference.html#preprocessor-options
- Not CI available yet