### PR TITLE
Add FlexiBLAS to the BLAS meta package.

### DIFF
--- a/src/metapackage/fpm_meta_blas.f90
+++ b/src/metapackage/fpm_meta_blas.f90
@@ -26,7 +26,7 @@ contains
         integer :: i
         character(len=:), allocatable :: include_flag, libdir
         character(*), parameter :: candidates(*) = &
-                                   [character(20) :: 'mkl-dynamic-lp64-tbb', 'flexiblas', 'openblas', 'blas']
+                                   [character(20) :: 'mkl-dynamic-lp64-tbb', 'openblas', 'blas', 'flexiblas']
 
         include_flag = get_include_flag(compiler, "")
 


### PR DESCRIPTION
FlexiBLAS (https://github.com/mpimd-csc/flexiblas) is the default BLAS on Fedora and RHEL, thus it should be searched as well.