### PR TITLE
feat: auto-apply features marked default = true in the manifest

### DIFF
--- a/src/filesystem_utilities.c
+++ b/src/filesystem_utilities.c
@@ -1,6 +1,18 @@
 #include <sys/stat.h>
 #include <dirent.h>
 
+#ifndef _WIN32
+#include <errno.h>
+#include <fcntl.h>
+#include <spawn.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+extern char **environ;
+#endif
+
 #if defined(__APPLE__) && !defined(__aarch64__) && !defined(__ppc__) && !defined(__i386__)
 DIR * opendir$INODE64( const char * dirName );
 struct dirent * readdir$INODE64( DIR * dir );
@@ -28,4 +40,79 @@ DIR *c_opendir(const char *dirname)
 struct dirent *c_readdir(DIR *dirp)
 {
     return readdir(dirp);
+}
+
+int c_run_argv(const char *joined, int argc, const char *redirect)
+{
+#ifdef _WIN32
+    (void)joined;
+    (void)argc;
+    (void)redirect;
+    return -1;
+#else
+    char **argv = NULL;
+    const char *p = joined;
+    pid_t pid;
+    int spawn_status;
+    int wait_status;
+    int i;
+    int use_redirect = redirect != NULL && redirect[0] != '\0';
+    posix_spawn_file_actions_t actions;
+    posix_spawn_file_actions_t *actions_ptr = NULL;
+
+    if (argc < 1) {
+        return 0;
+    }
+
+    argv = calloc((size_t)argc + 1, sizeof(char *));
+    if (argv == NULL) {
+        return -1;
+    }
+
+    for (i = 0; i < argc; ++i) {
+        argv[i] = (char *)p;
+        p += strlen(p) + 1;
+    }
+
+    if (use_redirect) {
+        if (posix_spawn_file_actions_init(&actions) != 0) {
+            free(argv);
+            return -1;
+        }
+        actions_ptr = &actions;
+        if (posix_spawn_file_actions_addopen(&actions, STDOUT_FILENO, redirect,
+                                             O_WRONLY | O_CREAT | O_TRUNC, 0666) != 0 ||
+            posix_spawn_file_actions_adddup2(&actions, STDOUT_FILENO, STDERR_FILENO) != 0) {
+            posix_spawn_file_actions_destroy(&actions);
+            free(argv);
+            return -1;
+        }
+    }
+
+    spawn_status = posix_spawnp(&pid, argv[0], actions_ptr, NULL, argv, environ);
+    if (use_redirect) {
+        posix_spawn_file_actions_destroy(&actions);
+    }
+    free(argv);
+
+    if (spawn_status != 0) {
+        return spawn_status;
+    }
+
+    do {
+        spawn_status = waitpid(pid, &wait_status, 0);
+    } while (spawn_status < 0 && errno == EINTR);
+
+    if (spawn_status < 0) {
+        return -1;
+    }
+
+    if (WIFEXITED(wait_status)) {
+        return WEXITSTATUS(wait_status);
+    }
+    if (WIFSIGNALED(wait_status)) {
+        return 128 + WTERMSIG(wait_status);
+    }
+    return -1;
+#endif
 }

--- a/src/filesystem_utilities.c
+++ b/src/filesystem_utilities.c
@@ -13,6 +13,12 @@
 extern char **environ;
 #endif
 
+#ifdef _WIN32
+#include <windows.h>
+#include <stdlib.h>
+#include <string.h>
+#endif
+
 #if defined(__APPLE__) && !defined(__aarch64__) && !defined(__ppc__) && !defined(__i386__)
 DIR * opendir$INODE64( const char * dirName );
 struct dirent * readdir$INODE64( DIR * dir );
@@ -42,13 +48,153 @@ struct dirent *c_readdir(DIR *dirp)
     return readdir(dirp);
 }
 
