### PR TITLE
feat: multiple simultaneous library targets

### DIFF
--- a/ci/run_tests.sh
+++ b/ci/run_tests.sh
@@ -344,5 +344,13 @@ pushd static_app_only
 test $EXIT_CODE -eq 0
 popd
 
+# Test both shared and static library types
+pushd both_lib_types
+"$fpm" build
+"$fpm" install --prefix=.
+# Check that exactly 2 libboth_lib_types library files were installed
+test $(ls lib/libboth_lib_types* | wc -l) -eq 2
+popd
+
 # Cleanup
 rm -rf ./*/build

--- a/example_packages/both_lib_types/fpm.toml
+++ b/example_packages/both_lib_types/fpm.toml
@@ -1,0 +1,3 @@
+name = "both_lib_types"
+library.type=["shared", "static"]
+install.library=true

--- a/example_packages/both_lib_types/src/both_lib_types.f90
+++ b/example_packages/both_lib_types/src/both_lib_types.f90
@@ -1,0 +1,15 @@
+module both_lib_types
+  implicit none
+  private
+
+  public :: say_hello
+  public :: get_number
+contains
+  subroutine say_hello
+    print *, "Hello from both_lib_types!"
+  end subroutine say_hello
+  
+  integer function get_number()
+     get_number = 42
+  end function get_number
+end module both_lib_types

--- a/src/fpm/manifest.f90
+++ b/src/fpm/manifest.f90
@@ -40,6 +40,7 @@ contains
 
         self%source_dir = "src"
         self%include_dir = [string_t("include")]
+        self%lib_type = [string_t("monolithic")]
 
     end subroutine default_library
 

--- a/src/fpm/manifest/library.f90
+++ b/src/fpm/manifest/library.f90
@@ -32,8 +32,8 @@ module fpm_manifest_library
         !> Alternative build script to be invoked
         character(len=:), allocatable :: build_script
         
-        !> Shared / Static / Monolithic library 
-        character(:), allocatable :: lib_type
+        !> Shared / Static / Monolithic library types (can be multiple)
+        type(string_t), allocatable :: lib_type(:)
 
     contains
 
@@ -63,10 +63,16 @@ contains
         !> Instance of the library configuration
         class(library_config_t), intent(in) :: self
         
+        integer :: i
+        
+        shared = .false.
         if (allocated(self%lib_type)) then 
-           shared = self%lib_type == "shared"
-        else
-           shared = .false.
+           do i = 1, size(self%lib_type)
+               if (self%lib_type(i)%s == "shared") then
+                   shared = .true.
+                   return
+               end if
+           end do
         endif
         
     end function shared
@@ -78,10 +84,16 @@ contains
         !> Instance of the library configuration
         class(library_config_t), intent(in) :: self
         
+        integer :: i
+        
+        static = .false.
         if (allocated(self%lib_type)) then 
-           static = self%lib_type == "static"
-        else
-           static = .false.
+           do i = 1, size(self%lib_type)
+               if (self%lib_type(i)%s == "static") then
+                   static = .true.
+                   return
+               end if
+           end do
         endif
     end function static
 
@@ -108,7 +120,8 @@ contains
         !> Error handling
         type(error_t), allocatable, intent(out) :: error
         
-        integer :: stat
+        integer :: stat, i
+        character(len=:), allocatable :: single_type
 
         call check(table, error)
         if (allocated(error)) return
@@ -118,10 +131,7 @@ contains
             return
         end if
 
-        if (has_list(table, "type")) then
-            call syntax_error(error, "Manifest key [library.type] does not allow list input")
-            return
-        end if
+        ! library.type can now be either a single value or a list
 
         call get_value(table, "source-dir", self%source_dir, "src")
         call get_value(table, "build-script", self%build_script)
@@ -129,16 +139,28 @@ contains
         call get_list(table, "include-dir", self%include_dir, error)
         if (allocated(error)) return
         
-        call get_value(table, "type", self%lib_type, "monolithic")
+        ! Parse library type - can be single value or array
+        if (has_list(table, "type")) then
+            ! Array of types
+            call get_list(table, "type", self%lib_type, error)
+            if (allocated(error)) return
+        else
+            ! Single type - convert to array for consistency
+            call get_value(table, "type", single_type, "monolithic")
+            self%lib_type = [string_t(single_type)]
+        end if
         
-        select case(self%lib_type)
-        case("shared","static","monolithic")
-            ! OK
-        case default
-            call fatal_error(error,"Value of library.type cannot be '"//self%lib_type &
-                                 //"', choose shared/static/monolithic (default)")
-            return
-        end select        
+        ! Validate all types in the array
+        do i = 1, size(self%lib_type)
+            select case(self%lib_type(i)%s)
+            case("shared","static","monolithic")
+                ! OK
+            case default
+                call fatal_error(error,"Value of library.type cannot be '"//self%lib_type(i)%s &
+                                     //"', choose shared/static/monolithic (default)")
+                return
+            end select
+        end do
         
         ! Set default value of include-dir if not found in manifest
         if (.not.allocated(self%include_dir)) then
@@ -146,7 +168,7 @@ contains
         end if
         
         if (.not.allocated(self%lib_type)) then 
-            self%lib_type = "monolithic"
+            self%lib_type = [string_t("monolithic")]
         end if
 
     end subroutine new_library
@@ -215,7 +237,7 @@ contains
             write(unit, fmt) "- include directory", string_cat(self%include_dir,",")
         end if
         
-        write(unit, fmt) "- library type", self%lib_type
+        write(unit, fmt) "- library type", string_cat(self%lib_type,",")
         
         if (allocated(self%build_script)) then
             write(unit, fmt) "- custom build", self%build_script
@@ -272,7 +294,7 @@ contains
         if (allocated(error)) return
         call set_list(table, "include-dir", self%include_dir, error)
         if (allocated(error)) return
-        call set_string(table, "type", self%lib_type, error, class_name)
+        call set_list(table, "type", self%lib_type, error)
         if (allocated(error)) return
 
     end subroutine dump_to_toml
@@ -295,7 +317,7 @@ contains
         if (allocated(error)) return
         call get_list(table, "include-dir", self%include_dir, error)
         if (allocated(error)) return
-        call get_value(table, "type", self%lib_type)
+        call get_list(table, "type", self%lib_type, error)
         if (allocated(error)) return
 
     end subroutine load_from_toml

--- a/src/fpm_model.f90
+++ b/src/fpm_model.f90
@@ -1208,7 +1208,10 @@ function get_package_libraries_link(model, package_name, prefix, exclude_self, d
         ndep = size(sorted_package_IDs)
     end if
     
-    package_deps = [(string_t(model%deps%dep(sorted_package_IDs(i))%name),i=1,ndep)]
+    allocate(package_deps(ndep))
+    do i=1,ndep
+        package_deps(i) = string_t(model%deps%dep(sorted_package_IDs(i))%name)
+    end do
     
     r = model%compiler%enumerate_libraries(prefix, package_deps)
     

--- a/src/fpm_targets.f90
+++ b/src/fpm_targets.f90
@@ -673,7 +673,7 @@ subroutine add_old_targets(targets, add_targets)
     ! Check for duplicate outputs
     do j=1,size(add_targets)
         associate(added=>add_targets(j)%ptr)
-
+            
         do i=1,size(targets)
 
             if (targets(i)%ptr%output_name == added%output_name) then
@@ -704,9 +704,17 @@ end subroutine add_old_target
 subroutine add_dependency(target, dependency)
     type(build_target_t), intent(inout) :: target
     type(build_target_t) , intent(in), target :: dependency
+    
+    integer :: i
+    
+    ! Ensure no duplicate dependencies: it may happen if we loop two library targets that 
+    ! contain the same objects
+    do i=1,size(target%dependencies)
+        if (target%dependencies(i)%ptr%output_name == dependency%output_name) return
+    end do
 
     target%dependencies = [target%dependencies, build_target_ptr(dependency)]
-
+    
 end subroutine add_dependency
 
 

--- a/src/fpm_targets.f90
+++ b/src/fpm_targets.f90
@@ -355,12 +355,22 @@ subroutine build_target_list(targets,model,library)
         ! Individual package libraries are built. 
         ! Create as many targets as the packages in the dependency tree
         do j=1,size(model%packages)
-                        
-            lib_name = library_filename(model%packages(j)%name,shared_lib,.false.,get_os_type())
             
-            call add_target(targets,package=model%packages(j)%name, &
-                            type=merge(FPM_TARGET_SHARED,FPM_TARGET_ARCHIVE,shared_lib), &
-                            output_name=lib_name)
+            ! Create static library target if requested
+            if (static_lib) then
+                lib_name = library_filename(model%packages(j)%name,.false.,.false.,get_os_type())
+                call add_target(targets,package=model%packages(j)%name, &
+                                type=FPM_TARGET_ARCHIVE, &
+                                output_name=lib_name)
+            end if
+            
+            ! Create shared library target if requested  
+            if (shared_lib) then
+                lib_name = library_filename(model%packages(j)%name,.true.,.false.,get_os_type())
+                call add_target(targets,package=model%packages(j)%name, &
+                                type=FPM_TARGET_SHARED, &
+                                output_name=lib_name)
+            end if
         end do
         
     endif
@@ -388,8 +398,17 @@ subroutine build_target_list(targets,model,library)
 
 
                     if (with_lib .and. sources(i)%unit_scope == FPM_SCOPE_LIB) then
-                        ! Archive depends on object
-                        call add_dependency(targets(merge(1,j,monolithic))%ptr, targets(size(targets))%ptr)
+                        ! Library targets depend on object
+                        if (monolithic) then
+                            call add_dependency(targets(1)%ptr, targets(size(targets))%ptr)
+                        elseif (static_lib .and. shared_lib) then
+                            ! Both types: static at (2*j-1), shared at (2*j)
+                            call add_dependency(targets(2*j-1)%ptr, targets(size(targets))%ptr)
+                            call add_dependency(targets(2*j)%ptr, targets(size(targets))%ptr)
+                        else
+                            ! Single type: package j at index j
+                            call add_dependency(targets(j)%ptr, targets(size(targets))%ptr)
+                        end if
                     end if
 
                 case (FPM_UNIT_CPPSOURCE)
@@ -401,8 +420,17 @@ subroutine build_target_list(targets,model,library)
                                 version = model%packages(j)%version)
 
                     if (with_lib .and. sources(i)%unit_scope == FPM_SCOPE_LIB) then
-                        ! Archive depends on object
-                        call add_dependency(targets(merge(1,j,monolithic))%ptr, targets(size(targets))%ptr)
+                        ! Library targets depend on object
+                        if (monolithic) then
+                            call add_dependency(targets(1)%ptr, targets(size(targets))%ptr)
+                        elseif (static_lib .and. shared_lib) then
+                            ! Both types: static at (2*j-1), shared at (2*j)
+                            call add_dependency(targets(2*j-1)%ptr, targets(size(targets))%ptr)
+                            call add_dependency(targets(2*j)%ptr, targets(size(targets))%ptr)
+                        else
+                            ! Single type: package j at index j
+                            call add_dependency(targets(j)%ptr, targets(size(targets))%ptr)
+                        end if
                     end if
 
                     !> Add stdc++ as a linker flag. If not already there.
@@ -469,9 +497,19 @@ subroutine build_target_list(targets,model,library)
 
                     if (with_lib) then
                         ! Executable depends on library file(s)
-                        do k=1,merge(1,size(model%packages),monolithic)
-                           call add_dependency(target, targets(k)%ptr)
-                        end do
+                        if (monolithic) then
+                            call add_dependency(target, targets(1)%ptr)
+                        elseif (static_lib .and. shared_lib) then
+                            ! Both types: depend on static libraries (2*k-1) for all packages
+                            do k=1,size(model%packages)
+                               call add_dependency(target, targets(2*k-1)%ptr)
+                            end do
+                        else
+                            ! Single type: depend on library for each package
+                            do k=1,size(model%packages)
+                               call add_dependency(target, targets(k)%ptr)
+                            end do
+                        end if
                     end if
 
                     endassociate

--- a/src/fpm_targets.f90
+++ b/src/fpm_targets.f90
@@ -712,7 +712,8 @@ subroutine add_dependency(target, dependency)
     do i=1,size(target%dependencies)
         if (target%dependencies(i)%ptr%output_name == dependency%output_name) return
     end do
-
+    if (dependency%output_name==target%output_name) return
+    
     target%dependencies = [target%dependencies, build_target_ptr(dependency)]
     
 end subroutine add_dependency

--- a/src/fpm_targets.f90
+++ b/src/fpm_targets.f90
@@ -1218,7 +1218,8 @@ subroutine resolve_target_linking(targets, model, library, error)
                         has_self_lib = .false.
                         find_self: do j=1,size(targets)
                             associate(target_loop=>targets(j)%ptr)
-                                if (any(target_loop%target_type==[FPM_TARGET_SHARED,FPM_TARGET_ARCHIVE]) &
+                                if ((target_loop%target_type==FPM_TARGET_ARCHIVE .or. &
+                                    (target_loop%target_type==FPM_TARGET_SHARED .and. .not.static)) &
                                     .and. target_loop%package_name==target%package_name) then 
                                     has_self_lib = .true.
                                     exit find_self


### PR DESCRIPTION
Add support for building multiple library target types (shared, static) simultaneously from a single package.

Usage Examples

  Single library type (backward compatible):

```toml
  [library]
  type = "shared"
```
  Multiple library types:
```toml
  [library]
  type = ["shared", "static"]
```
  Default behavior (monolithic):
```
  [library]
  # No type specified - defaults to monolithic
```

Rules

  - monolithic cannot be combined with shared or static
  - Only valid types are: "shared", "static", "monolithic"
  - Default type when unspecified is "monolithic"
  - Complete backward compatibility
