### PR TITLE
feat: selective `clean` functionality

### DIFF
--- a/src/fpm.f90
+++ b/src/fpm.f90
@@ -728,9 +728,6 @@ subroutine delete_targets(settings, error)
     call get_package_data(package, "fpm.toml", error, apply_defaults=.true.)
     if (allocated(error)) return
     
-    ! Ensure tests will be modeled
-    if (settings%clean_test) settings%build_tests = .true.  
-
     ! Build the model to understand targets
     call build_model(model, settings, package, error)
     if (allocated(error)) return

--- a/src/fpm.f90
+++ b/src/fpm.f90
@@ -17,7 +17,7 @@ use fpm_compiler, only: new_compiler, new_archiver, set_cpp_preprocessor_flags
 
 use fpm_sources, only: add_executable_sources, add_sources_from_dir
 use fpm_targets, only: targets_from_sources, build_target_t, build_target_ptr, &
-                        FPM_TARGET_EXECUTABLE, get_library_dirs
+                        FPM_TARGET_EXECUTABLE, get_library_dirs, filter_executable_targets
 use fpm_manifest, only : get_package_data, package_config_t
 use fpm_meta, only : resolve_metapackages
 use fpm_error, only : error_t, fatal_error, fpm_stop
@@ -692,6 +692,81 @@ subroutine delete_skip(is_unix)
     end do
 end subroutine delete_skip
 
