### PR TITLE
[metapackage] MPI: add SLURM `srun` as tentative MPI runner

### DIFF
--- a/src/metapackage/fpm_meta_mpi.f90
+++ b/src/metapackage/fpm_meta_mpi.f90
@@ -450,7 +450,8 @@ contains
         logical, intent(in) :: verbose
         type(error_t), allocatable, intent(out) :: error
 
-        character(*), parameter :: try(*) = ['mpiexec    ','mpirun     ','mpiexec.exe','mpirun.exe ']
+        character(*), parameter :: try(*) = ['mpiexec    ','mpirun     ','mpiexec.exe','mpirun.exe ', &
+                                             'srun       ']
         character(:), allocatable :: bindir
         integer :: itri
         logical :: success

--- a/src/metapackage/fpm_meta_mpi.f90
+++ b/src/metapackage/fpm_meta_mpi.f90
@@ -450,8 +450,7 @@ contains
         logical, intent(in) :: verbose
         type(error_t), allocatable, intent(out) :: error
 
-        character(*), parameter :: try(*) = ['mpiexec    ','mpirun     ','mpiexec.exe','mpirun.exe ', &
-                                             'srun       ']
+        character(*), parameter :: try(*) = [character(11) :: 'mpiexec','mpirun','mpiexec.exe','mpirun.exe','srun']
         character(:), allocatable :: bindir
         integer :: itri
         logical :: success


### PR DESCRIPTION
Address #1140 

@rouson: as I have no way to test this addition: do you think it will be enough to just add `srun` to the list of tentative MPI runners? Maybe in the future we will be able to attempt to build and run a simple program on-the-fly and try to run it with introspection, but it's not currently possible right now.