### PR TITLE
gcc-15 fixes: segfault on fpm install (#1149) and metapackages

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -23,23 +23,19 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-13, windows-latest]
         toolchain:
+          - {compiler: gcc, version: 10}
           - {compiler: gcc, version: 11}
           - {compiler: gcc, version: 12}
           - {compiler: gcc, version: 13}
           - {compiler: gcc, version: 14}
-          - {compiler: gcc, version: 15}
           - {compiler: intel, version: 2025.1}
         exclude:
-          - os: ubuntu-latest  # gcc 15 not available on Ubuntu yet
-            toolchain: {compiler: gcc, version: 15}
           - os: macos-13  # No Intel on MacOS anymore since 2024
             toolchain: {compiler: intel, version: '2025.1'}
           - os: windows-latest  # Doesn't pass build and tests yet
             toolchain: {compiler: intel, version: '2025.1'}
           - os: windows-latest  # gcc 14 not available on Windows yet
             toolchain: {compiler: gcc, version: 14}
-          - os: windows-latest  # gcc 15 not available on Windows yet
-            toolchain: {compiler: gcc, version: 15}
         include:
           - os: ubuntu-latest
             os-arch: linux-x86_64

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -23,11 +23,11 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-13, windows-latest]
         toolchain:
-          - {compiler: gcc, version: 10}
           - {compiler: gcc, version: 11}
           - {compiler: gcc, version: 12}
           - {compiler: gcc, version: 13}
           - {compiler: gcc, version: 14}
+          - {compiler: gcc, version: 15}
           - {compiler: intel, version: 2025.1}
         exclude:
           - os: macos-13  # No Intel on MacOS anymore since 2024
@@ -36,6 +36,8 @@ jobs:
             toolchain: {compiler: intel, version: '2025.1'}
           - os: windows-latest  # gcc 14 not available on Windows yet
             toolchain: {compiler: gcc, version: 14}
+          - os: windows-latest  # gcc 15 not available on Windows yet
+            toolchain: {compiler: gcc, version: 15}
         include:
           - os: ubuntu-latest
             os-arch: linux-x86_64

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -30,6 +30,8 @@ jobs:
           - {compiler: gcc, version: 15}
           - {compiler: intel, version: 2025.1}
         exclude:
+          - os: ubuntu-latest  # gcc 15 not available on Ubuntu yet
+            toolchain: {compiler: gcc, version: 15}
           - os: macos-13  # No Intel on MacOS anymore since 2024
             toolchain: {compiler: intel, version: '2025.1'}
           - os: windows-latest  # Doesn't pass build and tests yet

--- a/.github/workflows/meta.yml
+++ b/.github/workflows/meta.yml
@@ -35,16 +35,16 @@ jobs:
         include:
           - os: ubuntu-latest
             mpi: openmpi
-            release-flags: ["--flag -Wno-external-argument-mismatch"]            
+            release-flags: --flag ' -Wno-external-argument-mismatch'
           - os: ubuntu-latest
             mpi: mpich
-            release-flags: ["--flag -Wno-external-argument-mismatch"]            
+            release-flags: --flag ' -Wno-external-argument-mismatch'
           - os: macos-13
             mpi: openmpi
-            release-flags: ["--flag -Wno-external-argument-mismatch"]            
+            release-flags: --flag ' -Wno-external-argument-mismatch'
           - os: macos-13
             mpi: mpich
-            release-flags: ["--flag -Wno-external-argument-mismatch"]            
+            release-flags: --flag ' -Wno-external-argument-mismatch'
           - os: ubuntu-latest
             mpi: intel
             intel_version: "2024.1.0"

--- a/.github/workflows/meta.yml
+++ b/.github/workflows/meta.yml
@@ -212,7 +212,7 @@ jobs:
     - name: (macOS) Install homebrew OpenMPI
       if: contains(matrix.mpi,'openmpi') && contains(matrix.os,'macos')
       run: |
-        brew install --cc=gcc-${{ env.GCC_V }} openmpi
+        brew install openmpi
 
     - name: (macOS) Install homebrew HDF5
       if: contains(matrix.os,'macos')
@@ -226,7 +226,7 @@ jobs:
         brew install netcdf-fortran
 
     - name: (macOS) Patch gfortran paths
-      if: contains(matrix.mpi,'openmpi') && contains(matrix.os,'macos')
+      if: contains(matrix.os,'macos')
       run: |        
         # Backport gfortran shared libraries to version 10 folder. This is necessary because all macOS releases of fpm
         # have these paths hardcoded in the executable (no PIC?). Current bootstrap version 0.8.0 has gcc-10

