### PR TITLE
CI: Remove macos-14 + gcc-11 build

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -37,6 +37,8 @@ jobs:
             toolchain: {compiler: intel, version: '2025.2'}
           - os: macos-14  # gcc@10 not available on macos-14 (ARM64)
             toolchain: {compiler: gcc, version: 10}
+          - os: macos-14  # gcc@11 broken on macos-14 (ARM64)
+            toolchain: {compiler: gcc, version: 11}
           - os: macos-15-intel  # Intel compiler not available on macOS
             toolchain: {compiler: intel, version: '2025.2'}
           - os: macos-15-intel  # gcc@10 not available on macos-15


### PR DESCRIPTION
This Homebrew bottle appears to be broken with the current macos-14 runner image, and seemingly always fails in the post-install step of setup-fortran.

Also, macos-14 is scheduled to reach end-of-life next month, and the [macos-14 GitHub runner will be entirely retired in October](https://github.com/actions/runner-images/issues/13518), so it's not worth trying to fix.

Fixes #1314 

CC: @rouson 