### PR TITLE
fix: OpenMP flags incorrectly applied to C/C++ compilers that don't s…

### DIFF
--- a/src/fpm_compiler.F90
+++ b/src/fpm_compiler.F90
@@ -1859,8 +1859,9 @@ logical function check_c_source_runs(self, input, compile_flags, link_flags) res
     call self%compile_c(source,object,flags,logf,stat,dry_run=.false.)
     if (stat/=0) return
     
-    !> Link  
-    call self%link(exe,ldflags//" "//object,logf,stat)
+    !> Link using C compiler for pure C programs
+    call run(self%cc//" "//ldflags//" "//object//" -o "//exe, &
+              echo=self%echo, verbose=self%verbose, redirect=logf, exitstat=stat)
     if (stat/=0) return
     
     !> Run
@@ -1915,8 +1916,9 @@ logical function check_cxx_source_runs(self, input, compile_flags, link_flags) r
     call self%compile_cpp(source,object,flags,logf,stat,dry_run=.false.)
     if (stat/=0) return
     
-    !> Link  
-    call self%link(exe,ldflags//" "//object,logf,stat)
+    !> Link using C++ compiler for pure C++ programs
+    call run(self%cxx//" "//ldflags//" "//object//" -o "//exe, &
+              echo=self%echo, verbose=self%verbose, redirect=logf, exitstat=stat)
     if (stat/=0) return
     
     !> Run

--- a/src/fpm_targets.f90
+++ b/src/fpm_targets.f90
@@ -1113,6 +1113,11 @@ subroutine resolve_target_linking(targets, model, library, error)
                     ! Build link flags
                     target%link_flags = string_cat(target%link_objects, " ")
                     
+                    ! Add global link flags (including metapackage flags like OpenMP)
+                    if (allocated(model%link_flags)) then
+                        target%link_flags = model%link_flags//" "//target%link_flags
+                    endif
+                    
                     target%link_flags = target%link_flags // shared_lib_paths
 
                     ! Add dependencies' shared libraries (excluding self)

--- a/src/metapackage/fpm_meta_openmp.f90
+++ b/src/metapackage/fpm_meta_openmp.f90
@@ -101,11 +101,10 @@ module fpm_meta_openmp
             this%cxxflags = string_t(openmp_flag)
         endif
 
-        !> Set link flags if any language supports OpenMP
-        if (this%has_fortran_flags .or. this%has_c_flags .or. this%has_cxx_flags) then
-            this%has_link_flags = .true.
-            this%link_flags = string_t(link_flag)
-        endif
+        !> Always set link flags when OpenMP is requested
+        !> The linker needs OpenMP flags regardless of individual compiler support
+        this%has_link_flags = .true.
+        this%link_flags = string_t(link_flag)
 
     end subroutine init_openmp
 end module fpm_meta_openmp

--- a/src/metapackage/fpm_meta_openmp.f90
+++ b/src/metapackage/fpm_meta_openmp.f90
@@ -25,57 +25,87 @@ module fpm_meta_openmp
         type(metapackage_request_t), intent(in) :: all_meta(:)
         type(error_t), allocatable, intent(out) :: error
 
+        !> Local variables for OpenMP testing
+        character(:), allocatable :: openmp_flag, link_flag
+        character(len=*), parameter :: openmp_test_fortran = &
+            "use omp_lib; if (omp_get_max_threads() <= 0) stop 1; end"
+        character(len=*), parameter :: openmp_test_c = &
+            "#include <omp.h>" // new_line('a') // &
+            "int main() { return omp_get_max_threads() > 0 ? 0 : 1; }"
+        character(len=*), parameter :: openmp_test_cxx = &
+            "#include <omp.h>" // new_line('a') // &
+            "int main() { return omp_get_max_threads() > 0 ? 0 : 1; }"
+
         !> Cleanup
         call destroy(this)
         
         !> Set name
         this%name = "openmp"
 
-        !> OpenMP has compiler flags
-        this%has_build_flags = .true.
-        this%has_link_flags  = .true.
-
-        !> OpenMP flags should be added to
+        !> Get OpenMP flags based on compiler
         which_compiler: select case (compiler%id)
            case (id_gcc,id_f95)
-                this%flags      = string_t(flag_gnu_openmp)
-                this%link_flags = string_t(flag_gnu_openmp)
+                openmp_flag = flag_gnu_openmp
+                link_flag = flag_gnu_openmp
 
            case (id_intel_classic_windows,id_intel_llvm_windows)
-                this%flags      = string_t(flag_intel_openmp_win)
-                this%link_flags = string_t(flag_intel_openmp_win)
+                openmp_flag = flag_intel_openmp_win
+                link_flag = flag_intel_openmp_win
 
            case (id_intel_classic_nix,id_intel_classic_mac,&
                  id_intel_llvm_nix)
-                this%flags      = string_t(flag_intel_openmp)
-                this%link_flags = string_t(flag_intel_openmp)
+                openmp_flag = flag_intel_openmp
+                link_flag = flag_intel_openmp
 
            case (id_pgi,id_nvhpc)
-                this%flags      = string_t(flag_pgi_openmp)
-                this%link_flags = string_t(flag_pgi_openmp)
+                openmp_flag = flag_pgi_openmp
+                link_flag = flag_pgi_openmp
 
            case (id_ibmxl)
-                this%flags      = string_t(" -qsmp=omp")
-                this%link_flags = string_t(" -qsmp=omp")
+                openmp_flag = " -qsmp=omp"
+                link_flag = " -qsmp=omp"
 
            case (id_nag)
-                this%flags      = string_t(flag_nag_openmp)
-                this%link_flags = string_t(flag_nag_openmp)
+                openmp_flag = flag_nag_openmp
+                link_flag = flag_nag_openmp
 
            case (id_lfortran)
-                this%flags      = string_t(flag_lfortran_openmp)
-                this%link_flags = string_t(flag_lfortran_openmp)
+                openmp_flag = flag_lfortran_openmp
+                link_flag = flag_lfortran_openmp
 
            case (id_flang, id_flang_new)
-                this%flags      = string_t(flag_flang_new_openmp)
-                this%link_flags = string_t(flag_flang_new_openmp)
+                openmp_flag = flag_flang_new_openmp
+                link_flag = flag_flang_new_openmp
 
            case default
-
               call fatal_error(error,'openmp not supported on compiler '//compiler%name()//' yet')
+              return
 
         end select which_compiler
 
+        !> Test Fortran OpenMP support
+        if (compiler%check_fortran_source_runs(openmp_test_fortran, openmp_flag, link_flag)) then
+            this%has_fortran_flags = .true.
+            this%fflags = string_t(openmp_flag)
+        endif
+
+        !> Test C OpenMP support
+        if (compiler%check_c_source_runs(openmp_test_c, openmp_flag, link_flag)) then
+            this%has_c_flags = .true.
+            this%cflags = string_t(openmp_flag)
+        endif
+
+        !> Test C++ OpenMP support  
+        if (compiler%check_cxx_source_runs(openmp_test_cxx, openmp_flag, link_flag)) then
+            this%has_cxx_flags = .true.
+            this%cxxflags = string_t(openmp_flag)
+        endif
+
+        !> Set link flags if any language supports OpenMP
+        if (this%has_fortran_flags .or. this%has_c_flags .or. this%has_cxx_flags) then
+            this%has_link_flags = .true.
+            this%link_flags = string_t(link_flag)
+        endif
 
     end subroutine init_openmp
 end module fpm_meta_openmp


### PR DESCRIPTION
…… (#2)

* fix: OpenMP flags incorrectly applied to C/C++ compilers that don't support them

- Add C and C++ compiler capability testing functions to fpm_compiler.F90
- Modify OpenMP metapackage to test OpenMP support per language individually
- Only apply OpenMP flags to languages where the compiler actually supports them
- Fixes issue where clang C compiler fails with unsupported -fopenmp flag

Resolves #1159

🤖 Generated with [Claude Code](https://claude.ai/code)



* fix: Add missing temporary file cleanup in C/C++ compiler testing functions

- Add cleanup code to check_c_source_runs() and check_cxx_source_runs()
- Matches the cleanup pattern used in check_fortran_source_runs()
- Prevents accumulation of temporary files during OpenMP capability testing

Addresses review feedback from qodo-merge-pro

🤖 Generated with [Claude Code](https://claude.ai/code)



* test: Add comprehensive test coverage for C/C++ compiler capability functions

- Add test_check_c_source_runs() with tests for:
  - Valid C hello world program
  - Program that returns error code 1
  - Invalid compile flags
  - check_c_flags_supported() wrapper

- Add test_check_cxx_source_runs() with tests for:
  - Valid C++ hello world program
  - Program that returns error code 1
  - Invalid compile flags
  - check_cxx_flags_supported() wrapper

- Both test suites mirror the existing Fortran tests structure
- Tests verify error detection and temporary file cleanup

🤖 Generated with [Claude Code](https://claude.ai/code)



* test: Improve C/C++ test robustness and fix potential escaping issues

- Skip C/C++ tests if compiler is not available
- Use simpler test programs to avoid iostream complexities
- Use cstdio instead of iostream for better compatibility
- Gracefully handle missing or misconfigured C++ compilers

These changes make the tests more robust across different environments where C/C++ compilers may not be properly configured.

🤖 Generated with [Claude Code](https://claude.ai/code)



---------