### PR TITLE
feat: make flang-new a first-class citizen in fpm

### DIFF
--- a/src/fpm_compiler.F90
+++ b/src/fpm_compiler.F90
@@ -273,7 +273,13 @@ character(*), parameter :: &
     flag_cray_free_form = " -ffree"
 
 character(*), parameter :: &
-    flag_flang_new_openmp = " -fopenmp"
+    flag_flang_new_openmp = " -fopenmp", &
+    flag_flang_new_debug = " -g", &
+    flag_flang_new_opt = " -O3", &
+    flag_flang_new_pic = " -fPIC", &
+    flag_flang_new_free_form = " -ffree-form", &
+    flag_flang_new_fixed_form = " -ffixed-form", &
+    flag_flang_new_no_implicit_typing = " -fimplicit-none"
 
 contains
 
@@ -405,6 +411,11 @@ subroutine get_release_compile_flags(id, flags)
         flags = &
             flag_lfortran_opt
 
+    case(id_flang_new)
+        flags = &
+            flag_flang_new_opt//&
+            flag_flang_new_pic
+
     end select
 end subroutine get_release_compile_flags
 
@@ -500,6 +511,12 @@ subroutine get_debug_compile_flags(id, flags)
 
     case(id_lfortran)
         flags = ""
+
+    case(id_flang_new)
+        flags = &
+            flag_flang_new_debug//&
+            flag_flang_new_pic
+
     end select
 end subroutine get_debug_compile_flags
 
@@ -512,7 +529,7 @@ pure subroutine set_cpp_preprocessor_flags(id, flags)
     select case(id)
     case default
         flag_cpp_preprocessor = ""
-    case(id_caf, id_gcc, id_f95, id_nvhpc)
+    case(id_caf, id_gcc, id_f95, id_nvhpc, id_flang_new)
         flag_cpp_preprocessor = "-cpp"
     case(id_intel_classic_windows, id_intel_llvm_windows)
         flag_cpp_preprocessor = "/fpp"
@@ -700,6 +717,9 @@ function get_feature_flag(self, feature) result(flags)
        case(id_cray)
            flags = flag_cray_no_implicit_typing
 
+       case(id_flang_new)
+           flags = flag_flang_new_no_implicit_typing
+
        end select
 
     case("implicit-typing")
@@ -747,6 +767,9 @@ function get_feature_flag(self, feature) result(flags)
        case(id_cray)
            flags = flag_cray_free_form
 
+       case(id_flang_new)
+           flags = flag_flang_new_free_form
+
        end select
 
     case("fixed-form")
@@ -772,6 +795,9 @@ function get_feature_flag(self, feature) result(flags)
 
        case(id_lfortran)
            flags = flag_lfortran_fixed_form
+
+       case(id_flang_new)
+           flags = flag_flang_new_fixed_form
 
        end select
 

--- a/src/fpm_compiler.F90
+++ b/src/fpm_compiler.F90
@@ -10,7 +10,7 @@
 ! Intel oneAPI      ifx        icx     -module         -I            -qopenmp   X
 ! PGI               pgfortran  pgcc    -module         -I            -mp        X
 ! NVIDIA            nvfortran  nvc     -module         -I            -mp        X
-! LLVM flang        flang      clang   -module         -I            -mp        X
+! LLVM flang        flang      clang   -module-dir     -I            -fopenmp   X
 ! LFortran          lfortran   ---     -J              -I            --openmp   X
 ! Lahey/Futjitsu    lfc        ?       -M              -I            -openmp    ?
 ! NAG               nagfor     ?       -mdir           -I            -openmp    x
@@ -1000,8 +1000,13 @@ function get_id(compiler) result(id)
         return
     end if
 
-    if (check_compiler(compiler, "flang")) then
+    if (check_compiler(compiler, "flang-classic")) then
         id = id_flang
+        return
+    end if
+
+    if (check_compiler(compiler, "flang")) then
+        id = id_flang_new
         return
     end if
 
@@ -1745,7 +1750,7 @@ pure function compiler_name(self) result(name)
        case(id_pgi);       name = "pgfortran"
        case(id_nvhpc);     name = "nvfortran"
        case(id_nag);       name = "nagfor"
-       case(id_flang);     name = "flang"
+       case(id_flang);     name = "flang-classic"
        case(id_flang_new); name = "flang-new"
        case(id_f18);       name = "f18"
        case(id_ibmxl);     name = "xlf90"

--- a/src/fpm_compiler.F90
+++ b/src/fpm_compiler.F90
@@ -69,8 +69,8 @@ enum, bind(C)
         id_pgi, &
         id_nvhpc, &
         id_nag, &
+        id_flang_classic, &
         id_flang, &
-        id_flang_new, &
         id_f18, &
         id_ibmxl, &
         id_cray, &
