### PR TITLE
fix: serialize mkdir shell fork on the run_command lock

### DIFF
--- a/src/fpm_backend.F90
+++ b/src/fpm_backend.F90
@@ -327,11 +327,14 @@ subroutine build_target(model,target,verbose,dry_run,table,stat)
 
     integer :: fh
 
-    !$omp critical
+    ! mkdir shells out (is_dir 'test -d' and 'mkdir -p'), which forks. Serialize
+    ! it on the same run_command lock as every other shell fork so it cannot run
+    ! concurrently with a link/archive/compile shell fallback on another thread.
+    !$omp critical (run_command)
     if (.not.exists(dirname(target%output_file)) .and. .not.dry_run) then
         call mkdir(dirname(target%output_file),verbose)
     end if
-    !$omp end critical
+    !$omp end critical (run_command)
 
     select case(target%target_type)
 


### PR DESCRIPTION
## Summary

- Move directory creation in `build_target` from an unnamed `!$omp critical`
  to the named `critical(run_command)` lock that guards all other shell forks
- mkdir shells out twice (`is_dir` runs `test -d`, then `mkdir -p`), both of
  which fork; the unnamed critical was a different lock than `run_command`, so a
  mkdir fork on one thread could run concurrently with a compile/link/archive
  shell fallback on another — the exact concurrent-fork hazard the
  `run_command` lock exists to prevent

## Merge order

Independent — no ordering constraint. Logically related to the argv spawn chain
but does not depend on it.

**Note:** textual overlap with #1289 (interface-aware rebuild) — both edit the
`!$omp critical` block in `build_target`. Whichever merges second rebases.

**Independent PRs (any order):**
- Native is_dir (#1291)
- Native mkdir (#1292)
- Build only selected run targets (#1293)
- Skip dry-run for run/test --list (#1294)
- Skip dry-run for build --list (#1295)
- Serialize pretty-mode progress under OpenMP (#1296)
- Dependency-driven build scheduler (#1297)

**Stacked chain (merge in order):**
1. Fortran compiles via argv (#1299)
2. Parallel link/archive via argv (#1300)
3. C/C++ compiles via argv (#1301)

**Fork-safety fix:**
- **This PR** — Serialize mkdir on run_command lock (#1298)

**After the above:**
- Interface-aware rebuild (#1289, already open)
- Enable default features via manifest (#1302)

Refs: #962

## Verification

```
$ fpm build --flag -fopenmp
[100%] Project compiled successfully.

$ fpm test --flag -fopenmp
TALLY;TTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTT
PASSED: all 35 tests passed
```