### PR TITLE
Fix: Add -cpp flag support for `flang-new` compiler

### DIFF
--- a/src/fpm_compiler.F90
+++ b/src/fpm_compiler.F90
@@ -506,7 +506,7 @@ pure subroutine set_cpp_preprocessor_flags(id, flags)
     select case(id)
     case default
         flag_cpp_preprocessor = ""
-    case(id_caf, id_gcc, id_f95, id_nvhpc)
+    case(id_caf, id_gcc, id_f95, id_nvhpc, id_flang_new)
         flag_cpp_preprocessor = "-cpp"
     case(id_intel_classic_windows, id_intel_llvm_windows)
         flag_cpp_preprocessor = "/fpp"


### PR DESCRIPTION
Fixes #1155.

 Add support for `flang-new` to the case that uses the -cpp preprocessor flag in set_cpp_preprocessor_flags(). 
 The flang-new compiler requires the -cpp flag for preprocessing to work, but it wasn't included in the existing configuration.