### PR TITLE
fix: package versions

### DIFF
--- a/src/fpm.f90
+++ b/src/fpm.f90
@@ -96,8 +96,8 @@ subroutine build_model(model, settings, package, error)
     end if
 
     allocate(model%packages(model%deps%ndep))
-
     has_cpp = .false.
+
     do i = 1, model%deps%ndep
         associate(dep => model%deps%dep(i))
             file_name = join_path(dep%proj_dir, "fpm.toml")
@@ -116,9 +116,9 @@ subroutine build_model(model, settings, package, error)
             
             model%packages(i)%name = manifest%name
             associate(features => model%packages(i)%features)
-                features%implicit_typing = manifest%fortran%implicit_typing
+                features%implicit_typing   = manifest%fortran%implicit_typing
                 features%implicit_external = manifest%fortran%implicit_external
-                features%source_form = manifest%fortran%source_form
+                features%source_form       = manifest%fortran%source_form
             end associate
             model%packages(i)%version = manifest%version
 

--- a/src/fpm.f90
+++ b/src/fpm.f90
@@ -120,7 +120,7 @@ subroutine build_model(model, settings, package, error)
                 features%implicit_external = manifest%fortran%implicit_external
                 features%source_form = manifest%fortran%source_form
             end associate
-            model%packages(i)%version = package%version%s()
+            model%packages(i)%version = manifest%version
 
             !> Add this dependency's manifest macros
             if (allocated(manifest%preprocess)) then

--- a/src/fpm_compiler.F90
+++ b/src/fpm_compiler.F90
@@ -43,10 +43,11 @@ use fpm_filesystem, only: join_path, basename, get_temp_filename, delete_file, u
 use fpm_strings, only: split, string_cat, string_t, str_ends_with, str_begins_with_str, &
     & string_array_contains
 use fpm_manifest, only : package_config_t
-use fpm_error, only: error_t, fatal_error
+use fpm_error, only: error_t, fatal_error, fpm_stop
 use tomlf, only: toml_table
 use fpm_toml, only: serializable_t, set_string, set_value, toml_stat, get_value
 use fpm_compile_commands, only: compile_command_t, compile_command_table_t
+use fpm_versioning, only: version_t
 use shlex_module, only: sh_split => split, ms_split, quote => ms_quote
 implicit none
 public :: compiler_t, new_compiler, archiver_t, new_archiver, get_macros
@@ -523,7 +524,7 @@ end subroutine set_cpp_preprocessor_flags
 !> return them as defined flags.
 function get_macros(id, macros_list, version) result(macros)
     integer(compiler_enum), intent(in) :: id
-    character(len=:), allocatable, intent(in) :: version
+    type(version_t), optional, intent(in) :: version
     type(string_t), allocatable, intent(in) :: macros_list(:)
 
     character(len=:), allocatable :: macros
@@ -556,6 +557,7 @@ function get_macros(id, macros_list, version) result(macros)
         !> Split the macro name and value.
         call split(macros_list(i)%s, valued_macros, delimiters="=")
 
+        !> Replace {version} placeholder with the actual version string
         if (size(valued_macros) > 1) then
             !> Check if the value of macro starts with '{' character.
             if (str_begins_with_str(trim(valued_macros(size(valued_macros))), "{")) then
@@ -567,8 +569,17 @@ function get_macros(id, macros_list, version) result(macros)
                     if (index(valued_macros(size(valued_macros)), "version") /= 0) then
 
                         !> These conditions are placed in order to ensure proper spacing between the macros.
-                        macros = macros//macro_definition_symbol//trim(valued_macros(1))//'='//version
-                        cycle
+                        if (present(version)) then 
+                           
+                           macros = macros//macro_definition_symbol//trim(valued_macros(1))//'='//version%s()
+                           cycle
+                        
+                        else
+                            
+                           call fpm_stop(1,'Internal error: cannot expand {version} macro')
+                        
+                        endif
+                        
                     end if
                 end if
             end if

--- a/src/fpm_compiler.F90
+++ b/src/fpm_compiler.F90
@@ -576,7 +576,7 @@ function get_macros(id, macros_list, version) result(macros)
                         
                         else
                             