--- a/.github/workflows/meta.yml
+++ b/.github/workflows/meta.yml
@@ -31,17 +31,20 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
-      matrix:
-        release-flags: ["--flag -Wno-external-argument-mismatch"]            
+      matrix:        
         include:
           - os: ubuntu-latest
             mpi: openmpi
+            release-flags: ["--flag -Wno-external-argument-mismatch"]            
           - os: ubuntu-latest
             mpi: mpich
+            release-flags: ["--flag -Wno-external-argument-mismatch"]            
           - os: macos-13
             mpi: openmpi
+            release-flags: ["--flag -Wno-external-argument-mismatch"]            
           - os: macos-13
             mpi: mpich
+            release-flags: ["--flag -Wno-external-argument-mismatch"]            
           - os: ubuntu-latest
             mpi: intel
             intel_version: "2024.1.0"

--- a/.github/workflows/meta.yml
+++ b/.github/workflows/meta.yml
@@ -32,6 +32,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        release-flags: ["--flag -Wno-external-argument-mismatch"]            
         include:
           - os: ubuntu-latest
             mpi: openmpi
@@ -44,9 +45,11 @@ jobs:
           - os: ubuntu-latest
             mpi: intel
             intel_version: "2024.1.0"
+            release-flags: ""            # override: no GCC flags
           - os: ubuntu-latest
             mpi: intel
-            intel_version: "2025.0"        
+            intel_version: "2025.0" 
+            release-flags: ""            # override: no GCC flags       
 
     steps:
     - name: Checkout code
@@ -276,7 +279,7 @@ jobs:
       if: (!contains(matrix.mpi,'intel'))
       shell: bash
       run: |
-        ${{ env.BOOTSTRAP }} test
+        ${{ env.BOOTSTRAP }} test ${{ matrix.release-flags }}
 
     - name: Install Fortran fpm (bootstrap)
       shell: bash

--- a/.github/workflows/meta.yml
+++ b/.github/workflows/meta.yml
@@ -220,12 +220,6 @@ jobs:
         brew install netcdf
         brew install netcdf-fortran
 
-    # Phase 1: Bootstrap fpm with existing version
-    - name: Install fpm
-      uses: fortran-lang/setup-fpm@v7
-      with:
-        fpm-version: 'v0.8.0'
-
     - name: (macOS) Patch gfortran paths
       if: contains(matrix.mpi,'openmpi') && contains(matrix.os,'macos')
       run: |        
@@ -240,6 +234,12 @@ jobs:
         ln -fs /usr/local/opt/gcc@${{ env.GCC_V }}/lib/gcc/${{ env.GCC_V }}/libgfortran.5.dylib /usr/local/opt/gcc@10/lib/gcc/10/libgfortran.5.dylib
         # Newer gcc versions use libgcc_s.1.1.dylib
         ln -fs /usr/local/lib/gcc/${{ env.GCC_V }}/libgcc_s.1.dylib /usr/local/lib/gcc/10/libgcc_s.1.dylib || ln -fs /usr/local/lib/gcc/${{ env.GCC_V }}/libgcc_s.1.1.dylib /usr/local/lib/gcc/10/libgcc_s.1.dylib
+       
+    # Phase 1: Bootstrap fpm with existing version
+    - name: Install fpm
+      uses: fortran-lang/setup-fpm@v7
+      with:
+        fpm-version: 'v0.8.0'       
         
     - name: Remove fpm from path
       shell: bash

--- a/.github/workflows/meta.yml
+++ b/.github/workflows/meta.yml
@@ -52,11 +52,16 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v4
 
-    - name: (Ubuntu/macOS) setup gcc version
-      if: contains(matrix.os,'ubuntu') || contains(matrix.os,'macos')
+    - name: (Ubuntu) setup gcc version
+      if: contains(matrix.os,'ubuntu') 
       run: |
         echo "GCC_V=14" >> $GITHUB_ENV
 
+    - name: (macOS) setup gcc version
+      if: contains(matrix.os,'macos')
+      run: |
+        echo "GCC_V=15" >> $GITHUB_ENV        
+        
     - name: (Windows) Install MSYS2
       uses: msys2/setup-msys2@v2
       if: contains(matrix.os,'windows') && contains(matrix.mpi,'msmpi')
