### PR TITLE
fix(source-parsing): correct macro extraction for indented #if defined()

### DIFF
--- a/src/fpm_source_parsing.f90
+++ b/src/fpm_source_parsing.f90
@@ -233,8 +233,10 @@ subroutine parse_if_condition(lower_line, line, offset, heading_blanks, preproce
         start_pos = index(lower_line, 'defined(') + 8
         end_pos = index(lower_line(start_pos:), ')') - 1
 
+        ! end_pos is a length (relative to start_pos), so it must not be shifted
+        ! by heading_blanks here — only start_pos is converted to an absolute
+        ! position in `line`. See fpm#1265.
         start_pos = start_pos + heading_blanks
-        end_pos = end_pos + heading_blanks
 
         if (end_pos > 0) then
             macro_name = line(start_pos:start_pos + end_pos - 1)

--- a/src/fpm_source_parsing.f90
+++ b/src/fpm_source_parsing.f90
@@ -233,9 +233,6 @@ subroutine parse_if_condition(lower_line, line, offset, heading_blanks, preproce
         start_pos = index(lower_line, 'defined(') + 8
         end_pos = index(lower_line(start_pos:), ')') - 1
 
-        ! end_pos is a length (relative to start_pos), so it must not be shifted
-        ! by heading_blanks here — only start_pos is converted to an absolute
-        ! position in `line`. See fpm#1265.
         start_pos = start_pos + heading_blanks
 
         if (end_pos > 0) then

--- a/test/fpm_test/test_source_parsing.f90
+++ b/test/fpm_test/test_source_parsing.f90
@@ -57,6 +57,7 @@ contains
             & new_unittest("conditional-compilation-elif-else", test_conditional_compilation_elif_else), &
             & new_unittest("conditional-compilation_ifdef_else", test_conditional_compilation_ifdef_else), &
             & new_unittest("conditional-if-defined", test_conditional_if_defined), &
+            & new_unittest("conditional-if-defined-indented", test_conditional_if_defined_indented), &
             & new_unittest("conditional-macro-comparison", test_conditional_macro_comparison), &
             & new_unittest("define-without-trailing-space", test_define_no_trailing_space), &
             & new_unittest("macro-case-sensitivity", test_macro_case_sensitivity), &
@@ -1815,6 +1816,36 @@ contains
         end if
 
     end subroutine test_conditional_if_defined
+
+    !> Regression test for fpm#1265: indented `#if defined(MACRO)` must extract
+    !> the exact macro name, not include the trailing `)` and indent whitespace.
+    subroutine test_conditional_if_defined_indented(error)
+        type(error_t), allocatable, intent(out) :: error
+        type(srcfile_t) :: f_source
+        character(:), allocatable :: temp_file
+        integer :: unit
+        type(preprocess_config_t) :: cpp_config
+
+        temp_file = get_temp_filename()
+        open(file=temp_file, newunit=unit)
+        write(unit, '(a)') &
+            'module test_mod', &
+            '  #if defined(MY_FEATURE)', &
+            '  use feature_module', &
+            '  #endif', &
+            'end module test_mod'
+        close(unit)
+
+        call cpp_config%new([string_t('MY_FEATURE')])
+        cpp_config%name = "cpp"
+        f_source = parse_f_source(temp_file, error, preprocess=cpp_config)
+        if (allocated(error)) return
+
+        if (.not. ('feature_module' .in. f_source%modules_used)) &
+            call test_failed(error, &
+                'Indented #if defined(MY_FEATURE) skipped despite MY_FEATURE defined')
+
+    end subroutine test_conditional_if_defined_indented
 
     !> Test conditional compilation with #if MACRO == VALUE and #if MACRO != VALUE
     subroutine test_conditional_macro_comparison(error)


### PR DESCRIPTION
## Summary

- `parse_if_condition` was adding `heading_blanks` to `end_pos`, but `end_pos`
  is a length (distance from `start_pos` to the closing `)` in `lower_line`),
  not an absolute position. Adding the indent inflated the slice and made
  indented `#if defined(MACRO)` directives capture the trailing `)` and
  indent-equivalent whitespace; the resulting macro name never matched the
  defined list and the block was silently skipped.
- Drop the bad shift; add a regression test in `test_source_parsing.f90`.

Fixes #1265

Credit to @ijatinydv for the root-cause analysis, minimal reproducer, and
proposed fix in the issue; carried over here verbatim with a regression test.

## Verification

### Test fails on main
```
#      ... conditional-if-defined [PASSED]
# Starting conditional-if-defined-indented ... (31/36)
#      ... conditional-if-defined-indented [FAILED]
# Message: Indented #if defined(MY_FEATURE) skipped despite MY_FEATURE defined
# Starting conditional-macro-comparison ... (32/36)
```

### Test passes after fix
```
#      ... conditional-if-defined [PASSED]
# Starting conditional-if-defined-indented ... (31/36)
#      ... conditional-if-defined-indented [PASSED]
# Starting conditional-macro-comparison ... (32/36)
#      ... conditional-macro-comparison [PASSED]
```

Full `fpm test fpm-test` suite passes with the fix; no other test changes.