@@ -300,11 +300,11 @@ function get_default_flags(self, release) result(flags)
     ! Append position-independent code (PIC) flag, that is necessary 
     ! building shared libraries
     select case (self%id)
-    case (id_gcc, id_f95, id_caf, id_flang, id_f18, id_lfortran, &
+    case (id_gcc, id_f95, id_caf, id_flang_classic, id_f18, id_lfortran, &
           id_intel_classic_nix, id_intel_classic_mac, id_intel_llvm_nix, &
           id_pgi, id_nvhpc, id_nag, id_cray, id_ibmxl)
         pic_flag = " -fPIC"
-    case (id_flang_new)
+    case (id_flang)
         ! flang-new doesn't support -fPIC on Windows MSVC target
         if (get_os_type() == OS_WINDOWS) then
             pic_flag = ""
@@ -418,7 +418,7 @@ subroutine get_release_compile_flags(id, flags)
         flags = &
             flag_lfortran_opt
 
-    case(id_flang_new)
+    case(id_flang)
         flags = &
             flag_flang_new_opt//&
             flag_flang_new_pic
@@ -519,7 +519,7 @@ subroutine get_debug_compile_flags(id, flags)
     case(id_lfortran)
         flags = ""
 
-    case(id_flang_new)
+    case(id_flang)
         flags = &
             flag_flang_new_debug//&
             flag_flang_new_pic
@@ -536,7 +536,7 @@ pure subroutine set_cpp_preprocessor_flags(id, flags)
     select case(id)
     case default
         flag_cpp_preprocessor = ""
-    case(id_caf, id_gcc, id_f95, id_nvhpc, id_flang_new)
+    case(id_caf, id_gcc, id_f95, id_nvhpc, id_flang)
         flag_cpp_preprocessor = "-cpp"
     case(id_intel_classic_windows, id_intel_llvm_windows)
         flag_cpp_preprocessor = "/fpp"
@@ -631,7 +631,7 @@ function get_include_flag(self, path) result(flags)
         flags = "-I "//path
 
     case(id_caf, id_gcc, id_f95, id_cray, id_nvhpc, id_pgi, &
-        & id_flang, id_flang_new, id_f18, &
+        & id_flang_classic, id_flang, id_f18, &
         & id_intel_classic_nix, id_intel_classic_mac, &
         & id_intel_llvm_nix, id_lahey, id_nag, id_ibmxl, &
         & id_lfortran)
@@ -655,10 +655,10 @@ function get_module_flag(self, path) result(flags)
     case(id_caf, id_gcc, id_f95, id_cray, id_lfortran)
         flags = "-J "//path
 
-    case(id_nvhpc, id_pgi, id_flang)
+    case(id_nvhpc, id_pgi, id_flang_classic)
         flags = "-module "//path
 
-    case(id_flang_new, id_f18)
+    case(id_flang, id_f18)
         flags = "-module-dir "//path
 
     case(id_intel_classic_nix, id_intel_classic_mac, &
@@ -689,7 +689,7 @@ function get_shared_flag(self) result(shared_flag)
     select case (self%id)
     case default
         shared_flag = "-shared"
-    case (id_gcc, id_f95, id_flang, id_flang_new, id_lfortran)
+    case (id_gcc, id_f95, id_flang_classic, id_flang, id_lfortran)
         shared_flag = "-shared"
     case (id_intel_classic_nix, id_intel_llvm_nix, id_pgi, id_nvhpc)
         shared_flag = "-shared"
@@ -724,7 +724,7 @@ function get_feature_flag(self, feature) result(flags)
        case(id_cray)
            flags = flag_cray_no_implicit_typing
 
-       case(id_flang_new)
+       case(id_flang)
            flags = flag_flang_new_no_implicit_typing
 
        end select
@@ -758,7 +758,7 @@ function get_feature_flag(self, feature) result(flags)
        case(id_caf, id_gcc, id_f95)
            flags = flag_gnu_free_form
 
-       case(id_pgi, id_nvhpc, id_flang)
+       case(id_pgi, id_nvhpc, id_flang_classic)
            flags = flag_pgi_free_form
 
        case(id_nag)
@@ -774,7 +774,7 @@ function get_feature_flag(self, feature) result(flags)
        case(id_cray)
            flags = flag_cray_free_form
 
-       case(id_flang_new)
+       case(id_flang)
            flags = flag_flang_new_free_form
 
        end select
@@ -784,7 +784,7 @@ function get_feature_flag(self, feature) result(flags)
        case(id_caf, id_gcc, id_f95)
            flags = flag_gnu_fixed_form
 
-       case(id_pgi, id_nvhpc, id_flang)
+       case(id_pgi, id_nvhpc, id_flang_classic)
            flags = flag_pgi_fixed_form
 
        case(id_nag)
@@ -803,7 +803,7 @@ function get_feature_flag(self, feature) result(flags)
        case(id_lfortran)
            flags = flag_lfortran_fixed_form
 
-       case(id_flang_new)
+       case(id_flang)
            flags = flag_flang_new_fixed_form
 
        end select
@@ -875,7 +875,7 @@ subroutine get_default_c_compiler(f_compiler, c_compiler)
     case(id_intel_llvm_nix,id_intel_llvm_windows)
         c_compiler = 'icx'
 
-    case(id_flang, id_flang_new, id_f18)
+    case(id_flang_classic, id_flang, id_f18)
         c_compiler='clang'
 
     case(id_ibmxl)
@@ -910,7 +910,7 @@ subroutine get_default_cxx_compiler(f_compiler, cxx_compiler)
     case(id_intel_llvm_nix,id_intel_llvm_windows)
         cxx_compiler = 'icpx'
 
-    case(id_flang, id_flang_new, id_f18)
+    case(id_flang_classic, id_flang, id_f18)
         cxx_compiler='clang++'
 
     case(id_ibmxl)
@@ -1024,7 +1024,7 @@ function get_id(compiler) result(id)
     end if
 
     if (check_compiler(compiler, "flang-new")) then
-        id = id_flang_new
+        id = id_flang
         return
     end if
 
@@ -1034,12 +1034,12 @@ function get_id(compiler) result(id)
     end if
 
     if (check_compiler(compiler, "flang-classic")) then
-        id = id_flang
+        id = id_flang_classic
         return
     end if
 
     if (check_compiler(compiler, "flang")) then
-        id = id_flang_new
+        id = id_flang
         return
     end if
 
@@ -1783,8 +1783,8 @@ pure function compiler_name(self) result(name)
        case(id_pgi);       name = "pgfortran"
        case(id_nvhpc);     name = "nvfortran"
        case(id_nag);       name = "nagfor"
-       case(id_flang);     name = "flang-classic"
-       case(id_flang_new); name = "flang-new"
+       case(id_flang_classic);     name = "flang-classic"
+       case(id_flang); name = "flang"
        case(id_f18);       name = "f18"
        case(id_ibmxl);     name = "xlf90"
        case(id_cray);      name = "crayftn"

--- a/src/metapackage/fpm_meta_openmp.f90
+++ b/src/metapackage/fpm_meta_openmp.f90
@@ -2,7 +2,7 @@ module fpm_meta_openmp
     use fpm_compiler, only: compiler_t, id_gcc, id_f95, id_intel_classic_windows, &
        id_intel_llvm_windows, id_intel_classic_nix, id_intel_llvm_nix, &
        id_intel_classic_mac, id_pgi, id_nvhpc, id_ibmxl, id_nag, id_lfortran, &
-       id_flang, id_flang_new, flag_gnu_openmp, flag_intel_openmp_win, &
+       id_flang_classic, id_flang, flag_gnu_openmp, flag_intel_openmp_win, &
        flag_intel_openmp, flag_pgi_openmp, flag_nag_openmp, &
        flag_lfortran_openmp, flag_flang_new_openmp
     use fpm_strings, only: string_t
@@ -73,7 +73,7 @@ module fpm_meta_openmp
                 openmp_flag = flag_lfortran_openmp
                 link_flag = flag_lfortran_openmp
 
-           case (id_flang, id_flang_new)
+           case (id_flang_classic, id_flang)
                 openmp_flag = flag_flang_new_openmp
                 link_flag = flag_flang_new_openmp
 


### PR DESCRIPTION
Fixes #1089.

This PR makes LLVM Flang (`flang-new`) a first-class citizen in fpm by updating compiler identification and flag support.
Since Classic Flang is deprecated, this change makes `flang` resolve to  the modern LLVM implementation while preserving access to the legacy compiler, now `flang-classic`.

## Changes Made
- Both `"flang"` and `"flang-new"` now resolve to `id_flang_new` (LLVM Flang)
- `"flang-classic"` now resolves to `id_flang` (Classic Flang)
- `id_flang` compiler name changed from `"flang"` to `"flang-classic"`

### Added Complete Flag Support for flang-new
Based on the [official flang-new command line reference](https://flang.llvm.org/docs/FlangCommandLineReference.html):

- Debug/optimization: `-g`, `-O3`
- Source form: `-ffree-form`, `-ffixed-form`
- Implicit typing: `-fimplicit-none`
- C preprocessor: `-cpp`
- Platform-aware `-fPIC` handling (disabled on Windows MSVC target)

## Backward Compatibility

- Existing `flang-new` usage unchanged
- Legacy users can use `flang-classic`

cc: @rouson 