### PR TITLE
feat: custom build folder

### DIFF
--- a/ci/run_tests.sh
+++ b/ci/run_tests.sh
@@ -345,8 +345,7 @@ test $EXIT_CODE -eq 0
 popd
 
 # Test custom build directory functionality 
-script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-bash "$script_dir/test_custom_build_dir.sh" "$fpm" hello_world
+bash "../ci/test_custom_build_dir.sh" "$fpm" hello_world
 
 # Cleanup
 rm -rf ./*/build

--- a/ci/run_tests.sh
+++ b/ci/run_tests.sh
@@ -344,5 +344,8 @@ pushd static_app_only
 test $EXIT_CODE -eq 0
 popd
 
+# Test custom build directory functionality
+./test_custom_build_dir.sh "$fpm" hello_world
+
 # Cleanup
 rm -rf ./*/build

--- a/ci/run_tests.sh
+++ b/ci/run_tests.sh
@@ -345,7 +345,7 @@ test $EXIT_CODE -eq 0
 popd
 
 # Test custom build directory functionality
-./test_custom_build_dir.sh "$fpm" hello_world
+"$(dirname "$0")/test_custom_build_dir.sh" "$fpm" hello_world
 
 # Cleanup
 rm -rf ./*/build

--- a/ci/run_tests.sh
+++ b/ci/run_tests.sh
@@ -344,8 +344,9 @@ pushd static_app_only
 test $EXIT_CODE -eq 0
 popd
 
-# Test custom build directory functionality
-"$(dirname "$0")/test_custom_build_dir.sh" "$fpm" hello_world
+# Test custom build directory functionality 
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+bash "$script_dir/test_custom_build_dir.sh" "$fpm" hello_world
 
 # Cleanup
 rm -rf ./*/build

--- a/ci/test_custom_build_dir.sh
+++ b/ci/test_custom_build_dir.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+set -ex
+
+# Test script for custom build directory functionality
+# Usage: ./test_custom_build_dir.sh [fpm_executable] [example_package_dir]
+
+cd "$(dirname $0)/.."
+
+if [ "$1" ]; then
+   fpm="$1"
+else
+   fpm=fpm
+fi
+
+if [ "$2" ]; then
+   test_package="$2"
+else
+   test_package="hello_world"
+fi
+
+echo "Testing custom build directory functionality with package: $test_package"
+
+# Go to example packages directory
+pushd example_packages/
+
+# Test 1: Custom build directory with CLI option
+pushd "$test_package"
+echo "Test 1: CLI option --build-dir"
+rm -rf ./build custom_build_test
+"$fpm" build --build-dir custom_build_test
+test -d custom_build_test
+test -f custom_build_test/.gitignore
+"$fpm" run --build-dir custom_build_test --target "$test_package"
+# Verify standard build directory was not created
+test ! -d build
+echo "✓ CLI option --build-dir works"
+
+# Test 2: Environment variable
+echo "Test 2: Environment variable FPM_BUILD_DIR"
+rm -rf custom_build_test env_build_test
+FPM_BUILD_DIR=env_build_test "$fpm" build
+test -d env_build_test
+test -f env_build_test/.gitignore
+FPM_BUILD_DIR=env_build_test "$fpm" run --target "$test_package"
+echo "✓ Environment variable FPM_BUILD_DIR works"
+
+# Test 3: CLI option overrides environment variable
+echo "Test 3: CLI option overrides environment variable"
+rm -rf env_build_test cli_override_test
+FPM_BUILD_DIR=env_build_test "$fpm" build --build-dir cli_override_test
+test -d cli_override_test
+test ! -d env_build_test
+echo "✓ CLI option correctly overrides environment variable"
+
+# Test 4: Build directory validation - reserved names
+echo "Test 4: Build directory validation"
+# These should fail with specific error messages
+if "$fpm" build --build-dir src 2>&1 | grep -q "conflicts with source directory"; then
+    echo "✓ Correctly rejected 'src'"
+else
+    echo "ERROR: Should reject 'src'" && exit 1
+fi
+
+if "$fpm" build --build-dir app 2>&1 | grep -q "conflicts with source directory"; then
+    echo "✓ Correctly rejected 'app'"
+else
+    echo "ERROR: Should reject 'app'" && exit 1
+fi
+
+if "$fpm" build --build-dir test 2>&1 | grep -q "conflicts with source directory"; then
+    echo "✓ Correctly rejected 'test'"
+else
+    echo "ERROR: Should reject 'test'" && exit 1
+fi
+
+if "$fpm" build --build-dir . 2>&1 | grep -q "would overwrite the current"; then
+    echo "✓ Correctly rejected '.'"
+else
+    echo "ERROR: Should reject '.'" && exit 1
+fi
+
+# Test 5: Path normalization
+echo "Test 5: Path normalization"
+if "$fpm" build --build-dir ./src 2>&1 | grep -q "conflicts with source directory"; then
+    echo "✓ Correctly rejected './src' (path normalization works)"
+else
+    echo "ERROR: Should reject './src'" && exit 1
+fi
+
+# Test 6: Different commands with custom build directory
+echo "Test 6: Different commands with custom build directory"
+rm -rf test_build_all
+"$fpm" build --build-dir test_build_all
+"$fpm" run --build-dir test_build_all --target "$test_package"
+# Some packages may not have tests, so this might fail but that's expected
+"$fpm" test --build-dir test_build_all 2>/dev/null || echo "No tests in $test_package (expected)"
+echo "✓ All commands work with custom build directory"
+
+# Cleanup test directories
+rm -rf custom_build_test env_build_test cli_override_test test_build_all
+popd
+
+popd
+
+echo "All custom build directory tests passed!"

