### PR TITLE
CI for GCC 15, drop GCC 10

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -23,23 +23,19 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-13, windows-latest]
         toolchain:
+          - {compiler: gcc, version: 10}
           - {compiler: gcc, version: 11}
           - {compiler: gcc, version: 12}
           - {compiler: gcc, version: 13}
           - {compiler: gcc, version: 14}
-          - {compiler: gcc, version: 15}
           - {compiler: intel, version: 2025.1}
         exclude:
-          - os: ubuntu-latest  # gcc 15 not available on Ubuntu yet
-            toolchain: {compiler: gcc, version: 15}
           - os: macos-13  # No Intel on MacOS anymore since 2024
             toolchain: {compiler: intel, version: '2025.1'}
           - os: windows-latest  # Doesn't pass build and tests yet
             toolchain: {compiler: intel, version: '2025.1'}
           - os: windows-latest  # gcc 14 not available on Windows yet
             toolchain: {compiler: gcc, version: 14}
-          - os: windows-latest  # gcc 15 not available on Windows yet
-            toolchain: {compiler: gcc, version: 15}
         include:
           - os: ubuntu-latest
             os-arch: linux-x86_64

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -23,11 +23,11 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-13, windows-latest]
         toolchain:
-          - {compiler: gcc, version: 10}
           - {compiler: gcc, version: 11}
           - {compiler: gcc, version: 12}
           - {compiler: gcc, version: 13}
           - {compiler: gcc, version: 14}
+          - {compiler: gcc, version: 15}
           - {compiler: intel, version: 2025.1}
         exclude:
           - os: macos-13  # No Intel on MacOS anymore since 2024
@@ -36,6 +36,8 @@ jobs:
             toolchain: {compiler: intel, version: '2025.1'}
           - os: windows-latest  # gcc 14 not available on Windows yet
             toolchain: {compiler: gcc, version: 14}
+          - os: windows-latest  # gcc 15 not available on Windows yet
+            toolchain: {compiler: gcc, version: 15}
         include:
           - os: ubuntu-latest
             os-arch: linux-x86_64

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -30,6 +30,8 @@ jobs:
           - {compiler: gcc, version: 15}
           - {compiler: intel, version: 2025.1}
         exclude:
+          - os: ubuntu-latest  # gcc 15 not available on Ubuntu yet
+            toolchain: {compiler: gcc, version: 15}
           - os: macos-13  # No Intel on MacOS anymore since 2024
             toolchain: {compiler: intel, version: '2025.1'}
           - os: windows-latest  # Doesn't pass build and tests yet

--- a/src/fpm/cmd/install.f90
+++ b/src/fpm/cmd/install.f90
@@ -101,30 +101,32 @@ contains
     integer, intent(out) :: ntargets
 
     integer :: ii
-    type(string_t), allocatable :: install_target(:), temp(:)
+    type(string_t), allocatable :: install_target(:), apps(:), tests(:)
     type(build_target_ptr), allocatable :: libs(:)
 
-    allocate(install_target(0))
-
     call filter_library_targets(targets, libs)
-    install_target = [install_target, (string_t(libs(ii)%ptr%output_file),ii=1,size(libs))]
+    call filter_executable_targets(targets, FPM_SCOPE_APP, apps)
+    call filter_executable_targets(targets, FPM_SCOPE_TEST, tests)
 
-    call filter_executable_targets(targets, FPM_SCOPE_APP, temp)
-    install_target = [install_target, temp]
-
-    call filter_executable_targets(targets, FPM_SCOPE_TEST, temp)
-    install_target = [install_target, temp]
-
-    ntargets = size(install_target)
+    ntargets = size(libs) + size(apps) + size(tests)
+    allocate(install_target(ntargets))
+    
+    do ii = 1, size(libs)
+        install_target(ii) = string_t(libs(ii)%ptr%output_file)
+    end do
+    do ii = 1, size(apps)
+        install_target(size(libs) + ii) = string_t(apps(ii)%s)
+    end do
+    do ii = 1, size(tests)
+        install_target(size(libs) + size(apps) + ii) = string_t(tests(ii)%s)
+    end do
     
     if (verbose) then 
-
         write(unit, '("#", *(1x, g0))') &
           "total number of installable targets:", ntargets
         do ii = 1, ntargets
           write(unit, '("-", *(1x, g0))') install_target(ii)%s
         end do
-    
     endif
 
   end subroutine install_info

--- a/src/fpm_compiler.F90
+++ b/src/fpm_compiler.F90
@@ -178,7 +178,7 @@ character(*), parameter :: &
     flag_gnu_opt = " -O3 -funroll-loops", &
     flag_gnu_debug = " -g", &
     flag_gnu_pic = " -fPIC", &
-    flag_gnu_warn = " -Wall -Wextra", &
+    flag_gnu_warn = " -Wall -Wextra -Wno-external-argument-mismatch", &
     flag_gnu_check = " -fcheck=bounds -fcheck=array-temps", &
     flag_gnu_limit = " -fmax-errors=1", &
     flag_gnu_external = " -Wimplicit-interface", &


### PR DESCRIPTION
This adds CI for GCC 15, which is only available on macos-13 straightforwardly now. Support for GCC 10 is dropped due to end of life. The boostrap tests are skipped until the upstream.