### PR TITLE
fix(help_test): correct pack source for book2 filtering

### DIFF
--- a/test/help_test/help_test.f90
+++ b/test/help_test/help_test.f90
@@ -118,7 +118,7 @@ integer :: length
    call swallow('fpm_scratch_manual.txt',book2)
    ! get rid of lines from run() which is not on stderr at the moment
    book1=pack(book1,index(book1,' + build/')==0)
-   book2=pack(book1,index(book2,' + build/')==0)
+   book2=pack(book2,index(book2,' + build/')==0)
    write(*,*)'<INFO>book1 ',size(book1), len(book1)
    write(*,*)'<INFO>book2 ',size(book2), len(book2)
    if(size(book1)/=size(book2))then


### PR DESCRIPTION
## What

Fix incorrect source array used when filtering `book2` in `test/help_test/help_test.f90`.

## Problem

The existing implementation uses:

```fortran
book2 = pack(book1, index(book2, ' + build/') == 0)
```

This applies a mask derived from `book2` to `book1`, which can mix data between the two arrays before comparison.

## Fix

Update the line to:

```fortran
book2 = pack(book2, index(book2, ' + build/') == 0)
```

so that filtering is applied to the correct source array.

## Impact

This ensures book2 is filtered from its own content before comparison, preventing unintended data mixing with book1.

Closes #1269 