--- a/ci/test_custom_build_dir.sh
+++ b/ci/test_custom_build_dir.sh
@@ -4,7 +4,9 @@ set -ex
 # Test script for custom build directory functionality
 # Usage: ./test_custom_build_dir.sh [fpm_executable] [example_package_dir]
 
-cd "$(dirname $0)/.."
+# Move to repo root (works from <root> or <root>/ci)
+this_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$this_dir/.."
 
 if [ "$1" ]; then
    fpm="$1"

--- a/ci/test_custom_build_dir.sh
+++ b/ci/test_custom_build_dir.sh
@@ -4,10 +4,6 @@ set -ex
 # Test script for custom build directory functionality
 # Usage: ./test_custom_build_dir.sh [fpm_executable] [example_package_dir]
 
-# Move to repo root (works from <root> or <root>/ci)
-this_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-cd "$this_dir/.."
-
 if [ "$1" ]; then
    fpm="$1"
 else
@@ -21,9 +17,6 @@ else
 fi
 
 echo "Testing custom build directory functionality with package: $test_package"
-
-# Go to example packages directory
-pushd example_packages/
 
 # Test 1: Custom build directory with CLI option
 pushd "$test_package"
@@ -100,8 +93,6 @@ echo "✓ All commands work with custom build directory"
 
 # Cleanup test directories
 rm -rf custom_build_test env_build_test cli_override_test test_build_all
-popd
-
 popd
 
 echo "All custom build directory tests passed!"

--- a/src/fpm.f90
+++ b/src/fpm.f90
@@ -69,7 +69,8 @@ subroutine build_model(model, settings, package, error)
     end if
 
     call new_compiler_flags(model,settings)
-    model%build_prefix         = join_path("build", basename(model%compiler%fc))
+    model%build_dir            = settings%build_dir
+    model%build_prefix         = join_path(settings%build_dir, basename(model%compiler%fc))
     model%include_tests        = settings%build_tests
     model%enforce_module_names = package%build%module_naming
     model%module_prefix        = package%build%module_prefix
@@ -79,8 +80,8 @@ subroutine build_model(model, settings, package, error)
     if (allocated(error)) return
     
     ! Create dependencies
-    call new_dependency_tree(model%deps, cache=join_path("build", "cache.toml"), &
-    & path_to_config=settings%path_to_config)
+    call new_dependency_tree(model%deps, cache=join_path(settings%build_dir, "cache.toml"), &
+    & path_to_config=settings%path_to_config, build_dir=settings%build_dir)
 
     ! Build and resolve model dependencies
     call model%deps%add(package, error)
