### PR TITLE
[metapackage] fix/extend Intel LLVM MPI

### DIFF
--- a/.github/actions/setup-intel/action.yml
+++ b/.github/actions/setup-intel/action.yml
@@ -6,6 +6,12 @@ inputs:
     description: 'Operating system of the runner. Must contain "windows" or "ubuntu".'
     required: true
     type: string
+    
+  version:
+    description: 'Intel oneAPI installer version for Ubuntu (e.g. 2024.1.0).'
+    required: false
+    default: '2024.1.0'
+    type: string    
 
 runs:
   using: "composite"
@@ -87,7 +93,7 @@ runs:
       uses: fortran-lang/setup-fortran@v1
       with:
         compiler: intel
-        version: 2024.1.0  # Pinned until issue #1090 is resolved
+        version: ${{ inputs.version }}
 
     - name: (Ubuntu) Install Intel oneAPI MPI and build dependencies
       if: contains(inputs.os, 'ubuntu')

--- a/.github/workflows/meta.yml
+++ b/.github/workflows/meta.yml
@@ -34,15 +34,19 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
+            mpi: openmpi
+          - os: ubuntu-latest
+            mpi: mpich
+          - os: macos-13
+            mpi: openmpi
+          - os: macos-13
+            mpi: mpich
+          - os: ubuntu-latest
             mpi: intel
+            intel_version: "2024.1.0"
           - os: ubuntu-latest
-            mpi: openmpi
-          - os: ubuntu-latest
-            mpi: mpich
-          - os: macos-13
-            mpi: openmpi
-          - os: macos-13
-            mpi: mpich
+            mpi: intel
+            intel_version: "2025.0"        
 
     steps:
     - name: Checkout code
@@ -91,13 +95,13 @@ jobs:
           libnetcdf-dev libnetcdff-dev libopenblas-dev
 
     # Intel
-
     - name: Setup Intel Environment
       if: contains(matrix.mpi, 'intel')
       uses: ./.github/actions/setup-intel
       with:
         os: ${{ matrix.os }}
-
+        version: ${{ matrix.intel_version }}
+        
     - name: (Ubuntu) Build and Install HDF5 from source
       if: contains(matrix.os, 'ubuntu') && contains(matrix.mpi, 'intel')
       # Needs checkout if source code isn't available, adjust if needed

--- a/src/metapackage/fpm_meta_mpi.f90
+++ b/src/metapackage/fpm_meta_mpi.f90
@@ -1112,7 +1112,9 @@ contains
                                               exitcode=stat,cmd_success=success,screen_output=screen)
                      endif
 
-                     if (stat/=0 .or. .not.success) then
+                     ! LLVM wrappers bug: non-zero exit code when checking for "-v" -> only check for 
+                     ! successful command: https://github.com/spack/spack/issues/47672
+                     if (success) then
                         call syntax_error(error, &
                             'cannot retrieve MPICH library version from <mpichversion, '//wrapper%s//', mpiexec>')
                         return
@@ -1120,7 +1122,7 @@ contains
 
                   case (MPI_TYPE_INTEL)
 
-                     ! --showme:command returns the build command of this wrapper
+                     ! -v returns the build command of this wrapper
                      call run_wrapper(wrapper,[string_t('-v')],verbose=verbose, &
                                           exitcode=stat,cmd_success=success,screen_output=screen)
 

--- a/src/metapackage/fpm_meta_mpi.f90
+++ b/src/metapackage/fpm_meta_mpi.f90
@@ -1112,9 +1112,7 @@ contains
                                               exitcode=stat,cmd_success=success,screen_output=screen)
                      endif
 
-                     ! LLVM wrappers bug: non-zero exit code when checking for "-v" -> only check for 
-                     ! successful command: https://github.com/spack/spack/issues/47672
-                     if (success) then
+                     if (stat/=0 .or. .not.success) then
                         call syntax_error(error, &
                             'cannot retrieve MPICH library version from <mpichversion, '//wrapper%s//', mpiexec>')
                         return
@@ -1126,7 +1124,9 @@ contains
                      call run_wrapper(wrapper,[string_t('-v')],verbose=verbose, &
                                           exitcode=stat,cmd_success=success,screen_output=screen)
 
-                     if (stat/=0 .or. .not.success) then
+                     ! LLVM wrappers bug: non-zero exit code when checking for "-v" -> only check for 
+                     ! successful command: https://github.com/spack/spack/issues/47672
+                     if (.not.success) then
                         call syntax_error(error,'local INTEL MPI library does not support -v')
                         return
                      else

--- a/src/metapackage/fpm_meta_mpi.f90
+++ b/src/metapackage/fpm_meta_mpi.f90
@@ -761,8 +761,8 @@ contains
                          string_t(get_env('MPIf77','mpif77'))]
 
         if (get_os_type()==OS_WINDOWS) then
