### PR TITLE
ci: add macOS ARM64 and Intel x86_64 release artifacts

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-14, windows-latest]
+        os: [ubuntu-latest, macos-14, macos-15-intel, windows-latest]
         toolchain:
           - {compiler: gcc, version: 10}
           - {compiler: gcc, version: 11}
@@ -37,6 +37,10 @@ jobs:
             toolchain: {compiler: intel, version: '2025.2'}
           - os: macos-14  # gcc@10 not available on macos-14 (ARM64)
             toolchain: {compiler: gcc, version: 10}
+          - os: macos-15-intel  # Intel compiler not available on macOS
+            toolchain: {compiler: intel, version: '2025.2'}
+          - os: macos-15-intel  # gcc@10 not available on macos-15
+            toolchain: {compiler: gcc, version: 10}
           - os: windows-latest  # Doesn't pass build and tests yet
             toolchain: {compiler: intel, version: '2025.2'}
           - os: windows-latest  # gcc 14 not available on Windows yet
@@ -50,6 +54,9 @@ jobs:
             os-arch: linux-x86_64
             release-flags: --flag '--static -g -fbacktrace -O3'
           - os: macos-14
+            os-arch: macos-arm64
+            release-flags: --flag '-g -fbacktrace -O3'
+          - os: macos-15-intel
             os-arch: macos-x86_64
             release-flags: --flag '-g -fbacktrace -O3'
           - os: windows-latest


### PR DESCRIPTION
- Add `macos-15-intel` runner for Intel x86_64 builds
- Fix `macos-14` os-arch from `macos-x86_64` to `macos-arm64`

This ensures that releases will include properly labeled binaries for both macOS architectures:
- `fpm-VERSION-macos-arm64-gcc-12` (Apple Silicon)
- `fpm-VERSION-macos-x86_64-gcc-12` (Intel)

Fixes #1210