@@ -90,9 +91,9 @@ subroutine build_model(model, settings, package, error)
     call model%deps%update(error)
     if (allocated(error)) return
 
-    ! build/ directory should now exist
-    if (.not.exists("build/.gitignore")) then
-      call filewrite(join_path("build", ".gitignore"),["*"])
+    ! build directory should now exist
+    if (.not.exists(join_path(settings%build_dir, ".gitignore"))) then
+      call filewrite(join_path(settings%build_dir, ".gitignore"),["*"])
     end if
 
     allocate(model%packages(model%deps%ndep))

--- a/src/fpm/cmd/export.f90
+++ b/src/fpm/cmd/export.f90
@@ -44,8 +44,8 @@ contains
     if (len_trim(settings%dump_dependencies)>0) then
 
         !> Generate dependency tree
-        filename = join_path("build", "cache.toml")
-        call new_dependency_tree(deps, cache=filename, verbosity=merge(2, 1, settings%verbose))
+        filename = join_path(settings%build_dir, "cache.toml")
+        call new_dependency_tree(deps, cache=filename, verbosity=merge(2, 1, settings%verbose), build_dir=settings%build_dir)
         call deps%add(package, error)
         call handle_error(error)
 

--- a/src/fpm/dependency.f90
+++ b/src/fpm/dependency.f90
@@ -205,7 +205,7 @@ module fpm_dependency
 contains
 
   !> Create a new dependency tree
-  subroutine new_dependency_tree(self, verbosity, cache, path_to_config)
+  subroutine new_dependency_tree(self, verbosity, cache, path_to_config, build_dir)
     !> Instance of the dependency tree
     type(dependency_tree_t), intent(out) :: self
     !> Verbosity of printout
@@ -214,9 +214,15 @@ contains
     character(len=*), intent(in), optional :: cache
     !> Path to the global config file.
     character(len=*), intent(in), optional :: path_to_config
+    !> Custom build directory
+    character(len=*), intent(in), optional :: build_dir
 
     call resize(self%dep)
-    self%dep_dir = join_path("build", "dependencies")
+    if (present(build_dir)) then
+        self%dep_dir = join_path(build_dir, "dependencies")
+    else
+        self%dep_dir = join_path("build", "dependencies")
+    end if
 
     if (present(verbosity)) self%verbosity = verbosity
 

--- a/src/fpm_backend.F90
+++ b/src/fpm_backend.F90
@@ -115,7 +115,7 @@ subroutine build_package(targets,model,verbose,dry_run)
     plain_output = .true.
 #endif
 
-    progress = build_progress_t(queue,plain_output)
+    progress = build_progress_t(queue,plain_output,model%build_dir)
 
     ! Loop over parallel schedule regions
     do i=1,size(schedule_ptr)-1

--- a/src/fpm_command_line.f90
+++ b/src/fpm_command_line.f90
@@ -89,6 +89,7 @@ type, extends(fpm_cmd_settings)  :: fpm_build_settings
     character(len=:),allocatable :: cflag
     character(len=:),allocatable :: cxxflag
     character(len=:),allocatable :: ldflag
+    character(len=:),allocatable :: build_dir
 end type
 
 type, extends(fpm_build_settings)  :: fpm_run_settings
@@ -158,7 +159,7 @@ character(len=20),parameter :: manual(*)=[ character(len=20) ::&
 &  'test',  'runner', 'install', 'update', 'list',   'help',   'version', 'publish' ]
 
 character(len=:), allocatable :: val_runner, val_compiler, val_flag, val_cflag, val_cxxflag, val_ldflag, &
-    val_profile, val_runner_args, val_dump
+    val_profile, val_runner_args, val_dump, val_build_dir
 
 
 !   '12345678901234567890123456789012345678901234567890123456789012345678901234567890',&