@@ -207,7 +212,7 @@ jobs:
     - name: (macOS) Install homebrew OpenMPI
       if: contains(matrix.mpi,'openmpi') && contains(matrix.os,'macos')
       run: |
-        brew install openmpi #--cc=gcc-${{ env.GCC_V }} openmpi
+        brew install --cc=gcc-${{ env.GCC_V }} openmpi
 
     - name: (macOS) Install homebrew HDF5
       if: contains(matrix.os,'macos')

--- a/.github/workflows/meta.yml
+++ b/.github/workflows/meta.yml
@@ -198,17 +198,6 @@ jobs:
         which gfortran-${{ env.GCC_V }} || brew install gcc@${{ env.GCC_V }}
         which gfortran-${{ env.GCC_V }}
         which gfortran || ln -s /usr/local/bin/gfortran-${{ env.GCC_V }} /usr/local/bin/gfortran
-        # Backport gfortran shared libraries to version 10 folder. This is necessary because all macOS releases of fpm
-        # have these paths hardcoded in the executable (no PIC?). Current bootstrap version 0.8.0 has gcc-10
-        mkdir /usr/local/opt/gcc@10
-        mkdir /usr/local/opt/gcc@10/lib
-        mkdir /usr/local/opt/gcc@10/lib/gcc
-        mkdir /usr/local/opt/gcc@10/lib/gcc/10
-        mkdir /usr/local/lib/gcc/10
-        ln -fs /usr/local/opt/gcc@${{ env.GCC_V }}/lib/gcc/${{ env.GCC_V }}/libquadmath.0.dylib /usr/local/opt/gcc@10/lib/gcc/10/libquadmath.0.dylib
-        ln -fs /usr/local/opt/gcc@${{ env.GCC_V }}/lib/gcc/${{ env.GCC_V }}/libgfortran.5.dylib /usr/local/opt/gcc@10/lib/gcc/10/libgfortran.5.dylib
-        # Newer gcc versions use libgcc_s.1.1.dylib
-        ln -fs /usr/local/lib/gcc/${{ env.GCC_V }}/libgcc_s.1.dylib /usr/local/lib/gcc/10/libgcc_s.1.dylib || ln -fs /usr/local/lib/gcc/${{ env.GCC_V }}/libgcc_s.1.1.dylib /usr/local/lib/gcc/10/libgcc_s.1.dylib
 
     - name: (macOS) Install homebrew MPICH
       if: contains(matrix.mpi,'mpich') && contains(matrix.os,'macos')
@@ -237,6 +226,21 @@ jobs:
       with:
         fpm-version: 'v0.8.0'
 
+    - name: (macOS) Patch gfortran paths
+      if: contains(matrix.mpi,'openmpi') && contains(matrix.os,'macos')
+      run: |        
+        # Backport gfortran shared libraries to version 10 folder. This is necessary because all macOS releases of fpm
+        # have these paths hardcoded in the executable (no PIC?). Current bootstrap version 0.8.0 has gcc-10
+        mkdir /usr/local/opt/gcc@10
+        mkdir /usr/local/opt/gcc@10/lib
+        mkdir /usr/local/opt/gcc@10/lib/gcc
+        mkdir /usr/local/opt/gcc@10/lib/gcc/10
+        mkdir /usr/local/lib/gcc/10
+        ln -fs /usr/local/opt/gcc@${{ env.GCC_V }}/lib/gcc/${{ env.GCC_V }}/libquadmath.0.dylib /usr/local/opt/gcc@10/lib/gcc/10/libquadmath.0.dylib
+        ln -fs /usr/local/opt/gcc@${{ env.GCC_V }}/lib/gcc/${{ env.GCC_V }}/libgfortran.5.dylib /usr/local/opt/gcc@10/lib/gcc/10/libgfortran.5.dylib
+        # Newer gcc versions use libgcc_s.1.1.dylib
+        ln -fs /usr/local/lib/gcc/${{ env.GCC_V }}/libgcc_s.1.dylib /usr/local/lib/gcc/10/libgcc_s.1.dylib || ln -fs /usr/local/lib/gcc/${{ env.GCC_V }}/libgcc_s.1.1.dylib /usr/local/lib/gcc/10/libgcc_s.1.dylib
+        
     - name: Remove fpm from path
       shell: bash
       run: |

--- a/fpm.toml
+++ b/fpm.toml
@@ -21,7 +21,7 @@ fortran-regex.tag  = "1.1.2"
 jonquil.git = "https://github.com/toml-f/jonquil"
 jonquil.rev = "4fbd4cf34d577c0fd25e32667ee9e41bf231ece8"
 fortran-shlex.git = "https://github.com/perazz/fortran-shlex"
