### PR TITLE
fix: Skip -fPIC flag for flang-new on Windows MSVC targets

### DIFF
--- a/src/fpm_compiler.F90
+++ b/src/fpm_compiler.F90
@@ -288,10 +288,17 @@ function get_default_flags(self, release) result(flags)
     ! Append position-independent code (PIC) flag, that is necessary 
     ! building shared libraries
     select case (self%id)
-    case (id_gcc, id_f95, id_caf, id_flang, id_flang_new, id_f18, id_lfortran, &
+    case (id_gcc, id_f95, id_caf, id_flang, id_f18, id_lfortran, &
           id_intel_classic_nix, id_intel_classic_mac, id_intel_llvm_nix, &
           id_pgi, id_nvhpc, id_nag, id_cray, id_ibmxl)
         pic_flag = " -fPIC"
+    case (id_flang_new)
+        ! flang-new doesn't support -fPIC on Windows MSVC target
+        if (get_os_type() == OS_WINDOWS) then
+            pic_flag = ""
+        else
+            pic_flag = " -fPIC"
+        end if
     case (id_intel_classic_windows, id_intel_llvm_windows)
         pic_flag = ""  ! Windows does not use -fPIC
     case default


### PR DESCRIPTION
flang-new compiler doesn't support -fPIC flag when targeting Windows MSVC (x86_64-pc-windows-msvc), causing compilation failures. This change conditionally adds `-fPIC` only on Unix/Linux platforms for flang-new.

Fixes #1156.

cc: @gha3mi