### PR TITLE
[introspection] optional user-defined build and link flags

### DIFF
--- a/src/fpm_compiler.F90
+++ b/src/fpm_compiler.F90
@@ -124,6 +124,7 @@ contains
     procedure :: load_from_toml => compiler_load
     !> Fortran feature support
     procedure :: check_fortran_source_runs
+    procedure :: check_flags_supported
     procedure :: with_xdp
     procedure :: with_qp
     !> Return compiler name
@@ -1495,6 +1496,18 @@ logical function check_fortran_source_runs(self, input, compile_flags, link_flag
     close(unit,status='delete')
 
 end function check_fortran_source_runs
+
+!> Check if the given compile and/or link flags are accepted by the compiler
+logical function check_flags_supported(self, compile_flags, link_flags)
+    class(compiler_t), intent(in) :: self
+    character(len=*), optional, intent(in) :: compile_flags, link_flags
+
+    ! Minimal program that always compiles
+    character(len=*), parameter :: hello_world = "print *, 'Hello, World!'; end"
+
+    check_flags_supported = self%check_fortran_source_runs(hello_world, compile_flags, link_flags)
+    
+end function check_flags_supported
 
 !> Check if the current compiler supports 128-bit real precision
 logical function with_qp(self)

--- a/test/fpm_test/test_compiler.f90
+++ b/test/fpm_test/test_compiler.f90
@@ -51,6 +51,24 @@ contains
             call test_failed(error, "Cannot run Fortran hello world")
             return
         end if
+        
+        !> Test with invalid flags 
+        if (compiler%check_fortran_source_runs("print *, 'Hello world!'; end", &
+                                               link_flags=" -some-really-invalid-link-flag")) then 
+            call test_failed(error, "Invalid link flags did not trigger an error")
+            return
+        end if              
+        if (compiler%check_fortran_source_runs("print *, 'Hello world!'; end", &
+                                               compile_flags=" -certainly-not-a-build/flag")) then 
+            call test_failed(error, "Invalid compile flags did not trigger an error")
+            return
+        end if                              
+        if (compiler%check_fortran_source_runs("print *, 'Hello world!'; end", &
+                                               compile_flags=" -certainly-not-a-build/flag", &
+                                               link_flags=" -some-really-invalid-link-flag")) then 
+            call test_failed(error, "Invalid build and link flags did not trigger an error")
+            return
+        end if                              
 
     end subroutine test_check_fortran_source_runs
 

--- a/test/fpm_test/test_compiler.f90
+++ b/test/fpm_test/test_compiler.f90
@@ -68,7 +68,22 @@ contains
                                                link_flags=" -some-really-invalid-link-flag")) then 
             call test_failed(error, "Invalid build and link flags did not trigger an error")
             return
-        end if                              
+        end if           
+        
+        !> Test the flag check wrapper
+        if (compiler%check_flags_supported(compile_flags='-Werror=unknown-flag')) then
+            call test_failed(error, "Invalid compile flags did not trigger an error")
+            return
+        end if
+        if (compiler%check_flags_supported(link_flags='-Wl,--nonexistent-linker-option')) then
+            call test_failed(error, "Invalid link flags did not trigger an error")
+            return
+        end if
+        if (compiler%check_flags_supported(compile_flags='-Werror=unknown-flag', &
+                                           link_flags='-Wl,--nonexistent-linker-option')) then
+            call test_failed(error, "Invalid compile and link flags did not trigger an error")
+            return
+        end if
 
     end subroutine test_check_fortran_source_runs
 


### PR DESCRIPTION
- add optional `compile_flags` and `link_flags` when building a file for introspection
- add wrapper `compiler%check_flags_supported([compile_flags] [, link_flags])`
- add tests