### PR TITLE
Fix parsing of USE statements with inline comments without whitespace

### DIFF
--- a/src/fpm_source_parsing.f90
+++ b/src/fpm_source_parsing.f90
@@ -790,7 +790,20 @@ function parse_f_source(f_filename,error,preprocess) result(f_source)
             end if
 
             ! Process 'USE' statements
-            call parse_use_statement(f_filename,i,file_lines_lower(i)%s,using,intrinsic_module,mod_name,error)
+            block
+                character(:), allocatable :: line_for_parsing
+                integer :: comment_pos
+
+                comment_pos = index(file_lines_lower(i)%s, '!')
+                if (comment_pos > 0) then
+                    line_for_parsing = trim(file_lines_lower(i)%s(1:comment_pos-1))
+                else
+                    line_for_parsing = file_lines_lower(i)%s
+                end if
+
+                call parse_use_statement(f_filename,i,line_for_parsing,using,&
+                                        intrinsic_module,mod_name,error)
+            end block
             if (allocated(error)) return
 
             if (using) then

--- a/test/fpm_test/test_source_parsing.f90
+++ b/test/fpm_test/test_source_parsing.f90
@@ -24,6 +24,7 @@ contains
 
         testsuite = [ &
             & new_unittest("modules-used", test_modules_used), &
+            & new_unittest("modules-used-inline-comment", test_modules_used_inline_comment), &
             & new_unittest("intrinsic-modules-used", test_intrinsic_modules_used), &
             & new_unittest("nonintrinsic-modules-used", test_nonintrinsic_modules_used), &
             & new_unittest("include-stmt", test_include_stmt), &
@@ -137,6 +138,44 @@ contains
         call f_source%test_serialization('srcfile_t: serialization', error)
 
     end subroutine test_modules_used
+
+
+    !> Regression test: inline comments should not break module extraction
+    subroutine test_modules_used_inline_comment(error)
+
+        !> Error handling
+        type(error_t), allocatable, intent(out) :: error
+
+        integer :: unit
+        character(:), allocatable :: temp_file
+        type(srcfile_t), allocatable :: f_source
+
+        allocate(temp_file, source=get_temp_filename())
+
+        open(file=temp_file, newunit=unit)
+        write(unit, '(a)') &
+            & 'program test', &
+            & ' use utilities_mod!comment', &
+            & ' implicit none', &
+            & 'end program test'
+        close(unit)
+
+        f_source = parse_f_source(temp_file,error)
+        if (allocated(error)) then
+            return
+        end if
+
+        if (size(f_source%modules_used) /= 1) then
+            call test_failed(error,'Incorrect number of modules_used - expecting one')
+            return
+        end if
+
+        if (.not.('utilities_mod' .in. f_source%modules_used)) then
+            call test_failed(error,'Missing module in modules_used')
+            return
+        end if
+
+    end subroutine test_modules_used_inline_comment
 
 
     !> Check that intrinsic modules are properly ignore


### PR DESCRIPTION
**Description:**

Closes #1271

This fixes an issue where `USE` statements are parsed incorrectly when an inline comment is attached directly to the module name without a space.

For example:
`use utilities_mod!comment`

Previously, this was parsed as `utilities_mod!comment`, which is not a valid Fortran identifier. As a result, the dependency was skipped and could lead to build failures.

The fix strips inline comments (everything after `!`) and trims the line before passing it to `parse_use_statement`. This ensures the module name is extracted correctly.

Tested cases include:

* `use utilities_mod`
* `use utilities_mod ! comment`
* `use utilities_mod!comment`
* `use utilities_mod, only: x, y ! comment`

All valid cases now work correctly, and invalid inputs fail gracefully without crashes.

No regressions were observed.