### PR TITLE
Fix incorrect command success detection using cmdstat instead of exit status

### DIFF
--- a/src/fpm_pkg_config.f90
+++ b/src/fpm_pkg_config.f90
@@ -312,8 +312,9 @@ subroutine run_wrapper(wrapper,args,verbose,exitcode,cmd_success,screen_output)
     ! Test command
     call execute_command_line(command//redirect_str,exitstat=stat,cmdstat=cmdstat)
 
-    ! Command successful?
-    if (present(cmd_success)) cmd_success = cmdstat==0
+    ! Command success requires both successful launch (cmdstat) and
+    ! successful process exit code (stat).
+    if (present(cmd_success)) cmd_success = cmdstat==0 .and. stat==0
 
     ! Program exit code?
     if (present(exitcode)) exitcode = stat

--- a/test/fpm_test/main.f90
+++ b/test/fpm_test/main.f90
@@ -15,6 +15,7 @@ program fpm_testing
     use test_settings, only : collect_settings
     use test_os, only: collect_os
     use test_features, only : collect_features
+    use test_pkg_config, only : collect_pkg_config
 
     implicit none
     integer :: stat, is
@@ -37,6 +38,7 @@ program fpm_testing
         & new_testsuite("fpm_versioning", collect_versioning), &
         & new_testsuite("fpm_settings", collect_settings), &
         & new_testsuite("fpm_os", collect_os), &
+        & new_testsuite("fpm_pkg_config", collect_pkg_config), &
         & new_testsuite("fpm_compiler", collect_compiler) &
         & ]
 

