### PR TITLE
feat: custom module install directory

### DIFF
--- a/ci/run_tests.sh
+++ b/ci/run_tests.sh
@@ -344,5 +344,19 @@ pushd static_app_only
 test $EXIT_CODE -eq 0
 popd
 
+# Test custom module directory
+pushd custom_module_dir
+"$fpm" build
+rm -rf ./test_custom_install
+"$fpm" install --prefix ./test_custom_install
+# Verify modules are installed in custom directory
+test -f ./test_custom_install/custom/modules/greeting.mod
+test -f ./test_custom_install/custom/modules/math_utils.mod
+# Verify library is still installed normally
+test -f ./test_custom_install/lib/libcustom-module-dir.a
+# Clean up
+rm -rf ./test_custom_install
+popd
+
 # Cleanup
 rm -rf ./*/build

--- a/example_packages/custom_module_dir/README.md
+++ b/example_packages/custom_module_dir/README.md
@@ -1,0 +1,32 @@
+# Custom Module Directory Example
+
+This example demonstrates the use of a custom module directory in the `[install]` section of `fpm.toml`.
+
+## Features
+
+- Two simple Fortran modules: `greeting` and `math_utils`
+- Custom module installation directory specified as `custom/modules`
+- Shows how modules can be installed to a different location than headers
+
+## Configuration
+
+In `fpm.toml`:
+
+```toml
+[install]
+library = true
+module-dir = "custom/modules"
+```
+
+This configuration will install compiled `.mod` files to the `custom/modules` directory instead of the default `include` directory.
+
+## Testing
+
+To test this example:
+
+```bash
+cd example_packages/custom_module_dir
+fpm build
+fpm install --prefix /tmp/test_install
+# Check that .mod files are in /tmp/test_install/custom/modules/
+```

--- a/example_packages/custom_module_dir/fpm.toml
+++ b/example_packages/custom_module_dir/fpm.toml
@@ -1,0 +1,3 @@
+name = "custom-module-dir"
+install.library = true
+install.module-dir = "custom/modules"

--- a/example_packages/custom_module_dir/src/greeting.f90
+++ b/example_packages/custom_module_dir/src/greeting.f90
@@ -1,0 +1,13 @@
+module greeting
+    implicit none
+    private
+    public :: say_hello
+
+contains
+
+    subroutine say_hello(name)
+        character(len=*), intent(in) :: name
+        print *, 'Hello, ' // name // '!'
+    end subroutine say_hello
+
+end module greeting

--- a/example_packages/custom_module_dir/src/math_utils.f90
+++ b/example_packages/custom_module_dir/src/math_utils.f90
@@ -1,0 +1,20 @@
+module math_utils
+    implicit none
+    private
+    public :: add_numbers, multiply_numbers
+
+contains
+
+    function add_numbers(a, b) result(sum)
+        integer, intent(in) :: a, b
+        integer :: sum
+        sum = a + b
+    end function add_numbers
+
+    function multiply_numbers(a, b) result(product)
+        integer, intent(in) :: a, b
+        integer :: product
+        product = a * b
+    end function multiply_numbers
+
+end module math_utils

--- a/src/fpm/cmd/install.f90
+++ b/src/fpm/cmd/install.f90
@@ -63,7 +63,7 @@ contains
 
     call new_installer(installer, prefix=settings%prefix, &
       bindir=settings%bindir, libdir=settings%libdir, testdir=settings%testdir, &
-      includedir=settings%includedir, &
+      includedir=settings%includedir, moduledir=package%install%module_dir, &
       verbosity=merge(2, 1, settings%verbose))
 
     if (allocated(package%library) .and. package%install%library) then
@@ -141,7 +141,7 @@ contains
     call filter_modules(targets, modules)
 
     do ii = 1, size(modules)
-      call installer%install_header(modules(ii)%s//".mod", error)
+      call installer%install_module(modules(ii)%s//".mod", error)
       if (allocated(error)) exit
     end do
     if (allocated(error)) return

--- a/src/fpm/installer.f90
+++ b/src/fpm/installer.f90
@@ -27,6 +27,8 @@ module fpm_installer
     character(len=:), allocatable :: testdir
     !> Include directory relative to the installation prefix
     character(len=:), allocatable :: includedir
+    !> Module directory relative to the installation prefix
+    character(len=:), allocatable :: moduledir
     !> Output unit for informative printout
     integer :: unit = output_unit
     !> Verbosity of the installer
@@ -46,6 +48,8 @@ module fpm_installer
     procedure :: install_library
     !> Install a header/module in its correct subdirectory
     procedure :: install_header
+    !> Install a module in its correct subdirectory
+    procedure :: install_module
     !> Install a test program in its correct subdirectory
     procedure :: install_test
     !> Install a generic file into a subdirectory in the installation prefix
@@ -69,6 +73,9 @@ module fpm_installer
   !> Default name of the include subdirectory
   character(len=*), parameter :: default_includedir = "include"
 
+  !> Default name of the module subdirectory
+  character(len=*), parameter :: default_moduledir = "include"
+
   !> Copy command on Unix platforms
   character(len=*), parameter :: default_copy_unix = "cp"
 
@@ -90,7 +97,7 @@ module fpm_installer
 contains
 
   !> Create a new instance of an installer
-  subroutine new_installer(self, prefix, bindir, libdir, includedir, testdir, verbosity, &
+  subroutine new_installer(self, prefix, bindir, libdir, includedir, moduledir, testdir, verbosity, &
           copy, move)
     !> Instance of the installer
     type(installer_t), intent(out) :: self
@@ -102,6 +109,8 @@ contains
     character(len=*), intent(in), optional :: libdir
     !> Include directory relative to the installation prefix
     character(len=*), intent(in), optional :: includedir
+    !> Module directory relative to the installation prefix
+    character(len=*), intent(in), optional :: moduledir
     !> Test directory relative to the installation prefix
     character(len=*), intent(in), optional :: testdir    
     !> Verbosity of the installer
@@ -138,6 +147,12 @@ contains
       self%includedir = includedir
     else
       self%includedir = default_includedir
+    end if
+
+    if (present(moduledir)) then
+      self%moduledir = moduledir
+    else
+      self%moduledir = default_moduledir
     end if
     
     if (present(testdir)) then 
@@ -287,6 +302,18 @@ contains
 
     call self%install(header, self%includedir, error)
   end subroutine install_header
+
+  !> Install a module in its correct subdirectory
+  subroutine install_module(self, module, error)
+    !> Instance of the installer
+    class(installer_t), intent(inout) :: self
+    !> Path to the module
+    character(len=*), intent(in) :: module
+    !> Error handling
+    type(error_t), allocatable, intent(out) :: error
+
+    call self%install(module, self%moduledir, error)
+  end subroutine install_module
 
   !> Install a generic file into a subdirectory in the installation prefix
   subroutine install(self, source, destination, error)

--- a/test/fpm_test/test_installer.f90
+++ b/test/fpm_test/test_installer.f90
@@ -36,6 +36,7 @@ contains
             & new_unittest("install-pkgconfig", test_install_pkgconfig), &
             & new_unittest("install-sitepackages", test_install_sitepackages), &
             & new_unittest("install-mod", test_install_mod), &
+            & new_unittest("install-module-custom", test_install_module_custom), &
             & new_unittest("install-exe-unix", test_install_exe_unix), &
             & new_unittest("install-exe-win", test_install_exe_win), &
             & new_unittest("install-test-unix", test_install_tests_unix), &
@@ -183,6 +184,22 @@ contains
         call mock%install_header("name", error)
 
     end subroutine test_install_mod
+
+    subroutine test_install_module_custom(error)
+        !> Error handling
+        type(error_t), allocatable, intent(out) :: error
+
+        type(mock_installer_t) :: mock
+        type(installer_t) :: installer
+
+        call new_installer(installer, prefix="PREFIX", moduledir="custom/modules", verbosity=0, copy="mock")
+        mock%installer_t = installer
+        mock%expected_dir = join_path("PREFIX", "custom/modules")
+        mock%expected_run = 'mock "test_module.mod" "'//join_path("PREFIX", "custom/modules")//'"'
+
+        call mock%install_module("test_module.mod", error)
+
+    end subroutine test_install_module_custom
 
     subroutine test_install_shared_library_unix(error)
         !> Error handling

--- a/test/fpm_test/test_manifest.f90
+++ b/test/fpm_test/test_manifest.f90
@@ -68,6 +68,7 @@ contains
             & new_unittest("example-empty", test_example_empty, should_fail=.true.), &
             & new_unittest("install-library", test_install_library), &
             & new_unittest("install-empty", test_install_empty), &
+            & new_unittest("install-module-dir", test_install_module_dir), &
             & new_unittest("install-wrongkey", test_install_wrongkey, should_fail=.true.), &
             & new_unittest("preprocess-empty", test_preprocess_empty), &
             & new_unittest("preprocess-wrongkey", test_preprocess_wrongkey, should_fail=.true.), &
@@ -1358,6 +1359,34 @@ contains
         call new_install_config(install, table, error)
 
     end subroutine test_install_wrongkey
+
+
+    subroutine test_install_module_dir(error)
+        use fpm_manifest_install
+
+        !> Error handling
+        type(error_t), allocatable, intent(out) :: error
+
+        type(toml_table) :: table
+        type(install_config_t) :: install
+
+        table = toml_table()
+        call set_value(table, "module-dir", "custom_modules")
+
+        call new_install_config(install, table, error)
+        if (allocated(error)) return
+
+        if (.not.allocated(install%module_dir)) then
+            call test_failed(error, "Module directory should be allocated")
+            return
+        end if
+
+        if (install%module_dir /= "custom_modules") then
+            call test_failed(error, "Module directory should match input")
+            return
+        end if
+
+    end subroutine test_install_module_dir
 
     subroutine test_preprocess_empty(error)
         use fpm_manifest_preprocess


### PR DESCRIPTION
  ### Summary

 This PR extends `fpm` to support installing compiled module files (`.mod`) to a custom directory separate from headers, providing better organization.

  ### Changes

  **Manifest**
  - New optional `module-dir` field to `[install]` section
  - Default: fallback to `"include"` directory (backward compatible)

  **Installer**
  - Extended `installer_t` with `moduledir` field and `install_module()` method (now separate from `header`s)

  **Example & Testing:**
  - Added `example_packages/custom_module_dir/` demonstrating the feature
  - Integrated internal and CI tests

  ### Usage Example

  ```toml
  [install]
  library = true
  module-dir = "custom/modules"  # Optional: defaults to "include"
```