-fortran-shlex.tag = "2.0.0"
+fortran-shlex.tag = "2.0.1"
 
 [[test]]
 name = "cli-test"

--- a/src/fpm/cmd/install.f90
+++ b/src/fpm/cmd/install.f90
@@ -101,30 +101,32 @@ contains
     integer, intent(out) :: ntargets
 
     integer :: ii
-    type(string_t), allocatable :: install_target(:), temp(:)
+    type(string_t), allocatable :: install_target(:), apps(:), tests(:)
     type(build_target_ptr), allocatable :: libs(:)
 
-    allocate(install_target(0))
-
     call filter_library_targets(targets, libs)
-    install_target = [install_target, (string_t(libs(ii)%ptr%output_file),ii=1,size(libs))]
+    call filter_executable_targets(targets, FPM_SCOPE_APP, apps)
+    call filter_executable_targets(targets, FPM_SCOPE_TEST, tests)
 
-    call filter_executable_targets(targets, FPM_SCOPE_APP, temp)
-    install_target = [install_target, temp]
-
-    call filter_executable_targets(targets, FPM_SCOPE_TEST, temp)
-    install_target = [install_target, temp]
-
-    ntargets = size(install_target)
+    ntargets = size(libs) + size(apps) + size(tests)
+    allocate(install_target(ntargets))
+    
+    do ii = 1, size(libs)
+        install_target(ii) = string_t(libs(ii)%ptr%output_file)
+    end do
+    do ii = 1, size(apps)
+        install_target(size(libs) + ii) = string_t(apps(ii)%s)
+    end do
+    do ii = 1, size(tests)
+        install_target(size(libs) + size(apps) + ii) = string_t(tests(ii)%s)
+    end do
     
     if (verbose) then 
-
         write(unit, '("#", *(1x, g0))') &
           "total number of installable targets:", ntargets
         do ii = 1, ntargets
           write(unit, '("-", *(1x, g0))') install_target(ii)%s
         end do
-    
     endif
 
   end subroutine install_info

