### PR TITLE
Improve diagnostics when command execution fails in run()

### DIFF
--- a/src/fpm_filesystem.F90
+++ b/src/fpm_filesystem.F90
@@ -1052,6 +1052,10 @@ subroutine run(cmd,echo,exitstat,verbose,redirect)
 
     end if
 
+    if (.not. present(exitstat) .and. stat /= 0) then
+        write(stderr,'(a,i0)') '<ERROR>: command '//cmd//redirect_str//' returned status code ', stat
+    end if
+
     if (present(exitstat)) then
         exitstat = stat
     elseif (stat /= 0) then


### PR DESCRIPTION
Summary
Improve diagnostics when commands executed via `run` fail.

Changes

* Print an error message when a command returns a non-zero exit status and `exitstat` is not present
* Preserve existing API behavior and control flow
* Print diagnostics to stderr for consistency

This prevents silent command failures and improves debugging during builds.

Fixes #1262 