### PR TITLE
CI: enable gcc-15 on macOS

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -117,7 +117,7 @@ jobs:
     - name: Test Fortran fpm (bootstrap)
       shell: bash
       run: |
-        ${{ env.BOOTSTRAP }} test
+        ${{ env.BOOTSTRAP }} test --flag " -Wno-external-argument-mismatch"
 
     - name: Install Fortran fpm (bootstrap)
       shell: bash

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -52,6 +52,10 @@ jobs:
             os-arch: windows-x86_64
             release-flags: --flag '--static -g -fbacktrace -O3'
             exe: .exe
+          - os: macos-13
+            os-arch: macos-x86_64
+            toolchain: {compiler: gcc, version: 15}
+            release-flags: --flag '-g -fbacktrace -O3 -Wno-external-argument-mismatch'
 
     steps:
     - name: Checkout code

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -53,9 +53,8 @@ jobs:
             release-flags: --flag '--static -g -fbacktrace -O3'
             exe: .exe
           - os: macos-13
-            os-arch: macos-x86_64
             toolchain: {compiler: gcc, version: 15}
-            release-flags: --flag '-g -fbacktrace -O3 -Wno-external-argument-mismatch'
+            release-flags: --flag '-g -fbacktrace -Og -fcheck=all -Wno-external-argument-mismatch'
 
     steps:
     - name: Checkout code

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -54,7 +54,7 @@ jobs:
             exe: .exe
           - os: macos-13
             toolchain: {compiler: gcc, version: 15}
-            release-flags: --flag '-g -fbacktrace -Og -fcheck=all -Wno-external-argument-mismatch'
+            release-flags: --flag '-g -fbacktrace -Og -fcheck=all,no-recursion -Wno-external-argument-mismatch'
 
     steps:
     - name: Checkout code

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -28,6 +28,7 @@ jobs:
           - {compiler: gcc, version: 12}
           - {compiler: gcc, version: 13}
           - {compiler: gcc, version: 14}
+          - {compiler: gcc, version: 15}
           - {compiler: intel, version: 2025.1}
         exclude:
           - os: macos-13  # No Intel on MacOS anymore since 2024
@@ -36,6 +37,10 @@ jobs:
             toolchain: {compiler: intel, version: '2025.1'}
           - os: windows-latest  # gcc 14 not available on Windows yet
             toolchain: {compiler: gcc, version: 14}
+          - os: windows-latest  # gcc 15 not available on Windows yet
+            toolchain: {compiler: gcc, version: 15}
+          - os: ubuntu-latest  # gcc 15 not available on Ubuntu via setup-fortran yet
+            toolchain: {compiler: gcc, version: 15}
         include:
           - os: ubuntu-latest
             os-arch: linux-x86_64
@@ -53,7 +58,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Setup Fortran compiler
-      uses: fortran-lang/setup-fortran@v1.6.3
+      uses: fortran-lang/setup-fortran@v1.7.0
       id: setup-fortran
       with:
         compiler: ${{ matrix.toolchain.compiler }}

--- a/ci/run_tests.sh
+++ b/ci/run_tests.sh
@@ -231,7 +231,7 @@ pushd fpm_test_exe_issues
 popd
 
 pushd cpp_files
-"$fpm" test
+"$fpm" test --verbose
 popd
 
 # Test Fortran features

--- a/ci/run_tests.sh
+++ b/ci/run_tests.sh
@@ -231,10 +231,7 @@ pushd fpm_test_exe_issues
 popd
 
 pushd cpp_files
-which gcc-15
-which g++-15
-which gfortran
-"$fpm" test --verbose
+"$fpm" test 
 popd
 
 # Test Fortran features

--- a/ci/run_tests.sh
+++ b/ci/run_tests.sh
@@ -240,8 +240,7 @@ export FPM_CFLAGS="-g -O0 -fno-omit-frame-pointer"
 export FPM_LDFLAGS="-g"
 
 # Now run tests under LLDB
