### PR TITLE
bugfix: manifest test failure

### DIFF
--- a/src/fpm_compiler.F90
+++ b/src/fpm_compiler.F90
@@ -52,7 +52,7 @@ use shlex_module, only: sh_split => split, ms_split, quote => ms_quote
 implicit none
 public :: compiler_t, new_compiler, archiver_t, new_archiver, get_macros
 public :: append_clean_flags, append_clean_flags_array
-public :: debug
+public :: debug, id_gcc
 
 enum, bind(C)
     enumerator :: &

--- a/test/fpm_test/test_manifest.f90
+++ b/test/fpm_test/test_manifest.f90
@@ -1414,7 +1414,7 @@ contains
 
     !> Test macro parsing function get_macros_from_manifest
     subroutine test_macro_parsing(error)
-        use fpm_compiler, only: get_macros, compiler_enum
+        use fpm_compiler, only: get_macros, compiler_enum, id_gcc
 
         !> Error handling
         type(error_t), allocatable, intent(out) :: error
@@ -1423,6 +1423,8 @@ contains
         character(:), allocatable :: temp_file
         integer :: unit
         integer(compiler_enum)  :: id
+        
+        id = id_gcc
 
         allocate(temp_file, source=get_temp_filename())
 


### PR DESCRIPTION
the Macro parsing CI test may fail at random due to an uninitialized compiler ID value in the test routine:
https://github.com/perazz/fpm/actions/runs/17346215924/job/49246539792

Fix that. 