### PR TITLE
perf: optimize source parsing with insert_lines

### DIFF
--- a/src/fpm_source_parsing.f90
+++ b/src/fpm_source_parsing.f90
@@ -260,6 +260,10 @@ pure subroutine insert_lines(array, chunk, at_line)
 
     n = size(array)
     m = size(chunk)
+
+    ! Bounds check: at_line must be in valid range [1, n]
+    if (at_line < 1 .or. at_line > n) return
+
     new_size = n - 1 + m  ! Remove 1 line, add m lines
 
     allocate(new_array(new_size))


### PR DESCRIPTION
## Summary
- Replace O(n²) `append_line`/`append_lines` with O(k) `insert_lines` approach where k = number of include directives
- Issue only affected C preprocessor macro parsing in large source files

Was correctly reported by @jvdp1 in https://github.com/fortran-lang/fpm/pull/1218#issuecomment-3710155327

## Performance
Measured **17-28x speedup** on `metapackage_stdlib`:

| Metric | Before | After |
|--------|--------|-------|
| User time | 84.94s | 2.98s |
| Total time | 1:28.36 | 5.30s |