-fpm test \
-  --runner "lldb -o 'run' -o 'bt all' -o 'thread list' -o 'image list' -o 'quit' --"
+"$fpm" test --runner "lldb -o 'run' -o 'bt all' -o 'thread list' -o 'image list' -o 'quit' --"
 
 popd
 

--- a/ci/run_tests.sh
+++ b/ci/run_tests.sh
@@ -164,10 +164,10 @@ pushd program_with_module
 "$fpm" run --target Program_with_module
 popd
 
-pushd program_with_cpp_guarded_module
-"$fpm" build
-"$fpm" run 
-popd
+#pushd program_with_cpp_guarded_module
+#"$fpm" build
+#"$fpm" run 
+#popd
 
 pushd link_executable
 "$fpm" build
@@ -231,7 +231,18 @@ pushd fpm_test_exe_issues
 popd
 
 pushd cpp_files
-"$fpm" test 
+
+# Build with debug & no inlining so the backtrace is readable
+# Build with symbols
+export FPM_FFLAGS="-g -O0 -fbacktrace -fno-omit-frame-pointer"
+export FPM_CXXFLAGS="-g -O0 -fno-omit-frame-pointer"
+export FPM_CFLAGS="-g -O0 -fno-omit-frame-pointer"
+export FPM_LDFLAGS="-g"
+
+# Now run tests under LLDB
+fpm test \
+  --runner "lldb -o 'run' -o 'bt all' -o 'thread list' -o 'image list' -o 'quit' --"
+
 popd
 
 # Test Fortran features

--- a/ci/run_tests.sh
+++ b/ci/run_tests.sh
@@ -240,7 +240,7 @@ export FPM_CFLAGS="-g -O0 -fno-omit-frame-pointer"
 export FPM_LDFLAGS="-g"
 
 # Now run tests under LLDB
-"$fpm" test --runner "lldb -o 'run' -o 'bt all' -o 'thread list' -o 'image list' -o 'quit' --"
+"$fpm" test --verbose --runner "lldb -o 'run' -o 'bt all' -o 'thread list' -o 'image list' -o 'quit' --"
 
 popd
 

--- a/ci/run_tests.sh
+++ b/ci/run_tests.sh
@@ -231,6 +231,9 @@ pushd fpm_test_exe_issues
 popd
 
 pushd cpp_files
+which gcc-15
+which g++-15
+which gfortran
 "$fpm" test --verbose
 popd
 

--- a/ci/run_tests.sh
+++ b/ci/run_tests.sh
@@ -164,10 +164,10 @@ pushd program_with_module
 "$fpm" run --target Program_with_module
 popd
 
-#pushd program_with_cpp_guarded_module
-#"$fpm" build
-#"$fpm" run 
-#popd
+pushd program_with_cpp_guarded_module
+"$fpm" build
+"$fpm" run 
+popd
 
 pushd link_executable
 "$fpm" build
@@ -231,17 +231,7 @@ pushd fpm_test_exe_issues
 popd
 
 pushd cpp_files
-
-# Build with debug & no inlining so the backtrace is readable
-# Build with symbols
-export FPM_FFLAGS="-g -O0 -fbacktrace -fno-omit-frame-pointer"
-export FPM_CXXFLAGS="-g -O0 -fno-omit-frame-pointer"
-export FPM_CFLAGS="-g -O0 -fno-omit-frame-pointer"
-export FPM_LDFLAGS="-g"
-
-# Now run tests under LLDB
-"$fpm" test --verbose --runner "lldb -o 'run' -o 'bt all' -o 'thread list' -o 'image list' -o 'quit' --"
-
+"$fpm" test --verbose 
 popd
 
 # Test Fortran features

--- a/example_packages/cpp_files/src/cpp_files.f90
+++ b/example_packages/cpp_files/src/cpp_files.f90
@@ -6,7 +6,7 @@ module cpp_files
   public :: intvec_maxval
 
   interface
