### PR TITLE
perf: skip dry-run build for build --list

### DIFF
--- a/src/fpm.f90
+++ b/src/fpm.f90
@@ -579,8 +579,8 @@ if(settings%list)then
 endif
 if (settings%show_model) then
     call show_model(model)
-else
-    call build_package(targets,model,verbose=settings%verbose,dry_run=settings%list)
+else if (.not.settings%list) then
+    call build_package(targets,model,verbose=settings%verbose,dry_run=.false.)
 endif
 
 end subroutine cmd_build


### PR DESCRIPTION
## Summary

- Return from `fpm build --list` after printing the target paths
- The old path printed target paths, then called
  `build_package(..., dry_run=.true.)`; list mode does not need build graph
  sorting after the target list is already available
- `--show-model` still prints the model when requested

## Merge order

**Independent PRs (any order):**
- Native is_dir (#1291)
- Native mkdir (#1292)
- Build only selected run targets (#1293)
- Skip dry-run for run/test --list (#1294)
- Skip dry-run for build --list (#1295)
- Serialize pretty-mode progress under OpenMP (#1296)
- Dependency-driven build scheduler (#1297)

**Stacked chain (merge in order):**
1. Fortran compiles via argv (#1299)
2. Parallel link/archive via argv (#1300)
3. C/C++ compiles via argv (#1301)

**Fork-safety fix:**
- Serialize mkdir on run_command lock (#1298)

**After the above:**
- Interface-aware rebuild (#1289, already open)
- Enable default features via manifest (pending CI fix)


## Verification

```
$ fpm build --features openmp --compiler gfortran --flag '-O3 -g'
[100%] Project compiled successfully.

$ fpm test
TALLY;TTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTT
PASSED: all 35 tests passed
```

Benchmark (fpm self `build --list`, median of 3):

```
parallel: 0.59s main, 0.39s branch, 0.20s faster, 33.9%
serial:   0.45s main, 0.40s branch, 0.05s faster, 11.1%
```

Target list is identical after normalizing the build-dir prefix.