### PR TITLE
fix: macOS install_name_tool error for monolithic builds

### DIFF
--- a/src/fpm_targets.f90
+++ b/src/fpm_targets.f90
@@ -1239,10 +1239,11 @@ subroutine resolve_target_linking(targets, model, library, error)
                                                                             exclude_self=.not.has_self_lib)   
                                                                             
                         
-                        ! On macOS, add room for 2 install_name_tool paths
-                        target%link_flags = target%link_flags // model%compiler%get_headerpad_flags()
                         
                     end if
+
+                    ! On macOS, add room for 2 install_name_tool paths (always needed for executables)
+                    target%link_flags = target%link_flags // model%compiler%get_headerpad_flags()
 
                     if (allocated(target%link_libraries)) then
                         if (size(target%link_libraries) > 0) then


### PR DESCRIPTION
  On macOS, if there is no library, fpm install fails for monolithic builds with the error:
```
  install_name_tool: changing install names or rpaths can't be redone for: ./installed/bin/executable (for architecture arm64) because larger updated load commands do not fit (the
  program must be relinked, and you may need to use -headerpad or -headerpad_max_install_names)
```
  This occurs because:
  1. The installer always tries to add rpath entries (@executable_path/../lib and @executable_path) to all executables on macOS
  2. Header padding flags (-Wl,-headerpad,0x200) were only applied to executables in non-monolithic builds
  3. Monolithic builds (default when no library configuration is specified) produced executables without sufficient header space for install_name_tool to modify

Issue is fixed by always ensuring the necessary header padding also in monolithic executables.