-    integer function intvec_maxval(array, n) bind(C, name = "intvec_maxval")
+    integer(c_int) function intvec_maxval(array, n) bind(C, name = "intvec_maxval")
       import :: c_int, c_size_t
       integer(c_int), intent(in) :: array(*)
       integer(c_size_t), intent(in), value :: n

--- a/src/fpm.f90
+++ b/src/fpm.f90
@@ -45,13 +45,16 @@ subroutine build_model(model, settings, package_config, error)
     type(error_t), allocatable, intent(out) :: error
 
     integer :: i, j
-    type(package_config_t), target  :: package, dependency_config, dependency
+    type(package_config_t), allocatable, target  :: package, dependency_config, dependency
     type(package_config_t), pointer :: manifest
-    type(platform_config_t) :: target_platform
+    type(platform_config_t), allocatable, target :: target_platform
     character(len=:), allocatable :: file_name, lib_dir
     logical :: has_cpp
     logical :: duplicates_found, auto_exe, auto_example, auto_test
     type(string_t) :: include_dir
+    
+    ! Large variables -> safer on heap
+    allocate(package,dependency_config,dependency,target_platform)
 
     model%package_name = package_config%name
 
@@ -472,12 +475,15 @@ end subroutine check_module_names
 subroutine cmd_build(settings)
 type(fpm_build_settings), intent(inout) :: settings
 
-type(package_config_t) :: package
-type(fpm_model_t) :: model
+type(package_config_t), allocatable :: package
+type(fpm_model_t), allocatable :: model
 type(build_target_ptr), allocatable :: targets(:)
 type(error_t), allocatable :: error
 
 integer :: i
+
+! Large variables -> safer on heap
+allocate(package, model)
 
 call get_package_data(package, "fpm.toml", error, apply_defaults=.true.)
 if (allocated(error)) then
@@ -520,8 +526,8 @@ subroutine cmd_run(settings,test)
     integer :: i, j, col_width
     logical :: found(size(settings%name))
     type(error_t), allocatable :: error
-    type(package_config_t) :: package
-    type(fpm_model_t) :: model
+    type(package_config_t), allocatable :: package
+    type(fpm_model_t), allocatable :: model
     type(build_target_ptr), allocatable :: targets(:)
     type(string_t) :: exe_cmd
     type(string_t), allocatable :: executables(:)
@@ -530,6 +536,9 @@ subroutine cmd_run(settings,test)
     integer :: run_scope,firsterror
     integer, allocatable :: stat(:),target_ID(:)
     character(len=:),allocatable :: line,run_cmd,library_path
+    
+    ! Large variables -> safer on heap
+    allocate(package,model)
 
     call get_package_data(package, "fpm.toml", error, apply_defaults=.true.)
     if (allocated(error)) then
@@ -753,10 +762,13 @@ subroutine delete_targets(settings, error)
     class(fpm_clean_settings), intent(inout) :: settings
     type(error_t), allocatable, intent(out) :: error
 
-    type(package_config_t) :: package
-    type(fpm_model_t) :: model
+    type(package_config_t), allocatable :: package
+    type(fpm_model_t), allocatable :: model
     type(build_target_ptr), allocatable :: targets(:)
     logical :: deleted_any
+    
+    ! Large variables -> safer on heap
+    allocate(package,model)
 
     ! Get package configuration
     call get_package_data(package, "fpm.toml", error, apply_defaults=.true.)
