### PR TITLE
feat: Add support for 'fortran-standard' in fpm.toml

### DIFF
--- a/src/fpm.f90
+++ b/src/fpm.f90
@@ -63,6 +63,10 @@ subroutine build_model(model, settings, package_config, error)
     ! Set target OS to current OS (may be extended for cross-compilation in the future)
     model%target_os = get_os_type()
 
+    if (allocated(package_config%fortran_standard)) then
+        model%fortran_standard = package_config%fortran_standard
+    end if
+
     allocate(model%include_dirs(0))
     allocate(model%link_libraries(0))
     allocate(model%external_modules(0))
@@ -391,6 +395,14 @@ subroutine new_compiler_flags(model, settings, package)
     model%c_compile_flags       = assemble_flags(settings%cflag,   package%c_flags)
     model%cxx_compile_flags     = assemble_flags(settings%cxxflag, package%cxx_flags)
     model%link_flags            = assemble_flags(settings%ldflag,  package%link_time_flags)
+
+    if (allocated(package%fortran_standard)) then
+        ! Check if the compiler name contains "gfortran"
+        if (index(model%compiler%fc, "gfortran") > 0) then
+             model%fortran_compile_flags = model%fortran_compile_flags // &
+                                           " -std=f" // package%fortran_standard
+        end if
+    end if
 
 end subroutine new_compiler_flags
 

--- a/src/fpm/manifest/package.f90
+++ b/src/fpm/manifest/package.f90
@@ -76,6 +76,7 @@ module fpm_manifest_package
         character(len=:), allocatable :: author
         character(len=:), allocatable :: maintainer
         character(len=:), allocatable :: copyright
+        character(len=:), allocatable :: fortran_standard
 
         !> Additional feature collections beyond the default package feature
         type(feature_collection_t), allocatable :: features(:)
@@ -167,6 +168,7 @@ contains
         call get_value(table, "author", self%author)
         call get_value(table, "maintainer", self%maintainer)
         call get_value(table, "copyright", self%copyright)
+        call get_value(table, "fortran-standard", self%fortran_standard)
 
         ! Initialize shared feature components
         call init_feature_components(self%feature_config_t, table, root=root, error=error)
@@ -260,6 +262,7 @@ contains
                 name_present = .true.
 
             case("version", "license", "author", "maintainer", "copyright", &
+                    & "fortran-standard", &
                     & "description", "keywords", "categories", "homepage", "build", &
                     & "dependencies", "dev-dependencies", "profiles", "features", "test", "executable", &
                     & "example", "library", "install", "extra", "preprocess", "fortran")
@@ -404,6 +407,10 @@ contains
             if (allocated(this%copyright)) then
                 if (.not.this%copyright==other%copyright) return
             end if
+            if (allocated(this%fortran_standard).neqv.allocated(other%fortran_standard)) return
+            if (allocated(this%fortran_standard)) then
+                if (.not.this%fortran_standard==other%fortran_standard) return
+            end if
             if (allocated(this%profiles).neqv.allocated(other%profiles)) return
             if (allocated(this%profiles)) then
                 if (.not.size(this%profiles)==size(other%profiles)) return
@@ -453,6 +460,8 @@ contains
        call set_string(table, "maintainer", self%maintainer, error, class_name)
        if (allocated(error)) return
        call set_string(table, "copyright", self%copyright, error, class_name)
+       if (allocated(error)) return
+       call set_string(table, "fortran-standard", self%fortran_standard, error, class_name)
        if (allocated(error)) return
 
        if (allocated(self%profiles)) then

--- a/src/fpm_model.f90
+++ b/src/fpm_model.f90
@@ -227,6 +227,9 @@ type, extends(serializable_t) :: fpm_model_t
     !> Target operating system
     integer :: target_os = OS_ALL
 
+    !> User-specified Fortran standard (e.g., "2018")
+    character(:), allocatable :: fortran_standard
+
     contains
     
         !> Get target link flags


### PR DESCRIPTION
This PR implements the fortran-standard field in the [package] table (addresses Issue #1131).

Summary: Users can now specify the Fortran standard (e.g., 2018, 2008) in fpm.toml. This value is passed to the compiler using the appropriate flag (currently implemented for GFortran as -std=f<year>).

Changes:
- src/fpm/manifest/package.f90: Added fortran_standard to package_config_t and updated parser/dump logic.
- src/fpm_model.f90: Added fortran_standard to fpm_model_t.
- src/fpm.f90:
-    Updated build_model to copy the standard from manifest to model.
-    Updated new_compiler_flags to append -std=f<year> when using GFortran.

Testing:
- Created a test project with fortran-standard = "2018".
- Verified via fpm build --verbose that the flag -std=f2018 was passed to gfortran.