### PR TITLE
fix: ensure installed binaries have executable permissions

### DIFF
--- a/src/fpm/installer.f90
+++ b/src/fpm/installer.f90
@@ -217,8 +217,6 @@ contains
     ! on MacOS, add two relative paths for search of dynamic library dependencies: 
     add_rpath: if (self%os==OS_MACOS) then  
         
-        ! exe_path is already calculated above
-        
         ! First path: for bin/lib/include structure
         cmd = "install_name_tool -add_rpath @executable_path/../lib " // exe_path
         call self%run(cmd, error)

--- a/src/fpm_filesystem.F90
+++ b/src/fpm_filesystem.F90
@@ -1279,6 +1279,9 @@ end subroutine os_delete_dir
 #else
         ! Fallback using shell command
         call run("chmod +x " // filename, echo=.false., verbose=.false., exitstat=stat)
+        if (stat /= 0) then
+            write(stderr, *) "Warning: Failed to set executable permissions on: ", filename
+        end if
 #endif
 
     end subroutine set_executable

--- a/test/fpm_test/test_filesystem.f90
+++ b/test/fpm_test/test_filesystem.f90
@@ -2,7 +2,8 @@ module test_filesystem
     use testsuite, only: new_unittest, unittest_t, error_t, test_failed
     use fpm_filesystem, only: canon_path, is_dir, mkdir, os_delete_dir, &
                               join_path, is_absolute_path, get_home, &
-                              delete_file, read_lines, get_temp_filename
+                              delete_file, read_lines, get_temp_filename, &
+                              set_executable, filewrite, exists
     use fpm_environment, only: OS_WINDOWS, get_os_type, os_is_unix
     use fpm_strings, only: string_t, split_lines_first_last
     implicit none
@@ -24,7 +25,8 @@ contains
             & new_unittest("test-is-absolute-path", test_is_absolute_path), &
             & new_unittest("test-get-home", test_get_home), &
             & new_unittest("test-split-lines-first-last", test_split_lines_first_last), &
-            & new_unittest("test-crlf-lines", test_dir_with_crlf) &
+            & new_unittest("test-crlf-lines", test_dir_with_crlf), &
+            & new_unittest("test-set-executable", test_set_executable) &
             ]
 
     end subroutine collect_filesystem
@@ -428,6 +430,41 @@ contains
         1 format("Failed reading file with CRLF: ",a,:,i0,:,a,:,i0)
         
     end subroutine test_dir_with_crlf
+
+    ! Test for set_executable
+    subroutine test_set_executable(error)
+        type(error_t), allocatable, intent(out) :: error
+        character(len=:), allocatable :: temp_file
+        integer :: stat
+        
+        ! 1. Setup: Create a dummy file
+        temp_file = "test_exec_perm.txt"
+        call filewrite(temp_file, [character(len=13) :: "dummy content"])
+
+        if (.not. exists(temp_file)) then
+             call test_failed(error, "Setup failed: Could not create temp file")
+             return
+        end if
+
+        ! 2. Action: Call the function
+        call set_executable(temp_file)
+
+        ! 3. Assertion: Verify permissions
+        if (os_is_unix()) then
+            ! 'test -x' returns 0 if executable, 1 if not
+           call execute_command_line("test -x " // temp_file, exitstat=stat)
+            
+            if (stat /= 0) then
+                call test_failed(error, "Test Failed: File was not made executable on Unix")
+                ! Attempt cleanup before returning
+                call delete_file(temp_file)
+                return
+            end if
+        end if
+        
+        call delete_file(temp_file)
+
+    end subroutine test_set_executable
     
 
 end module test_filesystem


### PR DESCRIPTION
Fixes #314 

This PR fixes an issue where binaries installed via `fpm install` (or `./install.sh`) did not have the executable bit set (resulting in `rw-r--r--`), requiring users to manually run `chmod +x`.

**Changes Implemented**

* **`src/fpm_filesystem.F90`**: Added a `set_executable` subroutine.
* It uses `c_chmod` (via `iso_c_binding`) for standard builds (efficient and standard).
* Includes a fallback to shell `chmod +x` for the bootstrap phase (`#ifdef FPM_BOOTSTRAP`).
* Includes an `os_is_unix()` check to ensure it only runs on relevant platforms (no-op on Windows).

**Testing**
Created a new project (`fpm new test_perms`), installed it, and verified via `ls -l` that the resulting binary in `~/.local/bin` (or prefix) has `-rwxr-xr-x` permissions.

```
test_perms [ master][?][🅵  9.4.0][🅒 lf]
❯ fpm install --prefix ./inst
 + mkdir -p build/dependencies
test_perms.f90                         done.
libtest_perms.a                        done.
main.f90                               done.
test_perms                             done.
[100%] Project compiled successfully.
 + mkdir -p ./inst/bin
# Update: build/gfortran_A86CEF2075723C1E/app/test_perms -> ./inst/bin

test_perms [ master][?][🅵  9.4.0][🅒 lf]
❯ ls -l inst/bin/test_perms
-rwxr-xr-x 1 anas anas 16912 Jan 22 17:42 inst/bin/test_perms
```

* **Regression Testing:** Ran the full test suite via `fpm test`. All 35 tests PASSED.