### PR TITLE
perf: create Unix directories without shell

### DIFF
--- a/src/filesystem_utilities.c
+++ b/src/filesystem_utilities.c
@@ -1,5 +1,8 @@
 #include <sys/stat.h>
 #include <dirent.h>
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
 
 #if defined(__APPLE__) && !defined(__aarch64__) && !defined(__ppc__) && !defined(__i386__)
 DIR * opendir$INODE64( const char * dirName );
@@ -13,6 +16,50 @@ int c_is_dir(const char *path)
     struct stat m;
     int r = stat(path, &m);
     return r == 0 && S_ISDIR(m.st_mode);
+}
+
+int c_mkdir_p(const char *path)
+{
+#ifdef _WIN32
+    return -1;
+#else
+    char *tmp;
+    char *p;
+    size_t len;
+    int result;
+    struct stat m;
+
+    if (path == NULL || path[0] == '\0') {
+        return -1;
+    }
+
+    len = strlen(path);
+    tmp = malloc(len + 1);
+    if (tmp == NULL) {
+        return -1;
+    }
+    memcpy(tmp, path, len + 1);
+
+    for (p = tmp + 1; *p != '\0'; ++p) {
+        if (*p != '/') {
+            continue;
+        }
+        *p = '\0';
+        if (mkdir(tmp, 0777) != 0 && errno != EEXIST) {
+            free(tmp);
+            return -1;
+        }
+        *p = '/';
+    }
+
+    result = mkdir(tmp, 0777);
+    free(tmp);
+    if (result != 0 && errno != EEXIST) {
+        return -1;
+    }
+
+    return stat(path, &m) == 0 && S_ISDIR(m.st_mode) ? 0 : -1;
+#endif
 }
 
 const char *get_d_name(struct dirent *d)

--- a/src/fpm_filesystem.F90
+++ b/src/fpm_filesystem.F90
@@ -49,6 +49,12 @@ module fpm_filesystem
             character(kind=c_char), intent(in) :: path(*)
             integer(kind=c_int) :: r
         end function c_is_dir
+
+        function c_mkdir_p(path) result(r) bind(c, name="c_mkdir_p")
+            import c_char, c_int
+            character(kind=c_char), intent(in) :: path(*)
+            integer(kind=c_int) :: r
+        end function c_mkdir_p
     end interface
 #endif
 
@@ -380,7 +386,14 @@ subroutine mkdir(dir, echo)
 
     select case (get_os_type())
         case (OS_UNKNOWN, OS_LINUX, OS_MACOS, OS_CYGWIN, OS_SOLARIS, OS_FREEBSD, OS_OPENBSD)
+#ifndef FPM_BOOTSTRAP
+            if (present(echo)) then
+                if (echo) print *, '+ mkdir -p ', dir
+            end if
+            stat = c_mkdir_p(dir(1:len_trim(dir))//c_null_char)
+#else
             call run('mkdir -p ' // dir, exitstat=stat,echo=echo,verbose=.false.)
+#endif
 
         case (OS_WINDOWS)
             call run("mkdir " // windows_path(dir), &


### PR DESCRIPTION
## Summary

- Create Unix directories through a C helper instead of `mkdir -p` through the shell
- Windows and bootstrap builds keep the existing command path
- Independent of the native `is_dir` change

## Context

Removes fork calls from directory creation on Unix. Like the `is_dir` change,
this is neutral on fpm self-build benchmarks (compiler time dominates) but
eliminates shell forks that are unsafe under OpenMP threads.

## Merge order

**Independent PRs (any order):**
- Native is_dir (#1291)
- Native mkdir (#1292)
- Build only selected run targets (#1293)
- Skip dry-run for run/test --list (#1294)
- Skip dry-run for build --list (#1295)
- Serialize pretty-mode progress under OpenMP (#1296)
- Dependency-driven build scheduler (#1297)

**Stacked chain (merge in order):**
1. Fortran compiles via argv (#1299)
2. Parallel link/archive via argv (#1300)
3. C/C++ compiles via argv (#1301)

**Fork-safety fix:**
- Serialize mkdir on run_command lock (#1298)

**After the above:**
- Interface-aware rebuild (#1289, already open)
- Enable default features via manifest (pending CI fix)


## Verification

```
$ fpm build --features openmp --compiler gfortran --flag '-O3 -g'
[100%] Project compiled successfully.

$ fpm test
TALLY;TTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTT
PASSED: all 35 tests passed
```

Benchmark (fpm self-build, median of 3):

```
parallel: 21.17s main, 21.15s branch, 0.02s faster, 0.1%
serial:   24.90s main, 24.85s branch, 0.05s faster, 0.2%
```