### PR TITLE
perf: use native directory checks on Unix

### DIFF
--- a/src/fpm_filesystem.F90
+++ b/src/fpm_filesystem.F90
@@ -214,8 +214,13 @@ logical function is_dir(dir)
     select case (get_os_type())
 
     case (OS_UNKNOWN, OS_LINUX, OS_MACOS, OS_CYGWIN, OS_SOLARIS, OS_FREEBSD, OS_OPENBSD)
+#ifndef FPM_BOOTSTRAP
+        is_dir = c_is_dir(dir(1:len_trim(dir))//c_null_char) /= 0
+        return
+#else
         call run( "test -d " // dir , &
                 & exitstat=stat,echo=.false.,verbose=.false.)
+#endif
 
     case (OS_WINDOWS)
         call run('cmd /c "if not exist ' // windows_path(dir) // '\ exit /B 1"', &


### PR DESCRIPTION
## Summary

- Use the existing C `c_is_dir` wrapper for Unix directory checks instead of shelling out
- Bootstrap path keeps the old shell command

## Context

Part of the parallel build safety and performance work. Removes shell overhead
from `is_dir` by using the existing C binding on Unix. Neutral on fpm self-build
(compiler time dominates), but eliminates fork calls that are unsafe under
OpenMP threads.

## Merge order

**Independent PRs (any order):**
- Native is_dir (#1291)
- Native mkdir (#1292)
- Build only selected run targets (#1293)
- Skip dry-run for run/test --list (#1294)
- Skip dry-run for build --list (#1295)
- Serialize pretty-mode progress under OpenMP (#1296)
- Dependency-driven build scheduler (#1297)

**Stacked chain (merge in order):**
1. Fortran compiles via argv (#1299)
2. Parallel link/archive via argv (#1300)
3. C/C++ compiles via argv (#1301)

**Fork-safety fix:**
- Serialize mkdir on run_command lock (#1298)

**After the above:**
- Interface-aware rebuild (#1289, already open)
- Enable default features via manifest (pending CI fix)


## Verification

fpm self-build and full test suite pass:

```
$ fpm build --features openmp --compiler gfortran --flag '-O3 -g'
[100%] Project compiled successfully.

$ fpm test
TALLY;TTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTT
PASSED: all 35 tests passed
```

Benchmark (fpm self-build, median of 3):

```
parallel: 21.17s main, 21.10s branch, 0.07s faster, 0.3%
serial:   24.90s main, 24.91s branch, 0.01s slower, 0.0%
```

Neutral — compile time dominates; the shell overhead removal matters for
the parallel safety story, not for this benchmark.