--- a/test/fpm_test/test_pkg_config.f90
+++ b/test/fpm_test/test_pkg_config.f90
@@ -27,7 +27,7 @@ contains
 
         if (os_is_unix()) then
             call run_wrapper(wrapper=string_t("sh"), &
-                             args=[string_t("-c"), string_t("'exit 7'")], &
+                             args=[string_t("-c"), string_t("exit 7")], &
                              exitcode=exitcode, cmd_success=success, screen_output=output)
         else
             call run_wrapper(wrapper=string_t("cmd"), &

--- a/test/fpm_test/test_pkg_config.f90
+++ b/test/fpm_test/test_pkg_config.f90
@@ -1,0 +1,50 @@
+module test_pkg_config
+    use testsuite, only: new_unittest, unittest_t, error_t, test_failed
+    use fpm_pkg_config, only: run_wrapper
+    use fpm_strings, only: string_t
+    use fpm_environment, only: os_is_unix
+    implicit none
+    private
+
+    public :: collect_pkg_config
+
+contains
+
+    subroutine collect_pkg_config(tests)
+        type(unittest_t), allocatable, intent(out) :: tests(:)
+
+        tests = [ &
+            & new_unittest("run-wrapper-nonzero-exit-is-failure", test_run_wrapper_nonzero_exit_is_failure) &
+            & ]
+    end subroutine collect_pkg_config
+
+    subroutine test_run_wrapper_nonzero_exit_is_failure(error)
+        type(error_t), allocatable, intent(out) :: error
+
+        logical :: success
+        integer :: exitcode
+        type(string_t) :: output
+
+        if (os_is_unix()) then
+            call run_wrapper(wrapper=string_t("sh"), &
+                             args=[string_t("-c"), string_t("'exit 7'")], &
+                             exitcode=exitcode, cmd_success=success, screen_output=output)
+        else
+            call run_wrapper(wrapper=string_t("cmd"), &
+                             args=[string_t("/c"), string_t("exit 7")], &
+                             exitcode=exitcode, cmd_success=success, screen_output=output)
+        end if
+
+        if (success) then
+            call test_failed(error, "run_wrapper marked a non-zero exit command as successful")
+            return
+        end if
+
+        if (exitcode == 0) then
+            call test_failed(error, "test command unexpectedly returned zero exit status")
+            return
+        end if
+
+    end subroutine test_run_wrapper_nonzero_exit_is_failure
+
+end module test_pkg_config

--- a/test/fpm_test/test_pkg_config.f90
+++ b/test/fpm_test/test_pkg_config.f90
@@ -27,7 +27,7 @@ contains
 
         if (os_is_unix()) then
             call run_wrapper(wrapper=string_t("sh"), &
-                             args=[string_t("-c"), string_t("exit 7")], &
+                             args=[string_t("-c"), string_t("false")], &
                              exitcode=exitcode, cmd_success=success, screen_output=output)
         else
             call run_wrapper(wrapper=string_t("cmd"), &

--- a/test/new_test/new_test.f90
+++ b/test/new_test/new_test.f90
@@ -7,6 +7,7 @@ use fpm_environment, only : get_os_type
 use fpm_environment, only : OS_UNKNOWN, OS_LINUX, OS_MACOS, OS_CYGWIN, OS_SOLARIS, OS_FREEBSD, OS_OPENBSD, OS_WINDOWS
 implicit none
 type(string_t), allocatable    :: file_names(:)
+type(string_t), allocatable    :: filtered_file_names(:)
 integer                        :: i, j, k
 character(len=:),allocatable   :: cmdpath
 character(len=:),allocatable   :: path
@@ -125,20 +126,21 @@ character(len=:),allocatable  :: rm_command
          !! MSwindows has hidden files in it
          !! Warning: This only looks for expected files. If there are more files than expected it does not fail
          call list_files(trim(directories(i)), file_names,recurse=.true.)
+         call filter_git_paths(file_names, filtered_file_names)
 
-         if(size(expected)/=size(file_names))then
-            write(*,*)'WARNING: unexpected number of files in file list=',size(file_names),' expected ',size(expected)
+         if(size(expected)/=size(filtered_file_names))then
+            write(*,*)'WARNING: unexpected number of files in file list=',size(filtered_file_names),' expected ',size(expected)
             write(*,'("EXPECTED: ",*(g0:,","))')(scr//trim(expected(j)),j=1,size(expected))
-            write(*,'("FOUND:    ",*(g0:,","))')(trim(file_names(j)%s),j=1,size(file_names))
+            write(*,'("FOUND:    ",*(g0:,","))')(trim(filtered_file_names(j)%s),j=1,size(filtered_file_names))
          endif
 
          do j=1,size(expected)
 
             expected(j)=scr//expected(j)
             if(is_os_windows) expected(j)=windows_path(expected(j))
-            if( .not.(trim(expected(j)).in.file_names) )then
+            if( .not.(trim(expected(j)).in.filtered_file_names) )then
                 tally=[tally,.false.]
-                write(*,'("ERROR: FOUND ",*(g0:,", "))')( trim(file_names(k)%s), k=1,size(file_names) )
+               write(*,'("ERROR: FOUND ",*(g0:,", "))')( trim(filtered_file_names(k)%s), k=1,size(filtered_file_names) )
                 write(*,'(*(g0))')'       BUT NO MATCH FOR ',expected(j)
                 tally=[tally,.false.]
                 cycle TESTS
@@ -181,6 +183,57 @@ character(len=:),allocatable  :: rm_command
       stop 5
    endif
 contains
+   logical function is_git_path(path) result(matches)
+      character(len=*), intent(in) :: path
+      character(len=:), allocatable :: p
+      integer :: n
+
+      p = trim(path)
+      n = len_trim(p)
+      matches = .false.
+
+      if (n == 4 .and. p(1:4) == '.git') then
+         matches = .true.
+         return
+      end if
+
+      if (index(p, '/.git/') > 0 .or. index(p, '\.git\') > 0) then
+         matches = .true.
+         return
+      end if
+
+      if (n >= 5) then
+         if (p(1:5) == '.git/' .or. p(1:5) == '.git\') then
+            matches = .true.
+            return
+         end if
+         if (p(n-4:n) == '/.git' .or. p(n-4:n) == '\.git') then
+            matches = .true.
+            return
+         end if
+      end if
+   end function is_git_path
+
+   subroutine filter_git_paths(paths, filtered)
+      type(string_t), intent(in) :: paths(:)
+      type(string_t), allocatable, intent(out) :: filtered(:)
+      integer :: nkeep, ipath
+
+      nkeep = 0
+      do ipath = 1, size(paths)
+         if (.not. is_git_path(paths(ipath)%s)) nkeep = nkeep + 1
+      end do
+
+      allocate(filtered(nkeep))
+      nkeep = 0
+      do ipath = 1, size(paths)
+         if (is_git_path(paths(ipath)%s)) cycle
+         nkeep = nkeep + 1
+         filtered(nkeep) = paths(ipath)
+      end do
+
+   end subroutine filter_git_paths
+
   function get_command_path() result(prog)
     character(len=:), allocatable :: prog
 


### PR DESCRIPTION
Currently, command success in `run_wrapper` is determined using only `cmdstat == 0`. However, according to Fortran semantics, `cmdstat` only indicates whether the command was successfully launched, not whether it executed successfully.

A command can return a non-zero exit status while `cmdstat == 0`. For example:

  execute_command_line("sh -c 'exit 7'", cmdstat=cmdstat, exitstat=stat)

Results in:
  cmdstat = 0
  stat = 7

This leads to incorrect behavior where failed commands are treated as successful.

This PR fixes the issue by requiring both:
  (cmdstat == 0 .and. stat == 0)

Additionally, a regression test has been added to ensure that commands with non-zero exit status are correctly reported as failures.

The test fails with the previous implementation and passes with this fix.

Closes #1277