### PR TITLE
[windows] gcc 15 hotfix: use non-default initializer for `compile_command_t`

### DIFF
--- a/src/fpm_compile_commands.F90
+++ b/src/fpm_compile_commands.F90
@@ -55,8 +55,34 @@ module fpm_compile_commands
         
     end type compile_command_table_t    
     
+    interface compile_command_t
+        module procedure cct_new
+    end interface compile_command_t
+    
     contains
     
+    !> Override default initializer (GCC 15 bug)
+    type(compile_command_t) function cct_new(directory,arguments,file) result(cct)
+        character(len=*), intent(in) :: directory,file
+        character(len=*), optional, intent(in) :: arguments(:)
+        
+        integer :: i,n
+        
+        cct%directory = string_t(trim(directory))
+        cct%file = string_t(trim(file))
+        
+        if (present(arguments)) then 
+           n = size(arguments)
+        else
+           n = 0
+        endif
+        allocate(cct%arguments(n))
+        do i=1,n
+            cct%arguments(i) = string_t(trim(arguments(i)))
+        end do
+        
+    end function cct_new  
+      
     !> Cleanup compile command
     elemental subroutine compile_command_destroy(self)
     
@@ -281,10 +307,9 @@ module fpm_compile_commands
         ! Fallback: use last argument if not found
         if (len_trim(source_file)==0) source_file = trim(args(n))
 
-        ! Fill in the compile_command_t
-        cmd = compile_command_t(directory = string_t(cwd), &
-                                arguments = [(string_t(trim(args(i))), i=1,n)], &
-                                file = string_t(source_file))
+        ! Fill in the compile_command_t. 
+        ! Use non-default initializer due to gcc 15 bug
+        cmd = compile_command_t(cwd, args, source_file)
         
         ! Add it to the structure
         !$omp critical (command_update)


### PR DESCRIPTION
Reported at https://fortran-lang.discourse.group/t/error-building-csv-fortran-with-fpm/9760/2

The MSYS build of `fpm` fails at generating a new `compile_command_t` with the default initializer. 
MSYS2 uses gcc15 already while we don't build fpm against it yet.

Fix: employ a user-defined initializer. 

cc: @zoziha @MehdiChinoune could you please confirm? 

@MehdiChinoune do you think it would be easier to release an `fpm 0.12.1` or to patch the fpm source in the MSYS2 recipe?  