### PR TITLE
Fix: deallocate  in metapackage_t destroy()

### DIFF
--- a/src/metapackage/fpm_meta_base.f90
+++ b/src/metapackage/fpm_meta_base.f90
@@ -91,6 +91,7 @@ module fpm_meta_base
         if (allocated(this%link_libs)) deallocate(this%link_libs)
         if (allocated(this%incl_dirs)) deallocate(this%incl_dirs)
         if (allocated(this%external_modules)) deallocate(this%external_modules)
+        if (allocated(this%dependency)) deallocate(this%dependency) 
     end subroutine destroy
 
     !> Resolve metapackage dependencies into the command line settings


### PR DESCRIPTION
This PR fixes a runtime error caused by attempting to allocate an already allocated variable in the `init_minpack` subroutine.

The root cause was that the `destroy(this)` subroutine of in _fpm_meta_base.f90_ did not deallocate the `dependency` allocatable array that was previously allocated in the subroutine `init_stdlib`, which led to a double-allocation error when calling `allocate(this%dependency(1))` inside `init_minpack`.