+#ifdef _WIN32
+/* Quote one argv token using the CommandLineToArgvW rules so that
+   CreateProcess reconstructs the exact token. Caller frees the result. */
+static char *win_quote_arg(const char *arg)
+{
+    size_t len = strlen(arg);
+    size_t i;
+    int needs = (len == 0);
+    char *out;
+    char *q;
+
+    for (i = 0; i < len; ++i) {
+        char c = arg[i];
+        if (c == ' ' || c == '\t' || c == '\n' || c == '\v' || c == '"') {
+            needs = 1;
+            break;
+        }
+    }
+
+    if (!needs) {
+        out = (char *)malloc(len + 1);
+        if (out) memcpy(out, arg, len + 1);
+        return out;
+    }
+
+    out = (char *)malloc(2 * len + 3);
+    if (!out) return NULL;
+    q = out;
+    *q++ = '"';
+    for (i = 0; i < len;) {
+        size_t nbs = 0;
+        size_t k;
+        while (i < len && arg[i] == '\\') { ++nbs; ++i; }
+        if (i == len) {
+            for (k = 0; k < 2 * nbs; ++k) *q++ = '\\';
+            break;
+        } else if (arg[i] == '"') {
+            for (k = 0; k < 2 * nbs + 1; ++k) *q++ = '\\';
+            *q++ = '"';
+            ++i;
+        } else {
+            for (k = 0; k < nbs; ++k) *q++ = '\\';
+            *q++ = arg[i++];
+        }
+    }
+    *q++ = '"';
+    *q = '\0';
+    return out;
+}
+#endif
+
 int c_run_argv(const char *joined, int argc, const char *redirect)
 {
 #ifdef _WIN32
-    (void)joined;
-    (void)argc;
-    (void)redirect;
-    return -1;
+    const char *p = joined;
+    int i;
+    int use_redirect = redirect != NULL && redirect[0] != '\0';
+    const char **argv = NULL;
+    char *cmd = NULL;
+    size_t cap = 1, n = 0;
+    char apppath[MAX_PATH];
+    char *appname = NULL;
+    DWORD found;
+    HANDLE hout = INVALID_HANDLE_VALUE;
+    SECURITY_ATTRIBUTES sa;
+    STARTUPINFOA si;
+    PROCESS_INFORMATION pi;
+    BOOL ok;
+    int result;
+
+    if (argc < 1) return 0;
+
+    argv = (const char **)calloc((size_t)argc + 1, sizeof(char *));
+    if (argv == NULL) return -1;
+    for (i = 0; i < argc; ++i) {
+        argv[i] = p;
+        p += strlen(p) + 1;
+    }
+
+    /* Reassemble a properly quoted command line for CreateProcess. */
+    cmd = (char *)malloc(cap);
+    if (cmd == NULL) { free((void *)argv); return -1; }
+    cmd[0] = '\0';
+    for (i = 0; i < argc; ++i) {
+        char *qa = win_quote_arg(argv[i]);
+        size_t ql;
+        size_t need;
+        if (qa == NULL) { free(cmd); free((void *)argv); return -1; }
+        ql = strlen(qa);
+        need = n + ql + 2;
+        if (need > cap) {
+            char *t;
+            cap = need * 2;
+            t = (char *)realloc(cmd, cap);
+            if (t == NULL) { free(qa); free(cmd); free((void *)argv); return -1; }
+            cmd = t;
+        }
+        if (i > 0) cmd[n++] = ' ';
+        memcpy(cmd + n, qa, ql);
+        n += ql;
+        cmd[n] = '\0';
+        free(qa);
+    }
+
+    /* Resolve the program through PATH with a default .exe extension. */
+    found = SearchPathA(NULL, argv[0], ".exe", MAX_PATH, apppath, NULL);
+    if (found > 0 && found < MAX_PATH) appname = apppath;
+
+    ZeroMemory(&si, sizeof(si));
+    si.cb = sizeof(si);
+    ZeroMemory(&pi, sizeof(pi));
+
+    /* Only override the child's std handles when redirecting. Setting
+       STARTF_USESTDHANDLES with the (often non-inheritable) console handles
+       can strip the child's console, so leave them alone otherwise and let
+       the child inherit the parent console normally. */
+    if (use_redirect) {
+        ZeroMemory(&sa, sizeof(sa));
+        sa.nLength = sizeof(sa);
+        sa.bInheritHandle = TRUE;
+        hout = CreateFileA(redirect, GENERIC_WRITE, FILE_SHARE_READ, &sa,
+                           CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);
+        if (hout == INVALID_HANDLE_VALUE) { free(cmd); free((void *)argv); return -1; }
+        si.dwFlags |= STARTF_USESTDHANDLES;
+        si.hStdInput = GetStdHandle(STD_INPUT_HANDLE);
+        si.hStdOutput = hout;
+        si.hStdError = hout;
+    }
+
+    ok = CreateProcessA(appname, cmd, NULL, NULL, use_redirect, 0, NULL, NULL, &si, &pi);
+    if (!ok) {
+        result = -1;
+    } else {
+        DWORD code = 1;
+        WaitForSingleObject(pi.hProcess, INFINITE);
+        GetExitCodeProcess(pi.hProcess, &code);
+        CloseHandle(pi.hProcess);
+        CloseHandle(pi.hThread);
+        /* Keep a real (possibly high-bit) exit code positive so the caller
+           does not mistake it for the stat < 0 spawn-failure sentinel. */
+        result = (code > 0x7fffffff) ? 1 : (int)code;
+    }
+
+    if (hout != INVALID_HANDLE_VALUE) CloseHandle(hout);
+    free(cmd);
+    free((void *)argv);
+    return result;
 #else
     char **argv = NULL;
     const char *p = joined;

--- a/src/fpm/manifest/feature.f90
+++ b/src/fpm/manifest/feature.f90
@@ -210,7 +210,7 @@ contains
                 exit
 
             ! Keys
-            case("description", "platform", "flags", "c-flags", &
+            case("default", "description", "platform", "flags", "c-flags", &
                  "cxx-flags", "link-time-flags", "preprocessor", "requires", &
                  "build", "install", "fortran", "library", "dependencies", &
                  "dev-dependencies", "executable", "example", "test", "preprocess")

--- a/src/fpm/manifest/feature_collection.f90
+++ b/src/fpm/manifest/feature_collection.f90
@@ -35,7 +35,10 @@ module fpm_manifest_feature_collection
         
         ! Features shared by specific platform/compiler configurations
         type(feature_config_t), allocatable :: variants(:)
-        
+
+        ! Auto-apply this feature when no explicit --features list is given
+        logical :: is_default = .false.
+
         contains
         
             procedure :: serializable_is_same => feature_collection_same
@@ -66,6 +69,7 @@ module fpm_manifest_feature_collection
         feature_collection_same = .false.
         select type (other => that)
         type is (feature_collection_t)
+            if (this%is_default .neqv. other%is_default) return
             if (.not.(this%base == other%base)) return
             if (allocated(this%variants) .neqv. allocated(other%variants)) return
             if (allocated(this%variants)) then
@@ -89,6 +93,9 @@ module fpm_manifest_feature_collection
         type(toml_table), pointer :: ptr_base, ptr_vars, ptr
         integer :: i
         character(len=32) :: key
+
+        ! default flag
+        call set_value(table, "default", self%is_default)
 
         ! base
         call add_table(table, "base", ptr_base)
@@ -123,6 +130,9 @@ module fpm_manifest_feature_collection
         type(toml_table), pointer :: ptr_base, ptr_vars, ptr
         type(toml_key),  allocatable :: keys(:)
         integer :: i
+
+        ! default flag
+        call get_value(table, "default", self%is_default, .false.)
 
         ! base (required)
         call get_value(table, "base", ptr_base)
@@ -234,16 +244,21 @@ module fpm_manifest_feature_collection
         character(*), intent(in) :: name
         type(error_t), allocatable, intent(out) :: error
         
-        integer :: i
+        integer :: i, stat
         type(platform_config_t) :: default_platform
         type(toml_key), allocatable :: keys(:)
-        
+        logical :: default_val
+
         default_platform = platform_config_t(id_all,OS_ALL)
-        
+
         ! Initialize base feature
         self%base%name = name
         self%base%platform = default_platform
-        
+
+        ! Parse optional "default" key
+        call get_value(table, "default", default_val, .false., stat=stat)
+        if (stat == toml_stat%success) self%is_default = default_val
+
         ! Traverse the table hierarchy to find variants
         call traverse_feature_table(self, table, name, default_platform, error)
         if (allocated(error)) return
@@ -277,7 +292,10 @@ module fpm_manifest_feature_collection
         
         ! First pass: check what types of keys we have
         do i = 1, size(keys)
-            
+
+            ! Skip collection-level keys handled by the caller
+            if (keys(i)%key == "default") cycle
+
             ! Check if this key is a valid OS name
             os_type = match_os_type(keys(i)%key)
             if (os_type /= OS_UNKNOWN) then

--- a/src/fpm/manifest/package.f90
+++ b/src/fpm/manifest/package.f90
@@ -623,6 +623,16 @@ contains
                 call apply_default_features(self, self%profiles(idx), cfg, platform, verbose, error)
                 if (allocated(error)) return
             end if
+
+            ! Apply features marked default = true in the manifest.
+            if (allocated(self%features)) then
+                do i = 1, size(self%features)
+                    if (self%features(i)%is_default) then
+                        call self%features(i)%merge_into_package(cfg, platform, error)
+                        if (allocated(error)) return
+                    end if
+                end do
+            end if
         end if
 
         ! Then apply the requested features on top

--- a/src/fpm_backend.F90
+++ b/src/fpm_backend.F90
@@ -327,11 +327,14 @@ subroutine build_target(model,target,verbose,dry_run,table,stat)
 
     integer :: fh
 
-    !$omp critical
+    ! mkdir shells out (is_dir 'test -d' and 'mkdir -p'), which forks. Serialize
+    ! it on the same run_command lock as every other shell fork so it cannot run
+    ! concurrently with a link/archive/compile shell fallback on another thread.
+    !$omp critical (run_command)
     if (.not.exists(dirname(target%output_file)) .and. .not.dry_run) then
         call mkdir(dirname(target%output_file),verbose)
     end if
-    !$omp end critical
+    !$omp end critical (run_command)
 
     select case(target%target_type)
 

--- a/src/fpm_command_line.f90
+++ b/src/fpm_command_line.f90
@@ -1663,9 +1663,16 @@ contains
             call fpm_stop(1, 'Error: --profile and --features cannot be used together')
         end if
         
-        ! Parse comma-separated features and profiles
-        if (specified('features') .and. len_trim(feats) > 0) then
-            call parse_features(feats, self%features)
+        ! Parse comma-separated features and profiles.
+        ! --features "openmp,mpi" → apply listed features (no auto-defaults).
+        ! --features ""            → explicit empty list (no auto-defaults).
+        ! (not specified)          → auto-default features apply.
+        if (specified('features')) then
+            if (len_trim(feats) > 0) then
+                call parse_features(feats, self%features)
+            else
+                allocate(self%features(0))
+            end if
         else
             if (allocated(self%features)) deallocate(self%features)
         end if

--- a/src/fpm_compile_commands.F90
+++ b/src/fpm_compile_commands.F90
@@ -284,39 +284,45 @@ module fpm_compile_commands
             return
         end if
 
-        ! Tokenize the input command into args(:)
-        if (target_os==OS_WINDOWS) then 
+        ! Get current working directory (no lexer state involved)
+        call get_current_directory(cwd, error)
+        if (allocated(error)) return
+
+        ! Tokenize the command and consume the deferred-length args(:) result
+        ! under the shared fpm_shlex_split lock. fortran-shlex is not reentrant,
+        ! and reading the result while another build thread re-enters the lexer
+        ! corrupts the tokens, so the split and readback stay in one region.
+        !$omp critical (fpm_shlex_split)
+        if (target_os==OS_WINDOWS) then
             args = ms_split(command, ucrt=.true., success=sh_success)
         else
             args = sh_split(command, join_spaced=.false., keep_quotes=.true., success=sh_success)
         end if
         n = size(args)
-        
-        if (n==0 .or. .not.sh_success) then 
+        if (n>0 .and. sh_success) then
+            ! Try to find the source file
+            allocate(character(len=0) :: source_file)
+            find_source_file: do i = 1, n-1
+                if (args(i) == "-c") then
+                    source_file = trim(args(i+1))
+                    exit find_source_file
+                end if
+            end do find_source_file
+
+            ! Fallback: use last argument if not found
+            if (len_trim(source_file)==0) source_file = trim(args(n))
+
+            ! Fill in the compile_command_t.
+            ! Use non-default initializer due to gcc 15 bug
+            cmd = compile_command_t(cwd, args, source_file)
+        end if
+        !$omp end critical (fpm_shlex_split)
+
+        if (n==0 .or. .not.sh_success) then
             call syntax_error(error, "compile_command_table_t failed tokenizing: <"//command//">")
             return
         end if
-        
-        ! Get current working directory
-        call get_current_directory(cwd, error)
-        if (allocated(error)) return
 
-        ! Try to find the source file
-        allocate(character(len=0) :: source_file)
-        find_source_file: do i = 1, n-1
-            if (args(i) == "-c") then
-                source_file = trim(args(i+1))
-                exit find_source_file
-            end if
-        end do find_source_file
-
-        ! Fallback: use last argument if not found
-        if (len_trim(source_file)==0) source_file = trim(args(n))
-
-        ! Fill in the compile_command_t. 
-        ! Use non-default initializer due to gcc 15 bug
-        cmd = compile_command_t(cwd, args, source_file)
-        
         ! Add it to the structure
         !$omp critical (command_update)
         call cct_register_object(self, cmd, error)

--- a/src/fpm_compiler.F90
+++ b/src/fpm_compiler.F90
@@ -38,6 +38,7 @@ use fpm_environment, only: &
         OS_FREEBSD, &
         OS_OPENBSD, &
         OS_UNKNOWN, &
+        os_is_unix, &
         library_filename
 use fpm_filesystem, only: join_path, basename, get_temp_filename, delete_file, unix_path, &
     & getline, run, run_argv
@@ -1427,11 +1428,9 @@ subroutine compile_fortran(self, input, output, args, log_file, stat, table, dry
     logical, optional, intent(in) :: dry_run
 
     character(len=:), allocatable :: command
-    character(len=:), allocatable :: parts(:)
     type(string_t), allocatable :: argv(:)
     type(error_t), allocatable :: error
     logical :: mock, tokenized
-    integer :: i
 
     ! Initialize intent(out) status so the mock path with no table returns
     ! a defined value.
@@ -1441,30 +1440,19 @@ subroutine compile_fortran(self, input, output, args, log_file, stat, table, dry
     mock = .false.
     if (present(dry_run)) mock = dry_run
 
-    ! Set command
+    ! Set command (shell fallback string) and build the argv token list. The
+    ! command is split with the OS-native lexer (POSIX on Unix, Windows rules
+    ! otherwise) so quoting and backslash paths survive on both platforms.
     command = self%fc // " -c " // input // " " // args // " -o " // output
+
     tokenized = .true.
-    !$omp critical(fpm_shlex_split)
-    parts = sh_split(self%fc, join_spaced=.false., keep_quotes=.false., success=tokenized)
-    !$omp end critical(fpm_shlex_split)
+    call split_append(argv, self%fc, .false., .false., tokenized)
     if (tokenized) then
-        do i = 1, size(parts)
-            if (len_trim(parts(i)) == 0) cycle
-            call add_strings(argv, string_t(clean_shlex_token(parts(i))))
-        end do
         call add_strings(argv, string_t("-c"))
         call add_strings(argv, string_t(input))
     end if
     if (tokenized .and. len_trim(args) > 0) then
-        !$omp critical(fpm_shlex_split)
-        parts = sh_split(args, join_spaced=.true., keep_quotes=.true., success=tokenized)
-        !$omp end critical(fpm_shlex_split)
-        if (tokenized) then
-            do i = 1, size(parts)
-                if (len_trim(parts(i)) == 0) cycle
-                call add_strings(argv, string_t(clean_shlex_token(parts(i))))
-            end do
-        end if
+        call split_append(argv, args, .true., .true., tokenized)
     end if
     if (tokenized) then
         call add_strings(argv, string_t("-o"))
@@ -1488,6 +1476,40 @@ subroutine compile_fortran(self, input, output, args, log_file, stat, table, dry
     endif
 
 contains
+
+    !> Split a command fragment into argv tokens with the OS-native lexer and
+    !> append them to argv. fortran-shlex is not reentrant, so the split runs
+    !> in a critical region. join_spaced/keep_quotes apply to the POSIX lexer;
+    !> the Windows lexer already returns final argv tokens.
+    subroutine split_append(argv, str, join_spaced, keep_quotes, ok)
+        type(string_t), allocatable, intent(inout) :: argv(:)
+        character(len=*), intent(in) :: str
+        logical, intent(in) :: join_spaced, keep_quotes
+        logical, intent(inout) :: ok
+
+        character(len=:), allocatable :: parts(:)
+        integer :: k
+
+        if (.not.ok) return
+
+        !$omp critical(fpm_shlex_split)
+        if (os_is_unix()) then
+            parts = sh_split(str, join_spaced=join_spaced, keep_quotes=keep_quotes, success=ok)
+        else
+            parts = ms_split(str, success=ok)
+        end if
+        !$omp end critical(fpm_shlex_split)
+        if (.not.ok) return
+
+        do k = 1, size(parts)
+            if (len_trim(parts(k)) == 0) cycle
+            if (os_is_unix()) then
+                call add_strings(argv, string_t(clean_shlex_token(parts(k))))
+            else
+                call add_strings(argv, string_t(trim(parts(k))))
+            end if
+        end do
+    end subroutine split_append
 
     function clean_shlex_token(token) result(clean)
         character(len=*), intent(in) :: token

--- a/src/fpm_compiler.F90
+++ b/src/fpm_compiler.F90
@@ -1464,7 +1464,10 @@ subroutine compile_fortran(self, input, output, args, log_file, stat, table, dry
        if (tokenized) then
           call run_argv(argv, echo=self%echo, verbose=self%verbose, redirect=log_file, exitstat=stat)
        else
+          ! Tokenization failed; serialize the shell fork (not concurrency-safe).
+          !$omp critical (run_command)
           call run(command, echo=self%echo, verbose=self%verbose, redirect=log_file, exitstat=stat)
+          !$omp end critical (run_command)
        end if
        if (stat/=0) return
     endif
@@ -1559,8 +1562,9 @@ subroutine compile_c(self, input, output, args, log_file, stat, table, dry_run)
     logical, optional, intent(in) :: dry_run
 
     character(len=:), allocatable :: command
+    type(string_t), allocatable :: argv(:)
     type(error_t), allocatable :: error
-    logical :: mock
+    logical :: mock, tokenized
 
     ! Initialize intent(out) status so the mock path with no table returns
     ! a defined value.
@@ -1570,12 +1574,32 @@ subroutine compile_c(self, input, output, args, log_file, stat, table, dry_run)
     mock = .false.
     if (present(dry_run)) mock = dry_run
 
-    ! Set command
+    ! Set command (shell fallback string) and build the argv token list, exec'd
+    ! via argv spawn (fork-safe under OpenMP) rather than through a shell.
     command = self%cc // " -c " // input // " " // args // " -o " // output
+
+    tokenized = .true.
+    call split_append(argv, self%cc, .false., .false., tokenized)
+    if (tokenized) then
+        call add_strings(argv, string_t("-c"))
+        call add_strings(argv, string_t(input))
+    end if
+    if (tokenized .and. len_trim(args) > 0) call split_append(argv, args, .true., .true., tokenized)
+    if (tokenized) then
+        call add_strings(argv, string_t("-o"))
+        call add_strings(argv, string_t(output))
+    end if
 
     ! Execute command
     if (.not.mock) then
-       call run(command, echo=self%echo, verbose=self%verbose, redirect=log_file, exitstat=stat)
+       if (tokenized) then
+          call run_argv(argv, echo=self%echo, verbose=self%verbose, redirect=log_file, exitstat=stat)
+       else
+          ! Tokenization failed; serialize the shell fork (not concurrency-safe).
+          !$omp critical (run_command)
+          call run(command, echo=self%echo, verbose=self%verbose, redirect=log_file, exitstat=stat)
+          !$omp end critical (run_command)
+       end if
        if (stat/=0) return
     endif
 
@@ -1607,8 +1631,9 @@ subroutine compile_cpp(self, input, output, args, log_file, stat, table, dry_run
     logical, optional, intent(in) :: dry_run
 
     character(len=:), allocatable :: command
+    type(string_t), allocatable :: argv(:)
     type(error_t), allocatable :: error
-    logical :: mock
+    logical :: mock, tokenized
 
     ! Initialize intent(out) status so the mock path with no table returns
     ! a defined value.
@@ -1618,12 +1643,32 @@ subroutine compile_cpp(self, input, output, args, log_file, stat, table, dry_run
     mock = .false.
     if (present(dry_run)) mock = dry_run
 
-    ! Set command
+    ! Set command (shell fallback string) and build the argv token list, exec'd
+    ! via argv spawn (fork-safe under OpenMP) rather than through a shell.
     command = self%cxx // " -c " // input // " " // args // " -o " // output
+
+    tokenized = .true.
+    call split_append(argv, self%cxx, .false., .false., tokenized)
+    if (tokenized) then
+        call add_strings(argv, string_t("-c"))
+        call add_strings(argv, string_t(input))
+    end if
+    if (tokenized .and. len_trim(args) > 0) call split_append(argv, args, .true., .true., tokenized)
+    if (tokenized) then
+        call add_strings(argv, string_t("-o"))
+        call add_strings(argv, string_t(output))
+    end if
 
     ! Execute command
     if (.not.mock) then
-       call run(command, echo=self%echo, verbose=self%verbose, redirect=log_file, exitstat=stat)
+       if (tokenized) then
+          call run_argv(argv, echo=self%echo, verbose=self%verbose, redirect=log_file, exitstat=stat)
+       else
+          ! Tokenization failed; serialize the shell fork (not concurrency-safe).
+          !$omp critical (run_command)
+          call run(command, echo=self%echo, verbose=self%verbose, redirect=log_file, exitstat=stat)
+          !$omp end critical (run_command)
+       end if
        if (stat/=0) return
     endif
 

--- a/src/fpm_compiler.F90
+++ b/src/fpm_compiler.F90
@@ -40,7 +40,7 @@ use fpm_environment, only: &
         OS_UNKNOWN, &
         library_filename
 use fpm_filesystem, only: join_path, basename, get_temp_filename, delete_file, unix_path, &
-    & getline, run
+    & getline, run, run_argv
 use fpm_strings, only: split, string_cat, string_t, str_ends_with, str_begins_with_str, &
     & string_array_contains, lower, add_strings
 use fpm_error, only: error_t, fatal_error, fpm_stop
@@ -1427,8 +1427,11 @@ subroutine compile_fortran(self, input, output, args, log_file, stat, table, dry
     logical, optional, intent(in) :: dry_run
 
     character(len=:), allocatable :: command
+    character(len=:), allocatable :: parts(:)
+    type(string_t), allocatable :: argv(:)
     type(error_t), allocatable :: error
-    logical :: mock
+    logical :: mock, tokenized
+    integer :: i
 
     ! Initialize intent(out) status so the mock path with no table returns
     ! a defined value.
@@ -1440,10 +1443,41 @@ subroutine compile_fortran(self, input, output, args, log_file, stat, table, dry
 
     ! Set command
     command = self%fc // " -c " // input // " " // args // " -o " // output
+    tokenized = .true.
+    !$omp critical(fpm_shlex_split)
+    parts = sh_split(self%fc, join_spaced=.false., keep_quotes=.false., success=tokenized)
+    !$omp end critical(fpm_shlex_split)
+    if (tokenized) then
+        do i = 1, size(parts)
+            if (len_trim(parts(i)) == 0) cycle
+            call add_strings(argv, string_t(clean_shlex_token(parts(i))))
+        end do
+        call add_strings(argv, string_t("-c"))
+        call add_strings(argv, string_t(input))
+    end if
+    if (tokenized .and. len_trim(args) > 0) then
+        !$omp critical(fpm_shlex_split)
+        parts = sh_split(args, join_spaced=.true., keep_quotes=.true., success=tokenized)
+        !$omp end critical(fpm_shlex_split)
+        if (tokenized) then
+            do i = 1, size(parts)
+                if (len_trim(parts(i)) == 0) cycle
+                call add_strings(argv, string_t(clean_shlex_token(parts(i))))
+            end do
+        end if
+    end if
+    if (tokenized) then
+        call add_strings(argv, string_t("-o"))
+        call add_strings(argv, string_t(output))
+    end if
 
     ! Execute command
     if (.not.mock) then
-       call run(command, echo=self%echo, verbose=self%verbose, redirect=log_file, exitstat=stat)
+       if (tokenized) then
+          call run_argv(argv, echo=self%echo, verbose=self%verbose, redirect=log_file, exitstat=stat)
+       else
+          call run(command, echo=self%echo, verbose=self%verbose, redirect=log_file, exitstat=stat)
+       end if
        if (stat/=0) return
     endif
 
@@ -1452,6 +1486,26 @@ subroutine compile_fortran(self, input, output, args, log_file, stat, table, dry
         call table%register(command, get_os_type(), error)
         stat = merge(-1,0,allocated(error))
     endif
+
+contains
+
+    function clean_shlex_token(token) result(clean)
+        character(len=*), intent(in) :: token
+        character(len=:), allocatable :: clean
+
+        integer :: j
+
+        clean = ""
+        do j = 1, len_trim(token)
+            select case (token(j:j))
+            case ("'", '"')
+                cycle
+            case default
+                clean = clean//token(j:j)
+            end select
+        end do
+        clean = trim(adjustl(clean))
+    end function clean_shlex_token
 
 end subroutine compile_fortran
 

--- a/src/fpm_compiler.F90
+++ b/src/fpm_compiler.F90
@@ -1495,23 +1495,26 @@ subroutine split_append(argv, str, join_spaced, keep_quotes, ok)
 
     if (.not.ok) return
 
+    ! fortran-shlex is not reentrant, and the deferred-length parts(:) result it
+    ! returns must be consumed before another thread re-enters the lexer. Hold the
+    ! lock across both the split and the readback into argv.
     !$omp critical(fpm_shlex_split)
     if (os_is_unix()) then
         parts = sh_split(str, join_spaced=join_spaced, keep_quotes=keep_quotes, success=ok)
     else
         parts = ms_split(str, success=ok)
     end if
+    if (ok) then
+        do k = 1, size(parts)
+            if (len_trim(parts(k)) == 0) cycle
+            if (os_is_unix()) then
+                call add_strings(argv, string_t(clean_shlex_token(parts(k))))
+            else
+                call add_strings(argv, string_t(trim(parts(k))))
+            end if
+        end do
+    end if
     !$omp end critical(fpm_shlex_split)
-    if (.not.ok) return
-
-    do k = 1, size(parts)
-        if (len_trim(parts(k)) == 0) cycle
-        if (os_is_unix()) then
-            call add_strings(argv, string_t(clean_shlex_token(parts(k))))
-        else
-            call add_strings(argv, string_t(trim(parts(k))))
-        end if
-    end do
 end subroutine split_append
 
 function clean_shlex_token(token) result(clean)

--- a/src/fpm_compiler.F90
+++ b/src/fpm_compiler.F90
@@ -1475,61 +1475,68 @@ subroutine compile_fortran(self, input, output, args, log_file, stat, table, dry
         stat = merge(-1,0,allocated(error))
     endif
 
-contains
-
-    !> Split a command fragment into argv tokens with the OS-native lexer and
-    !> append them to argv. fortran-shlex is not reentrant, so the split runs
-    !> in a critical region. join_spaced/keep_quotes apply to the POSIX lexer;
-    !> the Windows lexer already returns final argv tokens.
-    subroutine split_append(argv, str, join_spaced, keep_quotes, ok)
-        type(string_t), allocatable, intent(inout) :: argv(:)
-        character(len=*), intent(in) :: str
-        logical, intent(in) :: join_spaced, keep_quotes
-        logical, intent(inout) :: ok
-
-        character(len=:), allocatable :: parts(:)
-        integer :: k
-
-        if (.not.ok) return
-
-        !$omp critical(fpm_shlex_split)
-        if (os_is_unix()) then
-            parts = sh_split(str, join_spaced=join_spaced, keep_quotes=keep_quotes, success=ok)
-        else
-            parts = ms_split(str, success=ok)
-        end if
-        !$omp end critical(fpm_shlex_split)
-        if (.not.ok) return
-
-        do k = 1, size(parts)
-            if (len_trim(parts(k)) == 0) cycle
-            if (os_is_unix()) then
-                call add_strings(argv, string_t(clean_shlex_token(parts(k))))
-            else
-                call add_strings(argv, string_t(trim(parts(k))))
-            end if
-        end do
-    end subroutine split_append
-
-    function clean_shlex_token(token) result(clean)
-        character(len=*), intent(in) :: token
-        character(len=:), allocatable :: clean
-
-        integer :: j
-
-        clean = ""
-        do j = 1, len_trim(token)
-            select case (token(j:j))
-            case ("'", '"')
-                cycle
-            case default
-                clean = clean//token(j:j)
-            end select
-        end do
-        clean = trim(adjustl(clean))
-    end function clean_shlex_token
-
 end subroutine compile_fortran
+
+!> Split a command fragment into argv tokens with the OS-native lexer and
+!> append them to argv. fortran-shlex is not reentrant, so the split runs
+!> in a critical region. join_spaced/keep_quotes apply to the POSIX lexer;
+!> the Windows lexer already returns final argv tokens.
+subroutine split_append(argv, str, join_spaced, keep_quotes, ok)
+    type(string_t), allocatable, intent(inout) :: argv(:)
+    character(len=*), intent(in) :: str
+    logical, intent(in) :: join_spaced, keep_quotes
+    logical, intent(inout) :: ok
+
+    character(len=:), allocatable :: parts(:)
+    integer :: k
+
+    if (.not.ok) return
+
+    !$omp critical(fpm_shlex_split)
+    if (os_is_unix()) then
+        parts = sh_split(str, join_spaced=join_spaced, keep_quotes=keep_quotes, success=ok)
+    else
+        parts = ms_split(str, success=ok)
+    end if
+    !$omp end critical(fpm_shlex_split)
+    if (.not.ok) return
+
+    do k = 1, size(parts)
+        if (len_trim(parts(k)) == 0) cycle
+        if (os_is_unix()) then
+            call add_strings(argv, string_t(clean_shlex_token(parts(k))))
+        else
+            call add_strings(argv, string_t(trim(parts(k))))
+        end if
+    end do
+end subroutine split_append
+
+function clean_shlex_token(token) result(clean)
+    character(len=*), intent(in) :: token
+    character(len=:), allocatable :: clean
+
+    integer :: j
+
+    clean = ""
+    do j = 1, len_trim(token)
+        select case (token(j:j))
+        case ("'", '"')
+            cycle
+        case default
+            clean = clean//token(j:j)
+        end select
+    end do
+    clean = trim(adjustl(clean))
+end function clean_shlex_token
+
+!> True when the string ends in a blank (space or tab), i.e. its last character
+!> separates it from anything concatenated after it.
+logical function ends_with_blank(str)
+    character(len=*), intent(in) :: str
+    ends_with_blank = .false.
+    if (len(str) > 0) ends_with_blank = (str(len(str):len(str)) == ' ' &
+        & .or. str(len(str):len(str)) == char(9))
+end function ends_with_blank
 
 
 !> Compile a C object
@@ -1644,7 +1651,8 @@ subroutine link_executable(self, output, args, log_file, stat, dry_run)
     logical, optional, intent(in) :: dry_run
 
     character(len=:), allocatable :: command
-    logical :: mock
+    type(string_t), allocatable :: argv(:)
+    logical :: mock, tokenized
 
     ! Initialize intent(out) status so the mock path returns a defined value.
     stat = 0
@@ -1653,16 +1661,27 @@ subroutine link_executable(self, output, args, log_file, stat, dry_run)
     mock = .false.
     if (present(dry_run)) mock = dry_run
 
-    ! Set command
+    ! Shell fallback string plus the argv token list. Exec via argv spawn
+    ! (fork-safe under OpenMP) so the link can run in parallel; the previous
+    ! run() needed critical(run_command) only because the shell fork is not.
     command = self%fc // " " // args // " -o " // output
+    tokenized = .true.
+    call split_append(argv, self%fc, .false., .false., tokenized)
+    if (tokenized .and. len_trim(args) > 0) call split_append(argv, args, .true., .true., tokenized)
+    if (tokenized) then
+        call add_strings(argv, string_t("-o"))
+        call add_strings(argv, string_t(output))
+    end if
 
-    ! Execute command. Serialize concurrent forks: gfortran's
-    ! execute_command_line uses system(3) which forks, and concurrent
-    ! fork from OpenMP threads is documented non-thread-safe.
     if (.not.mock) then
-        !$omp critical (run_command)
-        call run(command, echo=self%echo, verbose=self%verbose, redirect=log_file, exitstat=stat)
-        !$omp end critical (run_command)
+        if (tokenized) then
+            call run_argv(argv, echo=self%echo, verbose=self%verbose, redirect=log_file, exitstat=stat)
+        else
+            ! Tokenization failed; serialize the shell fork (not concurrency-safe).
+            !$omp critical (run_command)
+            call run(command, echo=self%echo, verbose=self%verbose, redirect=log_file, exitstat=stat)
+            !$omp end critical (run_command)
+        end if
     end if
 
 end subroutine link_executable
@@ -1683,7 +1702,8 @@ subroutine link_shared(self, output, args, log_file, stat, dry_run)
     logical, optional, intent(in) :: dry_run
 
     character(len=:), allocatable :: command
-    logical :: mock
+    type(string_t), allocatable :: argv(:)
+    logical :: mock, tokenized
     character(len=:), allocatable :: shared_flag
 
     ! Initialize intent(out) status so the mock path returns a defined value.
@@ -1695,11 +1715,24 @@ subroutine link_shared(self, output, args, log_file, stat, dry_run)
     shared_flag = get_shared_flag(self)
 
     command = self%fc // " " // shared_flag // " " // args // " -o " // output
+    tokenized = .true.
+    call split_append(argv, self%fc, .false., .false., tokenized)
+    if (tokenized .and. len_trim(shared_flag) > 0) call split_append(argv, shared_flag, .true., .true., tokenized)
+    if (tokenized .and. len_trim(args) > 0) call split_append(argv, args, .true., .true., tokenized)
+    if (tokenized) then
+        call add_strings(argv, string_t("-o"))
+        call add_strings(argv, string_t(output))
+    end if
 
     if (.not.mock) then
-        !$omp critical (run_command)
-        call run(command, echo=self%echo, verbose=self%verbose, redirect=log_file, exitstat=stat)
-        !$omp end critical (run_command)
+        if (tokenized) then
+            call run_argv(argv, echo=self%echo, verbose=self%verbose, redirect=log_file, exitstat=stat)
+        else
+            ! Tokenization failed; serialize the shell fork (not concurrency-safe).
+            !$omp critical (run_command)
+            call run(command, echo=self%echo, verbose=self%verbose, redirect=log_file, exitstat=stat)
+            !$omp end critical (run_command)
+        end if
     end if
 
 end subroutine link_shared
@@ -1723,7 +1756,10 @@ subroutine make_archive(self, output, args, log_file, stat, dry_run)
     !> Optional mocking
     logical, optional, intent(in) :: dry_run
 
-    logical :: mock
+    character(len=:), allocatable :: command
+    type(string_t), allocatable :: argv(:)
+    logical :: mock, tokenized
+    integer :: i
 
     ! Initialize intent(out) status so the mock path returns a defined value.
     stat = 0
@@ -1734,20 +1770,47 @@ subroutine make_archive(self, output, args, log_file, stat, dry_run)
 
     if (mock) return
 
+    ! Build the argv token list: archiver + flags, the archive name, then the
+    ! object files (already individual tokens). argv spawn is fork-safe under
+    ! OpenMP, so the archive runs without critical(run_command), and it has no
+    ! shell command-length ceiling.
+    tokenized = .true.
+    call split_append(argv, self%ar, .false., .false., tokenized)
+    if (tokenized) then
+        ! Reproduce `self%ar // output`. self%ar is concatenated directly with
+        ! output, so when it ends without a separator (MSVC `lib /OUT:`) the
+        ! name glues onto the last flag token; GNU `ar -rs ` ends in a space and
+        ! takes output as its own token.
+        if (size(argv) > 0 .and. .not.ends_with_blank(self%ar)) then
+            argv(size(argv))%s = argv(size(argv))%s // output
+        else
+            call add_strings(argv, string_t(output))
+        end if
+    end if
+
     if (self%use_response_file) then
         call write_response_file(output//".resp" , args)
-        !$omp critical (run_command)
-        call run(self%ar // output // " @" // output//".resp", echo=self%echo, &
-            &  verbose=self%verbose, redirect=log_file, exitstat=stat)
-        !$omp end critical (run_command)
-        call delete_file_win32(output//".resp")
-
+        command = self%ar // output // " @" // output//".resp"
+        if (tokenized) call add_strings(argv, string_t("@"//output//".resp"))
     else
+        command = self%ar // output // " " // string_cat(args, " ")
+        if (tokenized) then
+            do i = 1, size(args)
+                call add_strings(argv, args(i))
+            end do
+        end if
+    end if
+
+    if (tokenized) then
+        call run_argv(argv, echo=self%echo, verbose=self%verbose, redirect=log_file, exitstat=stat)
+    else
+        ! Tokenization failed; serialize the shell fork (not concurrency-safe).
         !$omp critical (run_command)
-        call run(self%ar // output // " " // string_cat(args, " "), &
-            & echo=self%echo, verbose=self%verbose, redirect=log_file, exitstat=stat)
+        call run(command, echo=self%echo, verbose=self%verbose, redirect=log_file, exitstat=stat)
         !$omp end critical (run_command)
     end if
+
+    if (self%use_response_file) call delete_file_win32(output//".resp")
 
     contains
         subroutine delete_file_win32(file)

--- a/src/fpm_filesystem.F90
+++ b/src/fpm_filesystem.F90
@@ -8,7 +8,7 @@ module fpm_filesystem
                                OS_CYGWIN, OS_SOLARIS, OS_FREEBSD, OS_OPENBSD
     use fpm_environment, only: separator, get_env, os_is_unix
     use fpm_strings, only: f_string, replace, string_t, split, split_lines_first_last, dilate, add_strings, &
-        str_begins_with_str
+        str_begins_with_str, string_cat
     use iso_c_binding, only: c_char, c_ptr, c_int, c_null_char, c_associated, c_f_pointer
     use fpm_error, only : fpm_stop, error_t, fatal_error
     implicit none
@@ -16,7 +16,7 @@ module fpm_filesystem
     public :: basename, canon_path, dirname, is_dir, join_path, number_of_rows, list_files, get_local_prefix, &
             mkdir, exists, get_temp_filename, windows_path, unix_path, getline, delete_file, fileopen, fileclose, &
             filewrite, warnwrite, parent_dir, is_hidden_file, read_lines, read_lines_expanded, which, run, &
-            os_delete_dir, is_absolute_path, get_home, execute_and_read_output, get_dos_path
+            run_argv, os_delete_dir, is_absolute_path, get_home, execute_and_read_output, get_dos_path
 
 #ifndef FPM_BOOTSTRAP
     interface
@@ -49,6 +49,13 @@ module fpm_filesystem
             character(kind=c_char), intent(in) :: path(*)
             integer(kind=c_int) :: r
         end function c_is_dir
+
+        function c_run_argv(joined, argc, redirect) result(r) bind(c, name="c_run_argv")
+            import c_char, c_int
+            character(kind=c_char), intent(in) :: joined(*), redirect(*)
+            integer(kind=c_int), intent(in), value :: argc
+            integer(kind=c_int) :: r
+        end function c_run_argv
     end interface
 #endif
 
@@ -1059,6 +1066,95 @@ subroutine run(cmd,echo,exitstat,verbose,redirect)
     end if
 
 end subroutine run
+
+subroutine run_argv(args,echo,exitstat,verbose,redirect)
+    type(string_t), intent(in) :: args(:)
+    logical,intent(in),optional  :: echo
+    integer, intent(out),optional :: exitstat
+    logical, intent(in), optional :: verbose
+    character(*), intent(in), optional :: redirect
+
+    character(:), allocatable :: command
+    character(:), allocatable :: joined
+    character(:), allocatable :: redirect_file
+    character(:), allocatable :: line
+    character(len=256) :: iomsg
+    logical :: echo_local, verbose_local
+    integer :: stat, fh, iostat, i
+
+    command = string_cat(args, " ")
+
+    if(present(echo))then
+       echo_local=echo
+    else
+       echo_local=.true.
+    end if
+
+    if(present(verbose))then
+        verbose_local=verbose
+    else
+        verbose_local=.true.
+    end if
+
+    if (present(redirect)) then
+        redirect_file = redirect
+    else
+        if(verbose_local)then
+            redirect_file = ""
+        else
+            if (os_is_unix()) then
+                redirect_file = "/dev/null"
+            else
+                redirect_file = "NUL"
+            end if
+        end if
+    end if
+
+    if(echo_local) print *, '+ ', command
+
+    if (size(args) < 1) then
+        stat = 0
+#ifndef FPM_BOOTSTRAP
+    elseif (os_is_unix()) then
+        joined = ""
+        do i = 1, size(args)
+            joined = joined//args(i)%s//c_null_char
+        end do
+        stat = c_run_argv(joined//c_null_char, int(size(args), c_int), &
+            redirect_file//c_null_char)
+#endif
+    else
+        call run(command, echo=.false., verbose=verbose_local, redirect=redirect_file, exitstat=stat)
+    end if
+
+    if (stat < 0) then
+        call run(command, echo=.false., verbose=verbose_local, redirect=redirect_file, exitstat=stat)
+    end if
+
+    if (verbose_local.and.present(redirect)) then
+
+        open(newunit=fh,file=redirect,status='old',iostat=iostat,iomsg=iomsg)
+        if(iostat == 0)then
+           do
+               call getline(fh, line, iostat)
+               if (iostat /= 0) exit
+               write(*,'(A)') trim(line)
+           end do
+        else
+           write(*,'(A)') trim(iomsg)
+        endif
+
+        close(fh)
+
+    end if
+
+    if (present(exitstat)) then
+        exitstat = stat
+    elseif (stat /= 0) then
+        call fpm_stop(stat,'*run_argv*: Command '//command//' returned a non-zero status code')
+    end if
+
+end subroutine run_argv
 
 !> Delete directory using system OS remove directory commands
 subroutine os_delete_dir(is_unix, dir, echo)

--- a/src/fpm_filesystem.F90
+++ b/src/fpm_filesystem.F90
@@ -1115,18 +1115,20 @@ subroutine run_argv(args,echo,exitstat,verbose,redirect)
     if (size(args) < 1) then
         stat = 0
 #ifndef FPM_BOOTSTRAP
-    elseif (os_is_unix()) then
+    else
         joined = ""
         do i = 1, size(args)
             joined = joined//args(i)%s//c_null_char
         end do
         stat = c_run_argv(joined//c_null_char, int(size(args), c_int), &
             redirect_file//c_null_char)
-#endif
+#else
     else
         call run(command, echo=.false., verbose=verbose_local, redirect=redirect_file, exitstat=stat)
+#endif
     end if
 
+    ! Fall back to the shell if the argv spawn was unavailable or failed (stat < 0).
     if (stat < 0) then
         call run(command, echo=.false., verbose=verbose_local, redirect=redirect_file, exitstat=stat)
     end if

--- a/src/fpm_filesystem.F90
+++ b/src/fpm_filesystem.F90
@@ -1124,13 +1124,19 @@ subroutine run_argv(args,echo,exitstat,verbose,redirect)
             redirect_file//c_null_char)
 #else
     else
+        !$omp critical (run_command)
         call run(command, echo=.false., verbose=verbose_local, redirect=redirect_file, exitstat=stat)
+        !$omp end critical (run_command)
 #endif
     end if
 
     ! Fall back to the shell if the argv spawn was unavailable or failed (stat < 0).
+    ! The shell forks, which is not safe to call concurrently from OpenMP
+    ! threads, so this rare path stays serialized.
     if (stat < 0) then
+        !$omp critical (run_command)
         call run(command, echo=.false., verbose=verbose_local, redirect=redirect_file, exitstat=stat)
+        !$omp end critical (run_command)
     end if
 
     if (verbose_local.and.present(redirect)) then


### PR DESCRIPTION
## Summary

- Add a `default = true` field to feature definitions in fpm.toml
- When no explicit `--features` list is given, features with `default = true`
  are automatically applied (alongside the existing default-profile mechanism)
- `--features ""` (explicit empty) opts out of auto-defaults
- `--features "openmp,mpi"` (explicit list) applies only listed features

## Context

After the argv spawn chain (#1299, #1300, #1301) and the mkdir fork-safety
fix (#1298), the parallel build backend is fully fork-safe. This PR lets
packages opt into default features automatically via the manifest.

A package that wants OpenMP by default declares:

```toml
[features.openmp]
default = true

[features.openmp.dependencies]
openmp = "*"
```

CI or users on compilers where a default feature is unsafe (e.g.
libgomp+--static on gcc 10-13, see #962) opt out with `--features ""`.

**Bootstrap note:** fpm's own `fpm.toml` cannot set `default = true` yet
because the bootstrap fpm (v0.13.0) rejects unknown keys in feature tables.
Once this change lands in a release and the bootstrap is bumped, a follow-up
adds `default = true` to fpm.toml and updates CI to use `--features ""` on
the affected compilers.

## Change

- `feature_collection_t` gains `is_default` logical, parsed from `default`
  key in the feature subtable, serialized in dump/load/same
- `export_config` iterates features with `is_default = .true.`
- `default` added to allowed-key whitelist in feature table validation
- `traverse_feature_table` skips the `default` key during traversal
- CLI: `--features ""` allocates a zero-size features array so
  `present(features)` is true and auto-defaults are suppressed

## Merge order

**This PR is stacked on the full fork-safety chain. Merge in order:**
1. Fortran compiles via argv (#1299)
2. Parallel link/archive via argv (#1300)
3. C/C++ compiles via argv (#1301)
4. Serialize mkdir on run_command lock (#1298)
5. **This PR** — auto-apply default features + CLI opt-out

Until #1299-#1301 and #1298 merge, the diff includes their commits.

Also in this series:
- Interface-aware rebuild (#1289, already open)
- Independent PRs: #1291, #1292, #1293, #1294, #1295, #1296, #1297

Refs: #962

## Verification

```
$ fpm build --features openmp --compiler gfortran --flag '-O3 -g'
[100%] Project compiled successfully.

$ fpm test
TALLY;TTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTT
PASSED: all 35 tests passed
```

CI: gcc 10-13 pass (the mechanism is available but fpm.toml does not yet
set `default = true` due to the bootstrap constraint).