### PR TITLE
fix: check before passing unallocated struct member in string concat

### DIFF
--- a/src/fpm_targets.f90
+++ b/src/fpm_targets.f90
@@ -505,7 +505,12 @@ subroutine build_target_list(targets,model,library)
                        case default
                             compile_flags = ""
                     end select
-                    target%compile_flags = target%compile_flags//' '//compile_flags
+
+                    if (allocated(target%compile_flags)) then
+                        target%compile_flags = target%compile_flags//' '//compile_flags
+                    else
+                        target%compile_flags = ' '//compile_flags                        
+                    end if
 
                     ! Executable depends on object
                     call add_dependency(target, targets(size(targets)-1)%ptr)
@@ -1132,8 +1137,10 @@ subroutine resolve_target_linking(targets, model, library, error)
                case (FPM_TARGET_CPP_OBJECT)
                    target%compile_flags = target%compile_flags//model%cxx_compile_flags
                case default
-                   target%compile_flags = target%compile_flags//model%fortran_compile_flags &
-                                        & // get_feature_flags(model%compiler, target%features)
+                    if (allocated(model%fortran_compile_flags)) then
+                        target%compile_flags = target%compile_flags//model%fortran_compile_flags
+                    end if
+                   target%compile_flags = target%compile_flags // get_feature_flags(model%compiler, target%features)
             end select
 
             !> Get macros as flags.
@@ -1230,7 +1237,11 @@ subroutine resolve_target_linking(targets, model, library, error)
 
                     call get_link_objects(target%link_objects,target,is_exe=.true.)
 
-                    target%link_flags = model%link_flags//" "//string_cat(target%link_objects," ")
+                    if (allocated(model%link_flags)) then
+                        target%link_flags = model%link_flags//" "//string_cat(target%link_objects," ")
+                    else 
+                        target%link_flags = " "//string_cat(target%link_objects," ")
+                    end if
                     
                     ! Add shared libs
                     if (.not.monolithic) then 


### PR DESCRIPTION
<img width="1083" height="286" alt="image" src="https://github.com/user-attachments/assets/a9980d63-5243-4094-9f41-1fcd5c91fd1b" />

<img width="1106" height="581" alt="image" src="https://github.com/user-attachments/assets/1b27b7ca-e2e5-41e5-9503-85c36a3be712" />

This PR fixes an instance of invalid Fortran code where an allocatable character component is referenced while unallocated during string concatenation. For eg.
`target%compile_flags = target%compile_flags // ' ' // compile_flags`

If target%compile_flags is unallocated, this code is not standard-conforming. Although automatic allocation on assignment is permitted for allocatable variables on the left-hand side, the right-hand side expression must be fully evaluated before allocation occurs.

Referencing an unallocated allocatable variable during expression evaluation is prohibited by the Fortran standard:
5.4.10 p2: “An unallocated allocatable variable shall not be referenced or defined.”
10.2.1.1: the right-hand side of an intrinsic assignment is evaluated prior to any automatic allocation.
9.7.1.3: automatic allocation applies only after expression evaluation.
10.1.5.3: the // operator requires both operands to be referenced to obtain their values.