-                           call fpm_stop(1,'Internal error: cannot expand {version} macro')
+                           call fpm_stop(1,'Internal error: cannot expand {version} macro in '//macros)
                         
                         endif
                         

--- a/src/fpm_compiler.F90
+++ b/src/fpm_compiler.F90
@@ -576,7 +576,7 @@ function get_macros(id, macros_list, version) result(macros)
                         
                         else
                             
-                           call fpm_stop(1,'Internal error: cannot expand {version} macro in '//macros)
+                           call fpm_stop(1,'Internal error: cannot expand {version} macro in '//macros_list(i)%s)
                         
                         endif
                         

--- a/src/fpm_model.f90
+++ b/src/fpm_model.f90
@@ -751,7 +751,7 @@ subroutine package_dump_to_toml(self, table, error)
     if (allocated(error)) return
 
     if (allocated(self%version)) then
-       call set_value(ptr, "version", self%version%s())
+       call set_value(table, "version", self%version%s())
     end if    
     if (allocated(error)) return
 
@@ -816,7 +816,7 @@ subroutine package_load_from_toml(self, table, error)
     call get_value(table, "name", self%name)
     call get_value(table, "version", version)
     if (allocated(version)) then
-        allocate(self%version)
+        if (.not.allocated(self%version)) allocate(self%version)
         call new_version(self%version, version, error)
         if (allocated(error)) then
             error%message = 'package_t: version error from TOML table - '//error%message

--- a/src/fpm_targets.f90
+++ b/src/fpm_targets.f90
@@ -1072,6 +1072,7 @@ subroutine resolve_target_linking(targets, model, library, error)
             end select
 
             !> Get macros as flags.
+            call target%info(6)
             target%compile_flags = target%compile_flags // get_macros(model%compiler%id, &
                                                             target%macros, &
                                                             target%version)

--- a/src/fpm_targets.f90
+++ b/src/fpm_targets.f90
@@ -428,10 +428,10 @@ subroutine build_target_list(targets,model,library)
 
                     call add_target(targets,package=model%packages(j)%name,type = exe_type,&
                                 output_name = get_object_name(sources(i)), &
-                                source = sources(i), &
-                                features = model%packages(j)%features, &
-                                preprocess = model%packages(j)%preprocess &
-                                )
+                                source      = sources(i), &
+                                features    = model%packages(j)%features, &
+                                preprocess  = model%packages(j)%preprocess, &
+                                version     = model%packages(j)%version)
 
                     if (sources(i)%unit_scope == FPM_SCOPE_APP) then
 
@@ -1072,7 +1072,6 @@ subroutine resolve_target_linking(targets, model, library, error)
             end select
 
             !> Get macros as flags.
-            call target%info(6)
             target%compile_flags = target%compile_flags // get_macros(model%compiler%id, &
                                                             target%macros, &
                                                             target%version)

--- a/test/fpm_test/test_manifest.f90
+++ b/test/fpm_test/test_manifest.f90
@@ -1420,7 +1420,7 @@ contains
         type(error_t), allocatable, intent(out) :: error
 
         type(package_config_t) :: package
-        character(:), allocatable :: temp_file,pkg_ver
+        character(:), allocatable :: temp_file
         integer :: unit
         integer(compiler_enum)  :: id
 
@@ -1439,9 +1439,7 @@ contains
 
         if (allocated(error)) return
 
-        pkg_ver = package%version%s()
-
-        if (get_macros(id, package%preprocess(1)%macros, pkg_ver) /= " -DFOO -DBAR=2 -DVERSION=0.1.0") then
+        if (get_macros(id, package%preprocess(1)%macros, package%version) /= " -DFOO -DBAR=2 -DVERSION=0.1.0") then
             call test_failed(error, "Macros were not parsed correctly")
         end if
 
@@ -1460,7 +1458,6 @@ contains
 
         character(:), allocatable :: toml_file_package
         character(:), allocatable :: toml_file_dependency
-        character(:), allocatable :: pkg_ver,dep_ver
 
         integer :: unit
         integer(compiler_enum)  :: id
@@ -1497,11 +1494,8 @@ contains
 
         if (allocated(error)) return
 
-        pkg_ver = package%version%s()
-        dep_ver = dependency%version%s()
-
-        macros_package = get_macros(id, package%preprocess(1)%macros, pkg_ver)
-        macros_dependency = get_macros(id, dependency%preprocess(1)%macros, dep_ver)
+        macros_package = get_macros(id, package%preprocess(1)%macros, package%version)
+        macros_dependency = get_macros(id, dependency%preprocess(1)%macros, dependency%version)
         if (macros_package == macros_dependency) then
             call test_failed(error, "Macros of package and dependency should not be equal")
         end if

--- a/test/fpm_test/test_toml.f90
+++ b/test/fpm_test/test_toml.f90
@@ -653,6 +653,7 @@ contains
 
         !> Create a dummy package
         pkg%name = "orderpack"
+        if (.not.allocated(pkg%version)) allocate(pkg%version)
         call new_version(pkg%version, "0.1.0", error)
         if (allocated(error)) return
         pkg%enforce_module_names = .false.

--- a/test/fpm_test/test_toml.f90
+++ b/test/fpm_test/test_toml.f90
@@ -653,7 +653,8 @@ contains
 
         !> Create a dummy package
         pkg%name = "orderpack"
-        pkg%version = "0.1.0"
+        call new_version(pkg%version, "0.1.0", error)
+        if (allocated(error)) return
         pkg%enforce_module_names = .false.
         pkg%module_prefix = string_t("")
         pkg%features%source_form = "free"


### PR DESCRIPTION
- Fix package versions as reported in https://fortran-lang.discourse.group/t/visualizing-fortran-projects-with-fpm-create-stunning-module-dependency-charts/9838/11
- Improve internal representation of `package_t` and `build_target_t`: use `type(version_t)` rather than simple strings