### PR TITLE
feat(test): add parsing support for args field in [[test]] manifest

### DIFF
--- a/src/fpm/manifest/test.f90
+++ b/src/fpm/manifest/test.f90
@@ -11,6 +11,7 @@
 !>name = "string"
 !>source-dir = "path"
 !>main = "file"
+!>args = ["--flag", "value"]
 !>link = ["lib"]
 !>[test.dependencies]
 !>```
@@ -18,8 +19,9 @@ module fpm_manifest_test
     use fpm_manifest_dependency, only : new_dependencies
     use fpm_manifest_executable, only : executable_config_t
     use fpm_error, only : error_t, syntax_error, bad_name_error
+    use fpm_strings, only : string_t
     use tomlf, only : toml_table, toml_key, toml_stat
-    use fpm_toml, only : get_value, get_list
+    use fpm_toml, only : get_value, get_list, has_list
     implicit none
     private
 
@@ -28,6 +30,9 @@ module fpm_manifest_test
 
     !> Configuation meta data for an test
     type, extends(executable_config_t) :: test_config_t
+
+        !> Command-line arguments passed to the test executable
+        character(len=:), allocatable :: args(:)
 
     contains
 
@@ -67,6 +72,9 @@ contains
         endif
         call get_value(table, "source-dir", self%source_dir, "test")
         call get_value(table, "main", self%main, "main.f90")
+
+        call get_args(table, self%args, error)
+        if (allocated(error)) return
 
         call get_value(table, "dependencies", child, requested=.false.)
         if (associated(child)) then
@@ -111,7 +119,7 @@ contains
             case("name")
                 name_present = .true.
 
-            case("source-dir", "main", "dependencies", "link")
+            case("source-dir", "main", "dependencies", "link", "args")
                 continue
 
             end select
@@ -164,6 +172,17 @@ contains
             end if
         end if
 
+        if (allocated(self%args)) then
+            if (size(self%args) > 1 .or. pr > 2) then
+                write(unit, fmti) "- arguments", size(self%args)
+            end if
+            if (pr > 2) then
+                do ii = 1, size(self%args)
+                    write(unit, fmt) "  - arg", self%args(ii)
+                end do
+            end if
+        end if
+
         if (allocated(self%dependency)) then
             if (size(self%dependency) > 1 .or. pr > 2) then
                 write(unit, fmti) "- dependencies", size(self%dependency)
@@ -174,6 +193,48 @@ contains
         end if
 
     end subroutine info
+
+
+    subroutine get_args(table, args, error)
+
+        type(toml_table), intent(inout) :: table
+
+        character(len=:), allocatable, intent(out) :: args(:)
+
+        type(error_t), allocatable, intent(out) :: error
+
+        type(string_t), allocatable :: values(:)
+        character(len=:), allocatable :: item
+        integer :: ii, maxlen
+
+        if (.not. table%has_key("args")) return
+
+        if (.not. has_list(table, "args")) then
+            call syntax_error(error, "Test args must be an array of strings")
+            return
+        end if
+
+        call get_list(table, "args", values, error)
+        if (allocated(error)) return
+
+        if (.not. allocated(values)) return
+        if (size(values) < 1) then
+            allocate(character(len=1) :: args(0))
+            return
+        end if
+
+        maxlen = 1
+        do ii = 1, size(values)
+            maxlen = max(maxlen, len(values(ii)%s))
+        end do
+
+        allocate(character(len=maxlen) :: args(size(values)))
+        do ii = 1, size(values)
+            item = values(ii)%s
+            args(ii) = item
+        end do
+
+    end subroutine get_args
 
 
 end module fpm_manifest_test

--- a/test/fpm_test/test_manifest.f90
+++ b/test/fpm_test/test_manifest.f90
@@ -69,6 +69,9 @@ contains
             & new_unittest("package-wrongtest", test_package_wrongtest, should_fail=.true.), &
             & new_unittest("package-duplicate", test_package_duplicate, should_fail=.true.), &
             & new_unittest("test-simple", test_test_simple), &
+            & new_unittest("test-args", test_test_args), &
+            & new_unittest("test-args-missing", test_test_args_missing), &
+            & new_unittest("test-args-typeerror", test_test_args_typeerror, should_fail=.true.), &
             & new_unittest("test-empty", test_test_empty, should_fail=.true.), &
             & new_unittest("test-typeerror", test_test_typeerror, should_fail=.true.), &
             & new_unittest("test-noname", test_test_noname, should_fail=.true.), &
@@ -1139,6 +1142,95 @@ contains
         if (allocated(error)) return
 
     end subroutine test_test_simple
+
+
+    !> Tests parsing of test arguments from a manifest table
+    subroutine test_test_args(error)
+        use fpm_manifest_test
+
+        !> Error handling
+        type(error_t), allocatable, intent(out) :: error
+
+        type(toml_table) :: table
+        type(toml_array), pointer :: children
+        integer :: stat
+        type(test_config_t) :: test
+
+        call new_table(table)
+        call set_value(table, 'name', 'example', stat)
+        call add_array(table, 'args', children, stat)
+        call set_value(children, 1, '--input', stat)
+        call set_value(children, 2, 'file.txt', stat)
+
+        call new_test(test, table, error)
+        if (allocated(error)) return
+
+        if (.not.allocated(test%args)) then
+            call test_failed(error, 'args is not allocated')
+            return
+        end if
+
+        if (size(test%args) /= 2) then
+            call test_failed(error, 'args does not have size 2')
+            return
+        end if
+
+        if (test%args(1) /= '--input') then
+            call test_failed(error, 'First test arg does not match')
+            return
+        end if
+
+        if (test%args(2) /= 'file.txt') then
+            call test_failed(error, 'Second test arg does not match')
+            return
+        end if
+
+    end subroutine test_test_args
+
+
+    !> Tests that test arguments are optional
+    subroutine test_test_args_missing(error)
+        use fpm_manifest_test
+
+        !> Error handling
+        type(error_t), allocatable, intent(out) :: error
+
+        type(toml_table) :: table
+        type(test_config_t) :: test
+        integer :: stat
+
+        call new_table(table)
+        call set_value(table, 'name', 'example', stat)
+
+        call new_test(test, table, error)
+        if (allocated(error)) return
+
+        if (allocated(test%args)) then
+            call test_failed(error, 'args should not be allocated when missing')
+            return
+        end if
+
+    end subroutine test_test_args_missing
+
+
+    !> Tests that scalar args values are rejected
+    subroutine test_test_args_typeerror(error)
+        use fpm_manifest_test
+
+        !> Error handling
+        type(error_t), allocatable, intent(out) :: error
+
+        type(toml_table) :: table
+        type(test_config_t) :: test
+        integer :: stat
+
+        call new_table(table)
+        call set_value(table, 'name', 'example', stat)
+        call set_value(table, 'args', 'not-an-array', stat)
+
+        call new_test(test, table, error)
+
+    end subroutine test_test_args_typeerror
 
 
     !> Tests cannot be created from empty tables


### PR DESCRIPTION
### Summary

This PR adds support for parsing an optional `args` field in `[[test]]` entries in `fpm.toml`.

Example:

```toml
[[test]]
name = "example"
args = ["--input", "file.txt"]
```

The parsed values are stored in `test_config_t` as an allocatable string array.

---

### Changes

* Extend `test_config_t` with `args(:)`
* Add `get_args` helper for parsing and validation
* Update `new_test` to parse the `args` field
* Update allowlist to accept `"args"`
* Add regression tests for:

  * valid `args` parsing
  * missing `args` field
  * invalid (non-array) `args` input

---

### Behavior

* `args` is optional
* If missing → remains unallocated
* If present → must be an array of strings
* Invalid types raise a syntax error

---

### Scope

This PR only adds **manifest parsing support**.

It does **not** modify:

* test execution
* command construction
* runtime behavior

Execution-level integration can be handled in a follow-up PR.

---

### Motivation

Currently, `[[test]]` entries do not support passing command-line arguments, limiting flexibility for parameterized tests.

This change introduces a small, backward-compatible improvement aligned with modern build system capabilities.

---

### Testing

Added regression tests in `test_manifest.f90`:

* `test-args` → verifies correct parsing
* `test-args-missing` → ensures optional behavior
* `test-args-typeerror` → validates error handling

All existing tests pass.

---

### Notes

* Keeps changes minimal and localized to manifest parsing
* Follows existing parsing and validation patterns
* Designed as an incremental step toward more flexible test configuration

Closes #1275 