### PR TITLE
Fix false intrinsic module detection for substring matches in USE parsing

### DIFF
--- a/src/fpm_source_parsing.f90
+++ b/src/fpm_source_parsing.f90
@@ -1334,8 +1334,8 @@ subroutine parse_use_statement(f_filename,i,line,use_stmt,is_intrinsic,module_na
 
     end if have_colons
 
-    ! If declared intrinsic, check that it is true
-    has_intrinsic_name = any([(index(module_name,trim(INTRINSIC_NAMES(j)))>0, &
+    ! If declared intrinsic, check that it exactly matches a known intrinsic module name
+    has_intrinsic_name = any([(trim(lower(module_name)) == trim(INTRINSIC_NAMES(j)), &
                              j=1,size(INTRINSIC_NAMES))])
     if (intr>0 .and. .not.has_intrinsic_name) then
 

--- a/test/fpm_test/test_source_parsing.f90
+++ b/test/fpm_test/test_source_parsing.f90
@@ -26,6 +26,7 @@ contains
             & new_unittest("modules-used", test_modules_used), &
             & new_unittest("modules-used-inline-comment", test_modules_used_inline_comment), &
             & new_unittest("intrinsic-modules-used", test_intrinsic_modules_used), &
+            & new_unittest("intrinsic-substring-module-name", test_intrinsic_substring_module_name), &
             & new_unittest("nonintrinsic-modules-used", test_nonintrinsic_modules_used), &
             & new_unittest("include-stmt", test_include_stmt), &
             & new_unittest("program", test_program), &
@@ -245,6 +246,50 @@ contains
         call f_source%test_serialization('srcfile_t: serialization', error)
 
     end subroutine test_intrinsic_modules_used
+
+
+    !> Regression test: intrinsic name substring must not classify a user module as intrinsic
+    subroutine test_intrinsic_substring_module_name(error)
+
+        !> Error handling
+        type(error_t), allocatable, intent(out) :: error
+
+        integer :: unit
+        character(:), allocatable :: temp_file
+        type(srcfile_t), allocatable :: f_source
+
+        allocate(temp_file, source=get_temp_filename())
+
+        open(file=temp_file, newunit=unit)
+        write(unit, '(a)') &
+            & 'program test', &
+            & '  use my_iso_fortran_env_utils', &
+            & '  use iso_fortran_env', &
+            & '  implicit none', &
+            & 'end program test'
+        close(unit)
+
+        f_source = parse_f_source(temp_file, error)
+        if (allocated(error)) then
+            return
+        end if
+
+        if (size(f_source%modules_used) /= 1) then
+            call test_failed(error, 'Incorrect number of modules_used - expecting one')
+            return
+        end if
+
+        if (.not.('my_iso_fortran_env_utils' .in. f_source%modules_used)) then
+            call test_failed(error, 'Expected user module my_iso_fortran_env_utils in modules_used')
+            return
+        end if
+
+        if ('iso_fortran_env' .in. f_source%modules_used) then
+            call test_failed(error, 'Intrinsic module found in modules_used')
+            return
+        end if
+
+    end subroutine test_intrinsic_substring_module_name
 
 
     !> Check that intrinsic module names are not ignored if declared non_intrinsic


### PR DESCRIPTION
#### Problem

Intrinsic module detection currently uses substring matching, which can incorrectly classify user-defined modules as intrinsic.

For example:

```fortran
use my_iso_fortran_env_utils
````

Since the module name contains `iso_fortran_env` as a substring, it is mistakenly treated as an intrinsic module. As a result, it is excluded from dependency tracking, leading to incorrect module resolution.

---

#### Fix

Replace substring-based matching with exact, case-normalized comparison.

A module is now considered intrinsic only if its name exactly matches a known intrinsic module name. This prevents false positives while preserving correct intrinsic handling.

---

#### Testing

Added a regression test `intrinsic-substring-module-name` that:

* Creates a temporary source file using `get_temp_filename()`
* Includes both:

  * a user-defined module containing an intrinsic substring
  * a real intrinsic module
* Verifies:

  * the user-defined module is correctly included in `modules_used`
  * the intrinsic module is correctly excluded

---

#### Impact

* Fixes incorrect exclusion of valid user-defined modules
* Ensures accurate dependency detection
* Maintains correct behavior for intrinsic modules

Closes #1273 