+!> Delete targets of a specific scope with given description
+subroutine delete_targets_by_scope(targets, scope, scope_name, deleted_any)
+    type(build_target_ptr), intent(in) :: targets(:)
+    integer, intent(in) :: scope
+    character(len=*), intent(in) :: scope_name
+    logical, intent(inout) :: deleted_any
+
+    type(string_t), allocatable :: scope_targets(:)
+    integer :: i
+
+    call filter_executable_targets(targets, scope, scope_targets)
+    if (size(scope_targets) > 0) then
+        write(stdout, '(A,I0,A,A,A)') "Deleting ", size(scope_targets), " ", scope_name, " targets"
+        do i = 1, size(scope_targets)
+            if (exists(scope_targets(i)%s)) then
+                call run('rm -f "'//scope_targets(i)%s//'"')
+                deleted_any = .true.
+            end if
+        end do
+    end if
+end subroutine delete_targets_by_scope
+
+!> Delete build artifacts for specific target types (test, apps, examples)
+subroutine delete_targets(settings, error)
+    class(fpm_clean_settings), intent(in) :: settings
+    type(error_t), allocatable, intent(out) :: error
+
+    type(package_config_t) :: package
+    type(fpm_model_t) :: model
+    type(build_target_ptr), allocatable :: targets(:)
+    type(fpm_build_settings) :: build_settings
+    logical :: deleted_any
+
+    ! Get package configuration
+    call get_package_data(package, settings%working_dir, error)
+    if (allocated(error)) return
+
+    ! Create minimal build settings to build the model
+    build_settings%working_dir = settings%working_dir
+    build_settings%path_to_config = settings%path_to_config
+    build_settings%build_tests = .true.
+    build_settings%prune = .true.
+    if (allocated(build_settings%profile)) deallocate(build_settings%profile)
+    allocate(character(len=5) :: build_settings%profile)
+    build_settings%profile = "debug"
+
+    ! Build the model to understand targets
+    call build_model(model, build_settings, package, error)
+    if (allocated(error)) return
+
+    ! Get build targets
+    call targets_from_sources(targets, model, build_settings%prune, error=error)
+    if (allocated(error)) return
+
+    deleted_any = .false.
+
+    ! Delete targets by scope
+    if (settings%clean_test) then
+        call delete_targets_by_scope(targets, FPM_SCOPE_TEST, "test", deleted_any)
+    end if
+
+    if (settings%clean_apps) then
+        call delete_targets_by_scope(targets, FPM_SCOPE_APP, "app", deleted_any)
+    end if
+
+    if (settings%clean_examples) then
+        call delete_targets_by_scope(targets, FPM_SCOPE_EXAMPLE, "example", deleted_any)
+    end if
+
+    if (.not. deleted_any) then
+        write(stdout, '(A)') "No matching build targets found to delete."
+    end if
+
+end subroutine delete_targets
+
 !> Delete the build directory including or excluding dependencies. Can be used
 !> to clear the registry cache.
 subroutine cmd_clean(settings)
@@ -708,6 +783,20 @@ subroutine cmd_clean(settings)
         if (allocated(error)) return
 
         call os_delete_dir(os_is_unix(), global_settings%registry_settings%cache_path)
+    end if
+
+    ! Handle target-specific cleaning
+    if (any([settings%clean_test, settings%clean_apps, settings%clean_examples])) then
+        if (.not. is_dir('build')) then
+            write (stdout, '(A)') "fpm: No build directory found."
+            return
+        end if
+        call delete_targets(settings, error)
+        if (allocated(error)) then
+            write(stderr, '(A)') 'Error: ' // error%message
+            return
+        end if
+        return
     end if
 
     if (is_dir('build')) then

--- a/src/fpm_command_line.f90
+++ b/src/fpm_command_line.f90
@@ -682,6 +682,9 @@ contains
                     cln%clean_apps     = clean_apps
                     cln%clean_examples = clean_examples
 
+                    ! Ensure tests will be modeled if they have to be cleaned
+                    if (clean_test) cln%build_tests = .true.  
+                    
                 end select
             end block
 

--- a/src/fpm_command_line.f90
+++ b/src/fpm_command_line.f90
@@ -279,7 +279,7 @@ contains
         ! not starting with dash
         CLI_RESPONSE_FILE=.true.
         cmdarg = get_subcommand()
-
+        
         common_args = &
           ' --directory:C " "' // &
           ' --verbose F'
@@ -579,10 +579,10 @@ contains
             allocate(fpm_test_settings :: cmd_settings)
             val_runner=sget('runner')
             if(specified('runner') .and. val_runner=='')val_runner='echo'
-
+            
             select type (cmd => cmd_settings)
             type is (fpm_test_settings)
-
+                
                 call build_settings(cmd, list=lget('list'), build_tests=.true., &
                                     config_file=sget('config-file'))
 
@@ -591,9 +591,9 @@ contains
                 cmd%name        = names
                 cmd%runner      = val_runner
                 cmd%runner_args = val_runner_args
-
+                
             end select
-
+            
         case('update')
             call set_args(common_args // '&
             & --fetch-only F &
@@ -1576,8 +1576,12 @@ contains
         arch     = sget('archiver')
 
         ! Handle --dump default (empty value means use 'fpm_model.toml')
-        dump     = sget('dump')
-        if (specified('dump') .and. dump=='') dump = 'fpm_model.toml'
+        if (specified('dump')) then 
+           dump = sget('dump')
+           if (dump=='') dump='fpm_model.toml'
+        else
+           dump = ''
+        endif
 
         if (present(config_file)) then
             if (len_trim(config_file) > 0) then
@@ -1588,7 +1592,7 @@ contains
         else
             cfg = sget('config-file')
         end if
-
+        
         ! Assign into this (polymorphic) object; allocatable chars auto-allocate
         self%profile       = prof
         self%prune         = .not. lget('no-prune')

--- a/src/fpm_command_line.f90
+++ b/src/fpm_command_line.f90
@@ -802,7 +802,8 @@ contains
    '      [--list] [--compiler COMPILER_NAME] [--config-file PATH] [-- ARGS]        ', &
    ' install [--profile PROF] [--flag FFLAGS] [--no-rebuild] [--prefix PATH]        ', &
    '         [--config-file PATH] [--registry-cache] [options]                      ', &
-   ' clean [--skip] [--all] [--config-file PATH] [--registry-cache]                 ', &
+   ' clean [--skip|--all] [--test] [--apps] [--examples] [--config-file PATH]       ', &
+   '       [--registry-cache]                                                      ', &
    ' publish [--token TOKEN] [--show-package-version] [--show-upload-data]          ', &
    '         [--dry-run] [--verbose] [--config-file PATH]                           ', &
    ' ']
@@ -912,7 +913,7 @@ contains
     '  + list     Display brief descriptions of all subcommands.            ', &
     '  + install  Install project.                                          ', &
     '  + clean    Delete directories in the "build/" directory, except      ', &
-    '             dependencies. Prompts for confirmation to delete.         ', &
+    '             dependencies. Use --test/--apps/--examples for selective. ', &
     '  + publish  Publish package to the registry.                          ', &
     '                                                                       ', &
     '  Their syntax is                                                      ', &
@@ -933,7 +934,8 @@ contains
     '    list [--list]                                                               ', &
     '    install [--profile PROF] [--flag FFLAGS] [--no-rebuild] [--prefix PATH]     ', &
     '            [options] [--config-file PATH] [--registry-cache]                    ', &
-    '    clean [--skip] [--all] [--config-file PATH] [--registry-cache]               ', &
+    '    clean [--skip|--all] [--test] [--apps] [--examples] [--config-file PATH]     ', &
+    '          [--registry-cache]                                                    ', &
     '    publish [--token TOKEN] [--show-package-version] [--show-upload-data]       ', &
     '            [--dry-run] [--verbose] [--config-file PATH]                        ', &
     '                                                                                ', &

--- a/src/fpm_command_line.f90
+++ b/src/fpm_command_line.f90
@@ -356,7 +356,7 @@ contains
                     if (specified('runner') .and. val_runner == '') val_runner = 'echo'
 
                     ! Run-specific fields
-                    cmd%args        = remaining
+                    if (allocated(remaining)) cmd%args = remaining
                     cmd%example     = lget('example')
                     cmd%name        = names
                     cmd%runner      = val_runner
@@ -586,7 +586,7 @@ contains
                 call build_settings(cmd, list=lget('list'), build_tests=.true., &
                                     config_file=sget('config-file'))
 
-                cmd%args        = remaining
+                if (allocated(remaining)) cmd%args = remaining
                 cmd%example     = .false.
                 cmd%name        = names
                 cmd%runner      = val_runner

--- a/src/fpm_command_line.f90
+++ b/src/fpm_command_line.f90
@@ -160,9 +160,7 @@ character(len=20),parameter :: manual(*)=[ character(len=20) ::&
 &  ' ',     'fpm',    'new',     'build',  'run',    'clean',  &
 &  'test',  'runner', 'install', 'update', 'list',   'help',   'version', 'publish' ]
 
-character(len=:), allocatable :: val_runner, val_compiler, val_flag, val_cflag, val_cxxflag, val_ldflag, &
-    val_profile, val_runner_args, val_dump
-
+character(len=:), allocatable :: val_runner,val_runner_args,val_dump
 
 !   '12345678901234567890123456789012345678901234567890123456789012345678901234567890',&
 character(len=80), parameter :: help_text_build_common(*) = [character(len=80) ::      &
@@ -526,8 +524,6 @@ contains
                 & --config-file " " &
                 &', help_install, version_text)
 
-            call check_build_vals()
-
             config_file = sget('config-file')
             allocate(install_settings)
 
@@ -557,8 +553,6 @@ contains
             call set_args(common_args // compiler_args // run_args // '&
             & --config-file " " &
             & -- ', help_test,version_text)
-
-            call check_build_vals()
 
             if( size(unnamed) > 1 )then
                 names=unnamed(2:)
@@ -636,8 +630,6 @@ contains
                 & --dependencies "filename" ', &
                 help_build, version_text)
 
-            call check_build_vals()
-
             allocate(export_settings)
             call build_settings(export_settings, show_model=.true.)
             call get_char_arg(export_settings%dump_model, 'model')
@@ -705,8 +697,6 @@ contains
             & --config-file " " &
             & --', help_publish, version_text)
 
-            call check_build_vals()
-
             config_file = sget('config-file')
             token_s = sget('token')
 
@@ -757,18 +747,6 @@ contains
         end if
 
     contains
-
-    subroutine check_build_vals()
-        val_compiler=sget('compiler')
-        if(val_compiler=='') val_compiler='gfortran'
-
-        val_flag = " " // sget('flag')
-        val_cflag = " " // sget('c-flag')
-        val_cxxflag = " " // sget('cxx-flag')
-        val_ldflag = " " // sget('link-flag')
-        val_profile = sget('profile')
-
-    end subroutine check_build_vals
 
     !> Print help text and stop
     subroutine printhelp(lines)

--- a/test/cli_test/cli_test.f90
+++ b/test/cli_test/cli_test.f90
@@ -29,6 +29,9 @@ logical                              :: w_e,act_w_e          ; namelist/act_cli/
 logical                              :: w_t,act_w_t          ; namelist/act_cli/act_w_t
 logical                              :: c_s,act_c_s          ; namelist/act_cli/act_c_s
 logical                              :: c_a,act_c_a          ; namelist/act_cli/act_c_a
+logical                              :: c_t,act_c_t          ; namelist/act_cli/act_c_t
+logical                              :: c_apps,act_c_apps    ; namelist/act_cli/act_c_apps
+logical                              :: c_ex,act_c_ex        ; namelist/act_cli/act_c_ex
 logical                              :: reg_c,act_reg_c      ; namelist/act_cli/act_reg_c
 logical                              :: show_v,act_show_v    ; namelist/act_cli/act_show_v
 logical                              :: show_u_d,act_show_u_d; namelist/act_cli/act_show_u_d
@@ -37,7 +40,7 @@ character(len=:), allocatable        :: token, act_token     ; namelist/act_cli/
 
 character(len=:), allocatable        :: profile,act_profile  ; namelist/act_cli/act_profile
 character(len=:), allocatable        :: args,act_args        ; namelist/act_cli/act_args
-namelist/expected/cmd,cstat,estat,w_e,w_t,c_s,c_a,reg_c,name,profile,args,show_v,show_u_d,dry_run,token
+namelist/expected/cmd,cstat,estat,w_e,w_t,c_s,c_a,c_t,c_apps,c_ex,reg_c,name,profile,args,show_v,show_u_d,dry_run,token
 integer                              :: lun
 logical,allocatable                  :: tally(:)
 logical,allocatable                  :: subtally(:)
@@ -76,6 +79,10 @@ character(len=*),parameter           :: tests(*)= [ character(len=256) :: &
 'CMD="clean",                                                      NAME=, ARGS="",', &
 'CMD="clean --skip",                                        C_S=T, NAME=, ARGS="",', &
 'CMD="clean --all",                                         C_A=T, NAME=, ARGS="",', &
+'CMD="clean --test",                                        C_T=T, NAME=, ARGS="",', &
+'CMD="clean --apps",                                     C_APPS=T, NAME=, ARGS="",', &
+'CMD="clean --examples",                                    C_EX=T, NAME=, ARGS="",', &
+'CMD="clean --test --apps",                           C_T=T, C_APPS=T, NAME=, ARGS="",', &
 'CMD="clean --registry-cache",                            REG_C=T, NAME=, ARGS="",', &
 'CMD="publish --token abc --show-package-version",       SHOW_V=T, NAME=, token="abc",ARGS="",', &
 'CMD="publish --token abc --show-upload-data",           SHOW_U_D=T, NAME=, token="abc",ARGS="",', &
@@ -273,6 +280,9 @@ type is (fpm_test_settings)
 type is (fpm_clean_settings)
     act_c_s=settings%clean_skip
     act_c_a=settings%clean_all
+    act_c_t=settings%clean_test
+    act_c_apps=settings%clean_apps
+    act_c_ex=settings%clean_examples
     act_reg_c=settings%registry_cache
 type is (fpm_install_settings)
 type is (fpm_publish_settings)


### PR DESCRIPTION
This PR adds new options to the `fpm clean` command for selectively deleting specific types of build artifacts:

  - `--test` - Delete only test executables
  - `--apps` - Delete only application executables
  - `--examples` - Delete only example executables

Usage

`fpm clean --test`           # Delete only test executables
`fpm clean --apps`           # Delete only app executables
`fpm clean --examples`       # Delete only example executables
`fpm clean --test --apps`    # Delete both test and app executables

This allows to quickly clean specific build artifacts without rebuilding everything. 
Resolves requirement for selective build artifact cleanup. Close #1136 