@@ -246,7 +247,7 @@ contains
         character(len=*), parameter :: fc_env = "FC", cc_env = "CC", ar_env = "AR", &
             & fflags_env = "FFLAGS", cflags_env = "CFLAGS", cxxflags_env = "CXXFLAGS", ldflags_env = "LDFLAGS", &
             & fc_default = "gfortran", cc_default = " ", ar_default = " ", flags_default = " ", &
-            & cxx_env = "CXX", cxx_default = " "
+            & cxx_env = "CXX", cxx_default = " ", build_dir_env = "BUILD_DIR", build_dir_default = "build"
         type(error_t), allocatable :: error
 
         call set_help()
@@ -300,7 +301,8 @@ contains
           ' --flag:: "'//get_fpm_env(fflags_env, flags_default)//'"' // &
           ' --c-flag:: "'//get_fpm_env(cflags_env, flags_default)//'"' // &
           ' --cxx-flag:: "'//get_fpm_env(cxxflags_env, flags_default)//'"' // &
-          ' --link-flag:: "'//get_fpm_env(ldflags_env, flags_default)//'"'
+          ' --link-flag:: "'//get_fpm_env(ldflags_env, flags_default)//'"' // &
+          ' --build-dir "'//get_fpm_env(build_dir_env, build_dir_default)//'"'
 
         ! now set subcommand-specific help text and process commandline
         ! arguments. Then call subcommand routine
@@ -363,6 +365,7 @@ contains
             & cflag=val_cflag, &
             & cxxflag=val_cxxflag, &
             & ldflag=val_ldflag, &
+            & build_dir=val_build_dir, &
             & example=lget('example'), &
             & list=lget('list'),&
             & build_tests=.false.,&
@@ -403,6 +406,7 @@ contains
             & cflag=val_cflag, &
             & cxxflag=val_cxxflag, &
             & ldflag=val_ldflag, &
+            & build_dir=val_build_dir, &
             & list=lget('list'),&
             & show_model=lget('show-model'),&
             & build_tests=lget('tests'),&
@@ -568,6 +572,7 @@ contains
                 cflag=val_cflag, &
                 cxxflag=val_cxxflag, &
                 ldflag=val_ldflag, &
+                build_dir=val_build_dir, &
                 no_rebuild=lget('no-rebuild'), &
                 verbose=lget('verbose')))
             call get_char_arg(install_settings%prefix, 'prefix')
@@ -639,6 +644,7 @@ contains
             & cflag=val_cflag, &
             & cxxflag=val_cxxflag, &
             & ldflag=val_ldflag, &
+            & build_dir=val_build_dir, &
             & example=.false., &
             & list=lget('list'), &
             & build_tests=.true., &
@@ -820,6 +826,7 @@ contains
         val_cxxflag = " " // sget('cxx-flag')
         val_ldflag = " " // sget('link-flag')
         val_profile = sget('profile')
+        val_build_dir = sget('build-dir')
 
     end subroutine check_build_vals
 

