### PR TITLE
fix: resolve MPI linker group issues and propagate library search paths

### DIFF
--- a/src/fpm_targets.f90
+++ b/src/fpm_targets.f90
@@ -1100,6 +1100,17 @@ subroutine resolve_target_linking(targets, model, library, error)
             global_link_flags = model%compiler%enumerate_libraries(global_link_flags, model%link_libraries)
         end if
     end if
+
+    ! Extract -L library search paths from C/C++ compile flags so that the
+    ! Fortran linker can find libraries specified via link_libraries.
+    ! This handles the case where users pass -L paths via --cxx-flag or --c-flag
+    ! but link_libraries (from fpm.toml [build] link) are resolved at link time.
+    if (allocated(model%cxx_compile_flags)) then
+        global_link_flags = global_link_flags // extract_library_paths(model%cxx_compile_flags)
+    end if
+    if (allocated(model%c_compile_flags)) then
+        global_link_flags = global_link_flags // extract_library_paths(model%c_compile_flags)
+    end if
     
     allocate(character(0) :: global_include_flags)
     if (allocated(model%include_dirs)) then
@@ -1616,5 +1627,38 @@ subroutine add_target_ptr_many(list,new)
     call move_alloc(from=tmp,to=list)
 
 end subroutine add_target_ptr_many
+
+
+!> Extract -L library search path flags from a flags string.
+!> This allows -L paths specified in C/C++ flags to be propagated
+!> to the Fortran linker when linking executables.
+function extract_library_paths(flags) result(paths)
+    character(*), intent(in) :: flags
+    character(:), allocatable :: paths
+
+    integer :: i, j, n
+
+    allocate(character(0) :: paths)
+    n = len_trim(flags)
+    i = 1
+
+    do while (i <= n - 1)
+        ! Look for -L followed by a path
+        if (flags(i:i+1) == '-L') then
+            ! Find the end of this flag (next space or end of string)
+            j = i + 2
+            do while (j <= n .and. flags(j:j) /= ' ')
+                j = j + 1
+            end do
+            ! Append this -L flag
+            paths = paths // ' ' // flags(i:j-1)
+            i = j
+        else
+            i = i + 1
+        end if
+    end do
+
+end function extract_library_paths
+
 
 end module fpm_targets

--- a/src/metapackage/fpm_meta_mpi.f90
+++ b/src/metapackage/fpm_meta_mpi.f90
@@ -586,7 +586,7 @@ contains
 
         ! Request to use libs in arbitrary order
         if (this%has_link_flags .and. compiler%is_gnu() .and. os_is_unix() .and. get_os_type()/=OS_MACOS) then
-            this%link_flags = string_t(' -Wl,--start-group '//this%link_flags%s)
+            this%link_flags = string_t(' -Wl,--start-group '//this%link_flags%s//' -Wl,--end-group')
         end if
 
         ! Add language-specific flags


### PR DESCRIPTION
This PR resolves the linking failures reported in #1226, specifically for projects using external C++ dependencies like libtorch.

**Key Fixes:**
- **MPI Grouping**: Added the missing `-Wl,--end-group` in `src/metapackage/fpm_meta_mpi.f90`. Previously, the unclosed group caused the linker to incorrectly wrap subsequent libraries into the circular dependency search, leading to resolution errors.
- **Flag Propagation**: Added logic in `src/fpm_targets.f90`to extract `-L` search paths from `c-flags` and `cxx-flags`. This ensures these paths are actually passed to the Fortran linker during the executable link step, which was previously missing.

**Testing:**
- Added and verified a new internal helper `extract_library_paths` with various inputs (single/multiple paths, no paths, and trailing flags).
- Ran `fpm test` and verified standard builds to ensure no regressions in core dependency handling.

Closes #1226