### PR TITLE
Fix stack overflow risk in split_<lines_>first_last

### DIFF
--- a/src/fpm_strings.f90
+++ b/src/fpm_strings.f90
@@ -535,10 +535,11 @@ pure subroutine split_first_last(string, set, first, last)
     integer, allocatable, intent(out) :: first(:)
     integer, allocatable, intent(out) :: last(:)
 
-    integer, dimension(len(string) + 1) :: istart, iend
+    integer, allocatable, dimension(:) :: istart, iend
     integer :: p, n, slen
 
     slen = len(string)
+    allocate(istart(slen + 1), iend(slen + 1))
 
     n = 0
     if (slen > 0) then
@@ -565,12 +566,13 @@ pure subroutine split_lines_first_last(string, first, last)
     integer, allocatable, intent(out) :: first(:)
     integer, allocatable, intent(out) :: last(:)
 
-    integer, dimension(len(string) + 1) :: istart, iend
+    integer, allocatable, dimension(:) :: istart, iend
     integer :: p, n, slen
     character, parameter :: CR = achar(13)
     character, parameter :: LF = new_line('A')
 
     slen = len(string)
+    allocate(istart(slen + 1), iend(slen + 1))
 
     n = 0
     if (slen > 0) then


### PR DESCRIPTION
### PR Description

Fix stack overflow risk in `split_first_last` and `split_lines_first_last` subroutines by replacing automatic stack arrays with heap-allocated allocatable arrays.

### Detailed Explanation

This patch addresses a potential segmentation fault (stack overflow) issue in the string splitting subroutines `split_first_last` and `split_lines_first_last`:
- **Problem**: The original code used automatic local arrays (`integer, dimension(len(string) + 1)`) allocated on the stack. For very long input strings ([`M_CLI2.f90`](https://github.com/urbanjost/M_CLI2/blob/master/src/M_CLI2.F90), len(content)=230k), this could exceed the stack size limit (typically a few MB) and trigger a segmentation fault.
- **Solution**: 
  1. Replace automatic stack arrays (`istart`, `iend`) with allocatable arrays (`integer, allocatable, dimension(:)`)
  2. Explicitly allocate these arrays on the heap using `allocate(istart(slen + 1), iend(slen + 1))` (matching the original size logic but using heap memory instead of stack, and eliminating stack overflow risk for large input strings.)

### Related Topics

This problem may occurs with fpm of O2/O3 optimization, and Discussion ["MSYS2 fpm compilation"](https://fortran-lang.discourse.group/t/msys2-fpm-compilation/10714) may be related to this fix.