### PR TITLE
perf: skip dry-run build for run --list and test --list

### DIFF
--- a/src/fpm.f90
+++ b/src/fpm.f90
@@ -692,11 +692,10 @@ subroutine cmd_run(settings,test)
 
     end if
 
-    call build_package(targets,model,verbose=settings%verbose,dry_run=settings%list)
-
     if (settings%list) then
          call compact_list()
     else
+        call build_package(targets,model,verbose=settings%verbose,dry_run=.false.)
 
         ! Save current library path and set a new one that includes the local 
         ! dynamic library folders


### PR DESCRIPTION
## Summary

- Return from `fpm run --list` and `fpm test --list` after candidate enumeration
- The old path enumerated candidates, called `build_package(..., dry_run=.true.)`,
  then printed the same list; list mode does not need target sorting or compile-command
  dry runs
- Normal `run` and `test` still call `build_package` before executing binaries

## Merge order

**Independent PRs (any order):**
- Native is_dir (#1291)
- Native mkdir (#1292)
- Build only selected run targets (#1293)
- Skip dry-run for run/test --list (#1294)
- Skip dry-run for build --list (#1295)
- Serialize pretty-mode progress under OpenMP (#1296)
- Dependency-driven build scheduler (#1297)

**Stacked chain (merge in order):**
1. Fortran compiles via argv (#1299)
2. Parallel link/archive via argv (#1300)
3. C/C++ compiles via argv (#1301)

**Fork-safety fix:**
- Serialize mkdir on run_command lock (#1298)

**After the above:**
- Interface-aware rebuild (#1289, already open)
- Enable default features via manifest (pending CI fix)


## Verification

```
$ fpm build --features openmp --compiler gfortran --flag '-O3 -g'
[100%] Project compiled successfully.

$ fpm test
TALLY;TTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTT
PASSED: all 35 tests passed
```

Benchmark (fpm self `test --list`, median of 3):

```
parallel: 0.51s main, 0.39s branch, 0.12s faster, 23.5%
serial:   0.46s main, 0.40s branch, 0.06s faster, 13.0%
```

Matched-name output is identical.