-            c_wrappers = [c_wrappers,string_t('mpicc.bat')]
-            cpp_wrappers = [cpp_wrappers,string_t('mpicxx.bat')]
+            c_wrappers    = [c_wrappers,string_t('mpicc.bat')]
+            cpp_wrappers  = [cpp_wrappers,string_t('mpicxx.bat')]
             fort_wrappers = [fort_wrappers,string_t('mpifc.bat')]
         endif
 
@@ -775,10 +775,9 @@ contains
              fort_wrappers = [fort_wrappers,string_t('mpigfortran'),string_t('mpgfortran'),&
                               string_t('mpig77'),string_t('mpg77')]
 
-           case (id_intel_classic_windows,id_intel_llvm_windows, &
-                 id_intel_classic_nix,id_intel_classic_mac,id_intel_llvm_nix,id_intel_llvm_unknown)
-
-                c_wrappers = [string_t(get_env('I_MPI_CC','mpiicc'))]
+           case (id_intel_classic_windows,id_intel_classic_nix,id_intel_classic_mac)
+                 
+                c_wrappers = [string_t(get_env('I_MPI_CC' ,'mpiicc'))]
               cpp_wrappers = [string_t(get_env('I_MPI_CXX','mpiicpc'))]
              fort_wrappers = [string_t(get_env('I_MPI_F90','mpiifort'))]
 
@@ -797,6 +796,32 @@ contains
                  if (intel_wrap/="") c_wrappers = [c_wrappers,string_t(intel_wrap)]
 
                  intel_wrap = join_path(mpi_root,'mpiicpc')
+                 if (get_os_type()==OS_WINDOWS) intel_wrap = get_dos_path(intel_wrap,error)
+                 if (intel_wrap/="") cpp_wrappers = [cpp_wrappers,string_t(intel_wrap)]
+
+             end if
+
+           case (id_intel_llvm_windows,id_intel_llvm_nix,id_intel_llvm_unknown)
+                 
+                c_wrappers = [string_t(get_env('I_MPI_CC' ,'mpiicx'))]
+              cpp_wrappers = [string_t(get_env('I_MPI_CXX','mpiicpx'))]
+             fort_wrappers = [string_t(get_env('I_MPI_F90','mpiifx'))]
+
+             ! Also search MPI wrappers via the base MPI folder
+             mpi_root = get_env('I_MPI_ROOT')
+             if (mpi_root/="") then
+
+                 mpi_root = join_path(mpi_root,'bin')
+
+                 intel_wrap = join_path(mpi_root,'mpiifx')
+                 if (get_os_type()==OS_WINDOWS) intel_wrap = get_dos_path(intel_wrap,error)
+                 if (intel_wrap/="") fort_wrappers = [fort_wrappers,string_t(intel_wrap)]
+
+                 intel_wrap = join_path(mpi_root,'mpiicx')
+                 if (get_os_type()==OS_WINDOWS) intel_wrap = get_dos_path(intel_wrap,error)
+                 if (intel_wrap/="") c_wrappers = [c_wrappers,string_t(intel_wrap)]
+
+                 intel_wrap = join_path(mpi_root,'mpiicpx')
                  if (get_os_type()==OS_WINDOWS) intel_wrap = get_dos_path(intel_wrap,error)
                  if (intel_wrap/="") cpp_wrappers = [cpp_wrappers,string_t(intel_wrap)]
 


### PR DESCRIPTION
- close #1090 
- add `mpiifx`, `mpiicx`, `mpiicpx` wrappers
- do not stop on non-zero exit code with Intel-LLVM (wrapper bug cf. https://github.com/spack/spack/issues/47672)
- generalize Intel version in CI tests 
- test 2024.1.0 and 2025.0