--- a/src/fpm/manifest/profiles.f90
+++ b/src/fpm/manifest/profiles.f90
@@ -783,19 +783,22 @@ module fpm_manifest_profile
               & new_profile('debug', &
                 & 'caf', &
                 & OS_ALL, &
-                & flags = ' -Wall -Wextra -Wimplicit-interface -fPIC -fmax-errors=1 -g -fcheck=bounds&
+                & flags = ' -Wall -Wextra -Wimplicit-interface -Wno-external-argument-mismatch&
+                          & -fPIC -fmax-errors=1 -g -fcheck=bounds&
                           & -fcheck=array-temps -fbacktrace', &
                 & is_built_in=.true.), &
               & new_profile('debug', &
                 & 'gfortran', &
                 & OS_ALL, &
-                & flags = ' -Wall -Wextra -Wimplicit-interface -fPIC -fmax-errors=1 -g -fcheck=bounds&
+                & flags = ' -Wall -Wextra -Wimplicit-interface -Wno-external-argument-mismatch&
+                          & -fPIC -fmax-errors=1 -g -fcheck=bounds&
                           & -fcheck=array-temps -fbacktrace -fcoarray=single', &
                 & is_built_in=.true.), &
               & new_profile('debug', &
                 & 'f95', &
                 & OS_ALL, &
-                & flags = ' -Wall -Wextra -Wimplicit-interface -fPIC -fmax-errors=1 -g -fcheck=bounds&
+                & flags = ' -Wall -Wextra -Wimplicit-interface -Wno-external-argument-mismatch&
+                          & -fPIC -fmax-errors=1 -g -fcheck=bounds&
                           & -fcheck=array-temps -Wno-maybe-uninitialized -Wno-uninitialized -fbacktrace', &
                 & is_built_in=.true.), &
               & new_profile('debug', &

--- a/src/fpm_compiler.F90
+++ b/src/fpm_compiler.F90
@@ -178,7 +178,7 @@ character(*), parameter :: &
     flag_gnu_opt = " -O3 -funroll-loops", &
     flag_gnu_debug = " -g", &
     flag_gnu_pic = " -fPIC", &
-    flag_gnu_warn = " -Wall -Wextra", &
+    flag_gnu_warn = " -Wall -Wextra -Wno-external-argument-mismatch", &
     flag_gnu_check = " -fcheck=bounds -fcheck=array-temps", &
     flag_gnu_limit = " -fmax-errors=1", &
     flag_gnu_external = " -Wimplicit-interface", &

--- a/src/fpm_compiler.F90
+++ b/src/fpm_compiler.F90
@@ -178,7 +178,7 @@ character(*), parameter :: &
     flag_gnu_opt = " -O3 -funroll-loops", &
     flag_gnu_debug = " -g", &
     flag_gnu_pic = " -fPIC", &
-    flag_gnu_warn = " -Wall -Wextra -Wno-external-argument-mismatch", &
+    flag_gnu_warn = " -Wall -Wextra -Wno-external-argument-mismatch", & ! do not check interfaces due to gcc 15.0-15.1 bug
     flag_gnu_check = " -fcheck=bounds -fcheck=array-temps", &
     flag_gnu_limit = " -fmax-errors=1", &
     flag_gnu_external = " -Wimplicit-interface", &

--- a/src/fpm_pkg_config.f90
+++ b/src/fpm_pkg_config.f90
@@ -338,7 +338,7 @@ subroutine run_wrapper(wrapper,args,verbose,exitcode,cmd_success,screen_output)
            close(iunit,status='delete')
 
         else
-           call fpm_stop(1,'cannot read temporary file from successful MPI wrapper')
+           call fpm_stop(1,'cannot read temporary file from successful command: '//command)
         endif
 
     end if

--- a/src/metapackage/fpm_meta_hdf5.f90
+++ b/src/metapackage/fpm_meta_hdf5.f90
@@ -4,7 +4,7 @@ module fpm_meta_hdf5
     use fpm_filesystem, only: join_path
     use fpm_pkg_config, only: assert_pkg_config, pkgcfg_has_package, pkgcfg_list_all
     use fpm_meta_base, only: metapackage_t, destroy
-    use fpm_meta_util, only: add_pkg_config_compile_options, lib_get_trailing
+    use fpm_meta_util, only: add_pkg_config_compile_options, lib_get_trailing, add_strings
     use fpm_manifest_metapackages, only: metapackage_request_t
     use fpm_error, only: error_t, fatal_error
 
@@ -112,8 +112,8 @@ module fpm_meta_hdf5
                       inquire(file=this_lib%s,exist=found)
 
                       ! File exists, but it is not linked against
-                      if (found) this%link_libs = [this%link_libs, &
-                                                   string_t(this%link_libs(i)%s//trim(find_hl(k)))]
+                      if (found) call add_strings(this%link_libs, &
+                                                   string_t(this%link_libs(i)%s//trim(find_hl(k))))
 
                    end do add_missing
 

--- a/test/fpm_test/test_toml.f90
+++ b/test/fpm_test/test_toml.f90
@@ -873,7 +873,7 @@ contains
 
         allocate(character(len=0) :: fpm)
         fpm = fpm//NL//'package-name = "fpm"'
-        fpm = fpm//NL//'fortran-flags = " -Wall -Wextra -fPIC -fmax-errors=1 -g "'
+        fpm = fpm//NL//'fortran-flags = " -Wall -Wextra -Wno-external-argument-mismatch -fPIC -fmax-errors=1 -g "'
         fpm = fpm//NL//'c-flags = ""'
         fpm = fpm//NL//'cxx-flags = ""'
         fpm = fpm//NL//'link-flags = ""'
@@ -1144,7 +1144,7 @@ contains
 
         allocate(character(len=0) :: fpm)
         fpm = fpm//NL//'package-name = "fpm"'
-        fpm = fpm//NL//'fortran-flags = " -Wall -Wextra -fPIC -fmax-errors=1 -g "'
+        fpm = fpm//NL//'fortran-flags = " -Wall -Wextra -Wno-external-argument-mismatch -fPIC -fmax-errors=1 -g "'
         fpm = fpm//NL//'c-flags = ""'
         fpm = fpm//NL//'cxx-flags = ""'
         fpm = fpm//NL//'link-flags = ""'


### PR DESCRIPTION
This is a small fix for `fpm install` segfaulting when compiled with GFortran 15.1.1 on Archlinux. It also adds a workaround for failing compilation on `-Wall` due to upstream GCC bugs https://gcc.gnu.org/bugzilla/show_bug.cgi?id=120470 / https://gcc.gnu.org/bugzilla/show_bug.cgi?id=119928 that have been fixed in git but exists up to including 15.1 .