--- a/src/fpm_command_line.f90
+++ b/src/fpm_command_line.f90
@@ -169,7 +169,9 @@ character(len=80), parameter :: help_text_build_common(*) = [character(len=80) :
     '                   high optimization and "debug" for full debug options.        ',&
     '                   If --flag is not specified the "debug" flags are the         ',&
     '                   default.                                                     ',&
-    ' --no-prune        Disable tree-shaking/pruning of unused module dependencies   '&
+    ' --no-prune        Disable tree-shaking/pruning of unused module dependencies   ',&
+    ' --build-dir DIR   Specify the build directory. Default is "build" unless set   ',&
+    '                   by the environment variable FPM_BUILD_DIR.                   '&
     ]
 !   '12345678901234567890123456789012345678901234567890123456789012345678901234567890',&
 character(len=80), parameter :: help_text_compiler(*) = [character(len=80) :: &
@@ -226,7 +228,10 @@ character(len=80), parameter :: help_text_environment(*) = [character(len=80) ::
     '                   will be overwritten by --archiver command line option', &
     '', &
     ' FPM_LDFLAGS       sets additional link arguments for creating executables', &
-    '                   will be overwritten by --link-flag command line option' &
+    '                   will be overwritten by --link-flag command line option', &
+    '', &
+    ' FPM_BUILD_DIR     sets the build directory for compilation output', &
+    '                   will be overwritten by --build-dir command line option' &
     ]
 
 contains
@@ -1194,7 +1199,8 @@ contains
     '                                                                       ', &
     'SYNOPSIS                                                               ', &
     ' fpm build [--profile PROF] [--flag FFLAGS] [--compiler COMPILER_NAME] ', &
-    '           [--list] [--tests] [--config-file PATH] [--dump [FILENAME]] ', &
+    '           [--build-dir DIR] [--list] [--tests] [--config-file PATH]    ', &
+    '           [--dump [FILENAME]]                                          ', &
     '                                                                       ', &
     ' fpm build --help|--version                                            ', &
     '                                                                       ', &
@@ -1210,7 +1216,7 @@ contains
     '    o test/    main program(s) and support files for project tests     ', &
     '    o example/ main program(s) for example programs                    ', &
     ' Changed or new files found are rebuilt. The results are placed in     ', &
-    ' the build/ directory.                                                 ', &
+    ' the build directory (default: build/).                               ', &
     '                                                                       ', &
     ' Non-default pathnames and remote dependencies are used if             ', &
     ' specified in the "fpm.toml" file.                                     ', &
@@ -1221,7 +1227,7 @@ contains
     help_text_flag, &
     ' --list        list candidates instead of building or running them.    ', &
     '               all dependencies are downloaded, and the build sequence ', &
-    '               is saved to `build/compile_commands.json`.              ', &
+    '               is saved to `<build-dir>/compile_commands.json`.         ', &
     ' --tests       build all tests (otherwise only if needed)              ', &
     ' --show-model  show the model and exit (do not build)                  ', &
     ' --dump [FILENAME] save model representation to file. use JSON format  ', &
@@ -1238,6 +1244,7 @@ contains
     '                                                                       ', &
     '  fpm build                   # build with debug options               ', &
     '  fpm build --profile release # build with high optimization           ', &
+    '  fpm build --build-dir /tmp/my_build # build to custom directory      ', &
     '' ]
 
     help_help=[character(len=80) :: &

--- a/src/fpm_command_line.f90
+++ b/src/fpm_command_line.f90
@@ -858,13 +858,16 @@ contains
         do i = 1, size(reserved_names)
             normalized_reserved = canon_path(trim(reserved_names(i)))
             if (normalized_build_dir == normalized_reserved) then
-                call fpm_stop(1, 'Error: Build directory "'//trim(build_dir)//'" conflicts with source directory "'//trim(reserved_names(i))//'".')
+                call fpm_stop(1, 'Error: Build directory "'//trim(build_dir) &
+                                  //'" conflicts with source directory "' &
+                                  //trim(reserved_names(i))//'".')
             end if
         end do
         
         ! Additional checks for problematic cases
         if (trim(build_dir) == "." .or. trim(build_dir) == "..") then
-            call fpm_stop(1, 'Error: Build directory cannot be "'//trim(build_dir)//'" as it would overwrite the current or parent directory.')
+            call fpm_stop(1, 'Error: Build directory cannot be "'//trim(build_dir)// &
+                             '" as it would overwrite the current or parent directory.')
         end if
         
     end subroutine validate_build_dir

--- a/src/fpm_command_line.f90
+++ b/src/fpm_command_line.f90
@@ -1620,12 +1620,15 @@ contains
         cxxflags = ' ' // sget('cxx-flag')
         ldflags  = ' ' // sget('link-flag')
         prof     = sget('profile')
+        
+        ! Set and validate build directory
         dir      = sget('build-dir')
+        call validate_build_dir(dir)
 
         ccomp    = sget('c-compiler')
         cxcomp   = sget('cxx-compiler')
         arch     = sget('archiver')
-
+        
         ! Handle --dump default (empty value means use 'fpm_model.toml')
         if (specified('dump')) then 
            dump = sget('dump')

--- a/src/fpm_command_line.f90
+++ b/src/fpm_command_line.f90
@@ -38,7 +38,6 @@ use fpm_release,      only : fpm_version, version_t
 use,intrinsic :: iso_fortran_env, only : stdin=>input_unit, &
                                        & stdout=>output_unit, &
                                        & stderr=>error_unit
-
 implicit none
 
 private
@@ -757,12 +756,10 @@ contains
             call move_alloc(working_dir, cmd_settings%working_dir)
         end if
 
-    contains
+    end subroutine get_command_line_settings
 
     !> Validate that build directory is not a reserved source directory name
     subroutine validate_build_dir(build_dir)
-        use fpm_error, only: fpm_stop
-        use fpm_filesystem, only: canon_path
         character(len=*), intent(in) :: build_dir
         character(len=*), parameter :: reserved_names(*) = [ &
             "src     ", "app     ", "test    ", "tests   ", &
@@ -808,8 +805,6 @@ contains
         endif
         stop
     end subroutine printhelp
-
-    end subroutine get_command_line_settings
 
     subroutine set_help()
    help_list_nodash=[character(len=80) :: &

--- a/src/fpm_model.f90
+++ b/src/fpm_model.f90
@@ -217,6 +217,9 @@ type, extends(serializable_t) :: fpm_model_t
     !> Base directory for build
     character(:), allocatable :: build_prefix
 
+    !> Build directory
+    character(:), allocatable :: build_dir
+
     !> Include directories
     type(string_t), allocatable :: include_dirs(:)
 
@@ -365,6 +368,7 @@ function info_model(model) result(s)
     s = s // ', cxx_compile_flags="' // model%cxx_compile_flags // '"'
     s = s // ', link_flags="' // model%link_flags // '"'
     s = s // ', build_prefix="' // model%build_prefix // '"'
+    s = s // ', build_dir="' // model%build_dir // '"'
     !    type(string_t), allocatable :: link_libraries(:)
     s = s // ", link_libraries=["
     do i = 1, size(model%link_libraries)
@@ -931,6 +935,10 @@ logical function model_is_same(this,that)
            if (allocated(this%build_prefix)) then
              if (.not.(this%build_prefix==other%build_prefix)) return
            end if
+           if (allocated(this%build_dir).neqv.allocated(other%build_dir)) return
+           if (allocated(this%build_dir)) then
+             if (.not.(this%build_dir==other%build_dir)) return
+           end if
            if (allocated(this%include_dirs).neqv.allocated(other%include_dirs)) return
            if (allocated(this%include_dirs)) then
              if (.not.(this%include_dirs==other%include_dirs)) return
@@ -996,6 +1004,8 @@ subroutine model_dump_to_toml(self, table, error)
     call set_string(table, "link-flags", self%link_flags, error, 'fpm_model_t')
     if (allocated(error)) return
     call set_string(table, "build-prefix", self%build_prefix, error, 'fpm_model_t')
+    if (allocated(error)) return
+    call set_string(table, "build-dir", self%build_dir, error, 'fpm_model_t')
     if (allocated(error)) return
     call set_list(table, "include-dirs", self%include_dirs, error)
     if (allocated(error)) return
@@ -1075,6 +1085,7 @@ subroutine model_load_from_toml(self, table, error)
     call get_value(table, "cxx-flags", self%cxx_compile_flags)
     call get_value(table, "link-flags", self%link_flags)
     call get_value(table, "build-prefix", self%build_prefix)
+    call get_value(table, "build-dir", self%build_dir)
 
     if (allocated(self%packages)) deallocate(self%packages)
     sub_deps: do ii = 1, size(keys)


### PR DESCRIPTION
This PR adds support for specifying a custom `build/` folder for build outputs in fpm. Users can now configure the build directory using either the `--build-dir` command-line option or the `FPM_BUILD_DIR` environment variable.

So, builds with different CLI/environment features (i.e. compilers, etc.) can have their own folder, avoiding overwrites.

Example:

`fpm build --build-dir build_gcc`
`fpm install --build-dir build_gcc --prefix=/gcc_packages/`

Closes #1137.