@@ -999,8 +1011,5 @@ subroutine restore_library_path(saved_path, error)
     if (.not.success) call fatal_error(error, "Cannot restore library path: "//saved_path)
 
 end subroutine restore_library_path
-
-
-
 
 end module fpm

--- a/src/fpm/manifest/preprocess.f90
+++ b/src/fpm/manifest/preprocess.f90
@@ -12,7 +12,7 @@
 
 module fpm_manifest_preprocess
    use fpm_error, only : error_t, syntax_error
-   use fpm_strings, only : string_t, operator(==)
+   use fpm_strings, only : string_t, operator(==), add_strings
    use tomlf, only : toml_table, toml_key, toml_stat
    use fpm_toml, only : get_value, get_list, serializable_t, set_value, set_list, &
                         set_string
@@ -326,31 +326,16 @@ contains
         if (.not.allocated(this%name)) this%name = that%name
 
         ! Add macros
-        if (allocated(that%macros)) then
-            if (allocated(this%macros)) then
-                this%macros = [this%macros, that%macros]
-            else
-                allocate(this%macros, source = that%macros)
-            end if
-        endif
-
+        if (allocated(that%macros)) &
+        call add_strings(this%macros, that%macros)
+            
         ! Add suffixes
-        if (allocated(that%suffixes)) then
-            if (allocated(this%suffixes)) then
-                this%suffixes = [this%suffixes, that%suffixes]
-            else
-                allocate(this%suffixes, source = that%suffixes)
-            end if
-        endif
+        if (allocated(that%suffixes)) &
+        call add_strings(this%suffixes, that%suffixes)
 
         ! Add directories
-        if (allocated(that%directories)) then
-            if (allocated(this%directories)) then
-                this%directories = [this%directories, that%directories]
-            else
-                allocate(this%directories, source = that%directories)
-            end if
-        endif
+        if (allocated(that%directories)) &
+        call add_strings(this%directories, that%directories)
 
     end subroutine add_config
 

--- a/src/fpm_compiler.F90
+++ b/src/fpm_compiler.F90
@@ -933,19 +933,22 @@ subroutine get_default_cxx_compiler(f_compiler, cxx_compiler)
 end subroutine get_default_cxx_compiler
 
 !> Check if C++ compiler is GNU-based by checking its version output
-function is_cxx_gnu_based(cxx_compiler) result(is_gnu)
-    character(len=*), intent(in) :: cxx_compiler
+function is_cxx_gnu_based(self) result(is_gnu)
+    class(compiler_t), intent(in) :: self
     logical :: is_gnu
     character(len=:), allocatable :: output_file, version_output
     integer :: stat, io
 
     is_gnu = .false.
+    
+    if (.not.allocated(self%cxx)) return
+    if (len_trim(self%cxx)<=0) return
 
     ! Get temporary file for compiler version output
     output_file = get_temp_filename()
 
     ! Run compiler with --version to get version info
-    call run(cxx_compiler//" --version > "//output_file//" 2>&1", &
+    call run(self%cxx//" --version > "//output_file//" 2>&1", &
              echo=.false., exitstat=stat)
 
     if (stat == 0) then

--- a/src/fpm_compiler.F90
+++ b/src/fpm_compiler.F90
@@ -962,6 +962,7 @@ function is_cxx_gnu_based(cxx_compiler) result(is_gnu)
                          index(version_output, 'GNU') > 0 .or. &
                          index(version_output, 'Free Software Foundation') > 0
             end if
+        end if
     end if
 
     ! Clean up temporary file

--- a/src/fpm_filesystem.F90
+++ b/src/fpm_filesystem.F90
@@ -7,7 +7,8 @@ module fpm_filesystem
                                OS_UNKNOWN, OS_LINUX, OS_MACOS, OS_WINDOWS, &
                                OS_CYGWIN, OS_SOLARIS, OS_FREEBSD, OS_OPENBSD
     use fpm_environment, only: separator, get_env, os_is_unix
-    use fpm_strings, only: f_string, replace, string_t, split, split_lines_first_last, dilate, str_begins_with_str
+    use fpm_strings, only: f_string, replace, string_t, split, split_lines_first_last, dilate, add_strings, &
+        str_begins_with_str
     use iso_c_binding, only: c_char, c_ptr, c_int, c_null_char, c_associated, c_f_pointer
     use fpm_error, only : fpm_stop, error_t, fatal_error
     implicit none
@@ -443,7 +444,7 @@ recursive subroutine list_files(dir, files, recurse)
             i = i + 1
 
             if (i > N_MAX) then
-                files = [files, files_tmp]
+                call add_strings(files, files_tmp)
                 i = 1
             end if
 
@@ -459,7 +460,7 @@ recursive subroutine list_files(dir, files, recurse)
     end if
 
     if (i > 0) then
-        files = [files, files_tmp(1:i)]
+        call add_strings(files, files_tmp(1:i))
     end if
 
     if (present(recurse)) then
@@ -470,11 +471,11 @@ recursive subroutine list_files(dir, files, recurse)
             do i=1,size(files)
                 if (c_is_dir(files(i)%s//c_null_char) /= 0) then
                     call list_files(files(i)%s, dir_files, recurse=.true.)
-                    sub_dir_files = [sub_dir_files, dir_files]
+                    call add_strings(sub_dir_files, dir_files)
                 end if
             end do
 
-            files = [files, sub_dir_files]
+            call add_strings(files, sub_dir_files)
         end if
     end if
 end subroutine list_files
@@ -531,12 +532,12 @@ recursive subroutine list_files(dir, files, recurse)
                 if (is_dir(files(i)%s)) then
 
                     call list_files(files(i)%s, dir_files, recurse=.true.)
-                    sub_dir_files = [sub_dir_files, dir_files]
+                    call add_strings(sub_dir_files, dir_files)
 
                 end if
             end do
 
-            files = [files, sub_dir_files]
+            call add_strings(files, sub_dir_files)
 
         end if
     end if

--- a/src/fpm_targets.f90
+++ b/src/fpm_targets.f90
@@ -30,7 +30,8 @@ use fpm_model
 use fpm_compiler, only : compiler_t
 use fpm_environment, only: get_os_type, OS_WINDOWS, OS_MACOS, library_filename
 use fpm_filesystem, only: dirname, join_path, canon_path
-use fpm_strings, only: string_t, operator(.in.), string_cat, fnv_1a, resize, lower, str_ends_with
+use fpm_strings, only: string_t, operator(.in.), string_cat, fnv_1a, resize, lower, str_ends_with, &
+    add_strings
 use fpm_compiler, only: get_macros
 use fpm_sources, only: get_exe_name_with_suffix
 use fpm_manifest_library, only: library_config_t
@@ -437,9 +438,9 @@ subroutine build_target_list(targets,model,library)
                     if (.not. ("stdc++" .in. model%link_libraries)) then
 
                         if (get_os_type() == OS_MACOS) then
-                            model%link_libraries = [model%link_libraries, string_t("c++")]
+                            call add_strings(model%link_libraries, string_t("c++"))
                         else
-                            model%link_libraries = [model%link_libraries, string_t("stdc++")]
+                            call add_strings(model%link_libraries, string_t("stdc++"))
                         end if
 
                     end if

--- a/src/fpm_targets.f90
+++ b/src/fpm_targets.f90
@@ -32,7 +32,7 @@ use fpm_environment, only: get_os_type, OS_WINDOWS, OS_MACOS, library_filename
 use fpm_filesystem, only: dirname, join_path, canon_path
 use fpm_strings, only: string_t, operator(.in.), string_cat, fnv_1a, resize, lower, str_ends_with, &
     add_strings
-use fpm_compiler, only: get_macros
+use fpm_compiler, only: get_macros, is_cxx_gnu_based
 use fpm_sources, only: get_exe_name_with_suffix
 use fpm_manifest_library, only: library_config_t
 use fpm_manifest_preprocess, only: preprocess_config_t
@@ -317,8 +317,8 @@ subroutine build_target_list(targets,model,library)
 
     integer :: i, j, k, n_source, exe_type
     character(:), allocatable :: exe_dir, compile_flags, lib_name
-    logical :: with_lib, monolithic, shared_lib, static_lib
-
+    logical :: with_lib, monolithic, shared_lib, static_lib, clang_cxx_backend_macos
+    
     ! Initialize targets
     allocate(targets(0))
 
@@ -327,6 +327,12 @@ subroutine build_target_list(targets,model,library)
                       j=1,size(model%packages))])
 
     if (n_source < 1) return
+    
+    if (get_os_type()==OS_MACOS) then 
+        clang_cxx_backend_macos = .not. is_cxx_gnu_based(model%compiler%cxx)
+    else
+        clang_cxx_backend_macos = .false.
+    endif
 
     with_lib = any(model%packages%has_library())
     
@@ -436,10 +442,12 @@ subroutine build_target_list(targets,model,library)
 
                     !> Add stdc++ as a linker flag. If not already there.
                     if (.not. ("stdc++" .in. model%link_libraries)) then
-
-                        if (get_os_type() == OS_MACOS) then
+                        
+                        if (clang_cxx_backend_macos) then
+                            ! On macOS with non-GNU C++ compiler (e.g., Clang), use "c++"
                             call add_strings(model%link_libraries, string_t("c++"))
                         else
+                            ! For GNU C++ compiler or non-macOS systems, use "stdc++"
                             call add_strings(model%link_libraries, string_t("stdc++"))
                         end if
 
@@ -1010,7 +1018,7 @@ subroutine prune_build_targets(targets, root_package, prune_unused_objects)
 
                 if (.not.(target%source%modules_provided(j)%s .in. modules_used)) then
 
-                    modules_used = [modules_used, target%source%modules_provided(j)]
+                    call add_strings(modules_used, target%source%modules_provided(j))
 
                 end if
 
@@ -1295,7 +1303,7 @@ contains
 
                 ! Add dependency object file to link object list
                 temp_str%s = dep%output_file
-                link_objects = [link_objects, temp_str]
+                call add_strings(link_objects, temp_str)
                 
                 ! For executable objects, also need to include non-library
                 !  dependencies from dependencies (recurse)
@@ -1324,7 +1332,7 @@ subroutine add_include_build_dirs(model, targets)
             if (target%target_type /= FPM_TARGET_OBJECT) cycle
             if (target%output_dir .in. build_dirs) cycle
             temp%s = target%output_dir
-            build_dirs = [build_dirs, temp]
+            call add_strings(build_dirs, temp)
         end associate
     end do
 
@@ -1356,7 +1364,7 @@ subroutine get_library_dirs(model, targets, shared_lib_dirs)
             if (all(target%target_type /= [FPM_TARGET_SHARED,FPM_TARGET_ARCHIVE])) cycle
             if (target%output_dir .in. shared_lib_dirs) cycle
             temp = string_t(target%output_dir)
-            shared_lib_dirs = [shared_lib_dirs, temp]
+            call add_strings(shared_lib_dirs, temp)
         end associate
     end do
     

--- a/src/fpm_targets.f90
+++ b/src/fpm_targets.f90
@@ -1519,8 +1519,8 @@ subroutine library_targets_to_deps(model, targets, target_ID)
     integer, allocatable, intent(out)        :: target_ID(:)
 
     integer :: it, ip, n
-
-    n = size(model%deps%dep)
+    
+    n = model%deps%ndep
     allocate(target_ID(n), source=0)
 
     do it = 1, size(targets)

--- a/src/fpm_targets.f90
+++ b/src/fpm_targets.f90
@@ -329,7 +329,7 @@ subroutine build_target_list(targets,model,library)
     if (n_source < 1) return
     
     if (get_os_type()==OS_MACOS) then 
-        clang_cxx_backend_macos = .not. is_cxx_gnu_based(model%compiler%cxx)
+        clang_cxx_backend_macos = .not. is_cxx_gnu_based(model%compiler)
     else
         clang_cxx_backend_macos = .false.
     endif

--- a/src/metapackage/fpm_meta_util.f90
+++ b/src/metapackage/fpm_meta_util.f90
@@ -1,7 +1,7 @@
 module fpm_meta_util
     use fpm_meta_base, only: metapackage_t, destroy
     use fpm_filesystem, only: join_path
-    use fpm_strings, only: split, string_t, str_begins_with_str
+    use fpm_strings, only: split, string_t, str_begins_with_str, add_strings
     use fpm_error, only: error_t
     use fpm_versioning, only: new_version
     use fpm_pkg_config, only: pkgcfg_get_libs, pkgcfg_get_build_flags, pkgcfg_get_version
@@ -12,11 +12,6 @@ module fpm_meta_util
 
     public :: add_pkg_config_compile_options, lib_get_trailing, add_strings
     
-    interface add_strings
-        module procedure add_strings_one
-        module procedure add_strings_many
-    end interface add_strings
-
     contains
 
     !> Add pkgconfig compile options to a metapackage
@@ -124,56 +119,5 @@ module fpm_meta_util
         end if
 
     end subroutine lib_get_trailing
-    
-    !> Add one element to a string array with a loop (gcc-15 bug on array initializer)
-    pure subroutine add_strings_one(list,new)
-        type(string_t), allocatable, intent(inout) :: list(:)
-        type(string_t), intent(in) :: new
-
-        integer :: i,n
-        type(string_t), allocatable :: tmp(:)
-
-        if (allocated(list)) then 
-           n = size(list)
-        else
-           n = 0
-        endif     
-
-        allocate(tmp(n+1))
-        do i=1,n
-           tmp(i) = list(i)
-        end do   
-        tmp(n+1) = new
-        call move_alloc(from=tmp,to=list)
-
-    end subroutine add_strings_one       
-    
-    !> Add elements to a string array with a loop (gcc-15 bug on array initializer)
-    pure subroutine add_strings_many(list,new)
-        type(string_t), allocatable, intent(inout) :: list(:)
-        type(string_t), intent(in) :: new(:)
-
-        integer :: i,n,add
-        type(string_t), allocatable :: tmp(:)
-
-        if (allocated(list)) then 
-           n = size(list)
-        else
-           n = 0
-        endif     
-
-        add = size(new)
-        if (add<=0) return
-
-        allocate(tmp(n+add))
-        do i=1,n
-           tmp(i) = list(i)
-        end do   
-        do i=1,add
-           tmp(n+i) = new(i)
-        end do   
-        call move_alloc(from=tmp,to=list)
-
-    end subroutine add_strings_many     
     
 end module fpm_meta_util

--- a/src/metapackage/fpm_meta_util.f90
+++ b/src/metapackage/fpm_meta_util.f90
@@ -45,7 +45,7 @@ module fpm_meta_util
                 current_lib = string_t(libs(i)%s(3:))
                 if (len_trim(current_lib%s) == 0) cycle
                 this%has_link_libraries = .true.
-                this%link_libs = [this%link_libs, current_lib]
+                call add_strings(this%link_libs, current_lib)
             else ! -L and others: concatenate
                 this%has_link_flags = .true.
                 this%link_flags = string_t(trim(this%link_flags%s)//' '//libs(i)%s)
@@ -68,7 +68,7 @@ module fpm_meta_util
                 current_include_dir = string_t(flags(i)%s(len(include_flag)+1:))
                 if (len_trim(current_include_dir%s) == 0) cycle
                 this%has_include_dirs = .true.
-                this%incl_dirs = [this%incl_dirs, current_include_dir]
+                call add_strings(this%incl_dirs, current_include_dir)
             else
                 this%has_build_flags = .true.
                 this%flags = string_t(trim(this%flags%s)//' '//flags(i)%s)


### PR DESCRIPTION
 Enable GCC 15 support in CI with necessary fixes for compiler compatibility issues.

  - **CI Changes**: Add GCC 15 to CI matrix (macOS only due to availability constraints)
  - **GCC 15 Bug Fixes**:
    - Replace array constructors with explicit loops in `add_strings` utilities to work around gfortran-15 stack overflow issues
    - Move large stack variables to heap allocation to prevent stack overflow crashes
    - Fix C++ interface compatibility with proper `c_int` types
  - **Compiler Detection**: Add GNU vs Clang C++ backend detection for proper linking on macOS