### PR TITLE
[macOS] Standardize dynamic library paths using `@rpath`

### DIFF
--- a/src/fpm.f90
+++ b/src/fpm.f90
@@ -604,6 +604,12 @@ subroutine cmd_run(settings,test)
                 if (settings%runner/=' ')     run_cmd = settings%runner_command()//' '//run_cmd
                 if (allocated(settings%args)) run_cmd = run_cmd//" "//settings%args
                 
+                ! System Integrity Protection will not propagate the .dylib environment variables
+                ! to the child process: add paths manually
+                if (get_os_type()==OS_MACOS)  run_cmd = "env DYLD_LIBRARY_PATH=" // &
+                                                         get_env("DYLD_LIBRARY_PATH","") // &
+                                                         " " // run_cmd
+
                 call run(run_cmd,echo=settings%verbose,exitstat=stat(i))                
                 
             else

--- a/src/fpm_compiler.F90
+++ b/src/fpm_compiler.F90
@@ -107,6 +107,8 @@ contains
     procedure :: get_export_flags    
     !> Get library install name flags
     procedure :: get_install_name_flags
+    !> Generate header padding flags for macOS executables
+    procedure :: get_headerpad_flags
     !> Compile a Fortran object
     procedure :: compile_fortran
     !> Compile a C object
@@ -1143,6 +1145,23 @@ function get_install_name_flags(self, target_dir, target_name) result(flags)
     flags = " -Wl,-install_name,@rpath/" // library_file
 
 end function get_install_name_flags
+
+!>
+!> Generate header padding flags for install_name_tool compatibility on macOS
+!>
+function get_headerpad_flags(self) result(flags)
+    class(compiler_t), intent(in) :: self
+    character(len=:), allocatable :: flags
+
+    if (get_os_type() /= OS_MACOS) then
+        flags = ""
+        return
+    end if
+
+    ! Reserve enough space in the Mach-O header to safely add two install_name or rpath later
+    flags = " -Wl,-headerpad,0x200"
+
+end function get_headerpad_flags
 
 !> Create new compiler instance
 subroutine new_compiler(self, fc, cc, cxx, echo, verbose)

--- a/src/fpm_compiler.F90
+++ b/src/fpm_compiler.F90
@@ -105,6 +105,8 @@ contains
     procedure :: get_main_flags
     !> Get library export flags
     procedure :: get_export_flags    
+    !> Get library install name flags
+    procedure :: get_install_name_flags
     !> Compile a Fortran object
     procedure :: compile_fortran
     !> Compile a C object
@@ -1116,6 +1118,28 @@ function get_export_flags(self, target_dir, target_name) result(export_flags)
     end select
 
 end function get_export_flags
+
+!>
+!> Generate `install_name` flag for a shared library build on macOS
+!>
+function get_install_name_flags(self, target_dir, target_name) result(flags)
+    class(compiler_t), intent(in) :: self
+    character(len=*), intent(in) :: target_dir, target_name
+    character(len=:), allocatable :: flags
+
+    if (get_os_type() /= OS_MACOS) then
+        flags = ""
+        return
+    end if
+
+    ! Shared library basename (e.g., libfoo.dylib)
+    if (str_ends_with(target_name, ".dylib")) then
+        flags = " -Wl,-install_name,@rpath/" // target_name
+    else
+        flags = " -Wl,-install_name,@rpath/" // target_name // ".dylib"
+    end if
+
+end function get_install_name_flags
 
 !> Create new compiler instance
 subroutine new_compiler(self, fc, cc, cxx, echo, verbose)

--- a/src/fpm_compiler.F90
+++ b/src/fpm_compiler.F90
@@ -1126,6 +1126,7 @@ function get_install_name_flags(self, target_dir, target_name) result(flags)
     class(compiler_t), intent(in) :: self
     character(len=*), intent(in) :: target_dir, target_name
     character(len=:), allocatable :: flags
+    character(len=:), allocatable :: library_file
 
     if (get_os_type() /= OS_MACOS) then
         flags = ""
@@ -1134,10 +1135,12 @@ function get_install_name_flags(self, target_dir, target_name) result(flags)
 
     ! Shared library basename (e.g., libfoo.dylib)
     if (str_ends_with(target_name, ".dylib")) then
-        flags = " -Wl,-install_name,@rpath/" // target_name
+        library_file = target_name        
     else
-        flags = " -Wl,-install_name,@rpath/" // target_name // ".dylib"
+        library_file = library_filename(target_name,.true.,.false.,OS_MACOS)
     end if
+    
+    flags = " -Wl,-install_name,@rpath/" // library_file
 
 end function get_install_name_flags
 

--- a/src/fpm_targets.f90
+++ b/src/fpm_targets.f90
@@ -1142,8 +1142,13 @@ subroutine resolve_target_linking(targets, model, library, error)
                     target%link_flags = target%link_flags // " " // &
                                         model%compiler%get_export_flags(target%output_dir,target%package_name)
                     
+                    ! Add install_name flag (macOS only)
+                    target%link_flags = target%link_flags // " " // &
+                                        model%compiler%get_install_name_flags(target%output_dir, target%package_name)                    
+                    
                     ! Add global link flags (e.g., system-wide libraries)
-                    target%link_flags = target%link_flags // " " // global_link_flags                
+                    target%link_flags = target%link_flags // " " // global_link_flags     
+                            
 
                 case (FPM_TARGET_EXECUTABLE)
 

--- a/src/fpm_targets.f90
+++ b/src/fpm_targets.f90
@@ -1181,7 +1181,12 @@ subroutine resolve_target_linking(targets, model, library, error)
                         target%link_flags = model%get_package_libraries_link(target%package_name, &
                                                                             target%link_flags, &
                                                                             error=error, &
-                                                                            exclude_self=.not.has_self_lib)                                                
+                                                                            exclude_self=.not.has_self_lib)   
+                                                                            
+                        
+                        ! On macOS, add room for 2 install_name_tool paths
+                        target%link_flags = target%link_flags // model%compiler%get_headerpad_flags()
+                        
                     end if
 
                     if (allocated(target%link_libraries)) then


### PR DESCRIPTION
On macOS, use `@rpath` for shared libraries to support relocatable builds.

- Link shared libs with `@rpath/lib<name>.dylib`
- Patch installed executables with:
  - `@executable_path`
  - `@executable_path/../lib`
- Add `-headerpad` at link time to allow post-install rpath injection

Supports both flat and `bin/lib/include` install layouts. No effect on non-macOS platforms.

cc: @jacobwilliams 