### PR TITLE
fix: serialize pretty-mode build progress output under OpenMP

### DIFF
--- a/src/fpm_backend_output.f90
+++ b/src/fpm_backend_output.f90
@@ -95,6 +95,7 @@ contains
         character(:), allocatable :: target_name
         character(100) :: output_string
         character(7) :: overall_progress
+        integer :: n_done
 
         associate(target=>progress%target_queue(queue_index)%ptr)
 
@@ -104,7 +105,9 @@ contains
                 target_name = basename(target%output_file)
             end if
 
-            write(overall_progress,'(A,I3,A)') '[',100*progress%n_complete/progress%n_target,'%] '
+            !$omp atomic read
+            n_done = progress%n_complete
+            write(overall_progress,'(A,I3,A)') '[',100*n_done/progress%n_target,'%] '
 
             if (progress%plain_mode) then ! Plain output
 
@@ -116,9 +119,12 @@ contains
 
                 write(output_string,'(A,T40,A,A)') target_name, COLOR_YELLOW//'compiling...'//COLOR_RESET
 
+                ! Keep a target's two-line update atomic so concurrent threads do
+                ! not interleave it and corrupt the console's relative cursor math.
+                !$omp critical(fpm_progress)
                 call progress%console%write_line(trim(output_string),progress%output_lines(queue_index))
-
                 call progress%console%write_line(overall_progress//'Compiling...',advance=.false.)
+                !$omp end critical(fpm_progress)
 
             end if
 
@@ -138,10 +144,12 @@ contains
         character(:), allocatable :: target_name
         character(100) :: output_string
         character(7) :: overall_progress
+        integer :: n_done
 
-        !$omp critical 
+        !$omp atomic capture
         progress%n_complete = progress%n_complete + 1
-        !$omp end critical
+        n_done = progress%n_complete
+        !$omp end atomic
 
         associate(target=>progress%target_queue(queue_index)%ptr)
 
@@ -157,7 +165,7 @@ contains
                 write(output_string,'(A,T40,A,A)') target_name,COLOR_RED//'failed.'//COLOR_RESET
             end if
 
-            write(overall_progress,'(A,I3,A)') '[',100*progress%n_complete/progress%n_target,'%] '
+            write(overall_progress,'(A,I3,A)') '[',100*n_done/progress%n_target,'%] '
 
             if (progress%plain_mode) then  ! Plain output
 
@@ -167,9 +175,10 @@ contains
 
             else ! Pretty output
 
+                !$omp critical(fpm_progress)
                 call progress%console%update_line(progress%output_lines(queue_index),trim(output_string))
-
                 call progress%console%write_line(overall_progress//'Compiling...',advance=.false.)
+                !$omp end critical(fpm_progress)
 
             end if
 


### PR DESCRIPTION
## Summary

- Wrap each target's compound pretty-mode status update in a named
  `critical(fpm_progress)` so it is atomic against other threads
- Make the `n_complete` counter coherent: `!$omp atomic capture` on increment
  and `!$omp atomic read` on use, replacing an unnamed critical write paired
  with an unsynchronized read
- Plain mode (off a TTY, including CI) is untouched: each line is a single
  self-contained write, so per-write atomicity already suffices

## Context

Each target's pretty-mode update is a compound of two `console_t` writes, and
`console_update_line` moves the terminal cursor relative to the tracked line
count. On `main` the two writes sit in separate unnamed `!$omp critical`
regions, so another worker thread can interleave its own output between them,
change `n_line`, and invalidate the cursor arithmetic. The result is garbled
progress on an interactive terminal under `-fopenmp`.

## Merge order

**Independent PRs (any order):**
- Native is_dir (#1291)
- Native mkdir (#1292)
- Build only selected run targets (#1293)
- Skip dry-run for run/test --list (#1294)
- Skip dry-run for build --list (#1295)
- Serialize pretty-mode progress under OpenMP (#1296)
- Dependency-driven build scheduler (#1297)

**Stacked chain (merge in order):**
1. Fortran compiles via argv (#1299)
2. Parallel link/archive via argv (#1300)
3. C/C++ compiles via argv (#1301)

**Fork-safety fix:**
- Serialize mkdir on run_command lock (#1298)

**After the above:**
- Interface-aware rebuild (#1289, already open)
- Enable default features via manifest (pending CI fix)


## Verification

```
$ fpm build --flag -fopenmp
[100%] Project compiled successfully.

$ fpm test --flag -fopenmp
TALLY;TTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTT
PASSED: all 35 tests passed
```

The defect is a non-deterministic data race that only manifests in pretty/TTY
mode under multiple OpenMP threads, so there is no stable automated reproducer.
The before-state is visible in the source on `main`: the compound update spans
two separate unnamed critical regions in `src/fpm_backend_output.f90`, and
`console_update_line` in `src/fpm_backend_console.f90` performs cursor movement
relative to a shared, concurrently-mutated `n_line`.