### PR TITLE
fix feature caching in fpm 

### DIFF
--- a/src/fpm/dependency.f90
+++ b/src/fpm/dependency.f90
@@ -1302,7 +1302,8 @@ contains
 
     integer :: ndep, ii
     logical :: is_unix
-    character(len=:), allocatable :: version, url, obj, rev, proj_dir
+    character(len=:), allocatable :: version, url, obj, rev, proj_dir, profile
+    type(string_t), allocatable :: features(:)
     type(toml_key), allocatable :: list(:)
     type(toml_table), pointer :: ptr
 
@@ -1317,6 +1318,14 @@ contains
 
     do ii = 1, size(list)
       call get_value(table, list(ii)%key, ptr)
+      ! Reset the per-entry optionals: `get_value`/`get_list` leave the
+      ! actual untouched when the key is absent, so a previous entry's
+      ! value would otherwise leak into this one.
+      if (allocated(features)) deallocate (features)
+      if (allocated(profile)) deallocate (profile)
+      call get_list(ptr, "features", features, error)
+      if (allocated(error)) exit
+      call get_value(ptr, "profile", profile)
       call get_value(ptr, "version", version)
       call get_value(ptr, "proj-dir", proj_dir)
       call get_value(ptr, "git", url)
@@ -1326,6 +1335,8 @@ contains
       self%ndep = self%ndep + 1
       associate (dep => self%dep(self%ndep))
         dep%name = list(ii)%key
+        if (allocated(features)) dep%features = features
+        if (allocated(profile)) dep%profile = profile
         if (is_unix) then
           dep%proj_dir = proj_dir
         else
@@ -1425,6 +1436,14 @@ contains
           if (allocated(dep%revision)) then
             call set_value(ptr, "rev", dep%revision)
           end if
+        end if
+        ! The requested features/profile are part of the dependency's IDENTITY:
+        ! they change its macros and its own dependency set, so a cache entry
+        ! that omits them resolves to a DIFFERENT package on the next run.
+        call set_list(ptr, "features", dep%features, error)
+        if (allocated(error)) exit
+        if (allocated(dep%profile)) then
+          call set_value(ptr, "profile", dep%profile)
         end if
       end associate
     end do

--- a/src/fpm/manifest/dependency.f90
+++ b/src/fpm/manifest/dependency.f90
@@ -426,6 +426,31 @@ contains
             if (.not.git_matches_manifest(cached%git,manifest%git,verbosity,iunit)) return
         end if
 
+        !> A different feature set (or profile) means different macros and
+        !> possibly different dependencies, so it is a different build of the
+        !> same revision -- the git checks above cannot see that.
+        if (allocated(cached%features).neqv.allocated(manifest%features)) then
+            if (verbosity>1) write(iunit,out_fmt) "FEATURES presence has changed. "
+            return
+        endif
+        if (allocated(cached%features)) then
+            if (.not.(cached%features==manifest%features)) then
+                if (verbosity>1) write(iunit,out_fmt) "FEATURES have changed. "
+                return
+            end if
+        end if
+        if (allocated(cached%profile).neqv.allocated(manifest%profile)) then
+            if (verbosity>1) write(iunit,out_fmt) "PROFILE presence has changed. "
+            return
+        endif
+        if (allocated(cached%profile)) then
+            if (.not.(cached%profile==manifest%profile)) then
+                if (verbosity>1) write(iunit,out_fmt) &
+                    "PROFILE has changed: "//cached%profile//" vs. "//manifest%profile
+                return
+            end if
+        end if
+
         !> All checks passed! The two instances are equal
         has_changed = .false.
 

--- a/test/fpm_test/test_package_dependencies.f90
+++ b/test/fpm_test/test_package_dependencies.f90
@@ -14,6 +14,8 @@ module test_package_dependencies
   use fpm_settings, only: fpm_global_settings, get_registry_settings, get_global_settings
   use fpm_downloader, only: downloader_t
   use fpm_versioning, only: version_t
+  use fpm_strings, only: string_t
+  use, intrinsic :: iso_fortran_env, only: output_unit
   use jonquil, only: json_object, json_value, json_loads, cast_to_object
 
   implicit none
@@ -45,6 +47,8 @@ contains
     testsuite = [ &
         & new_unittest("cache-load-dump", test_cache_load_dump), &
         & new_unittest("cache-dump-load", test_cache_dump_load), &
+        & new_unittest("cache-preserves-features", test_cache_preserves_features), &
+        & new_unittest("features-change-detection", test_features_change_detection), &
         & new_unittest("status-after-load", test_status), &
         & new_unittest("add-dependencies", test_add_dependencies), &
         & new_unittest("update-dependencies", test_update_dependencies), &
@@ -126,6 +130,134 @@ contains
     end if
 
   end subroutine test_cache_dump_load
+
+  !> A dependency's requested features and profile are part of its IDENTITY --
+  !> they change its macros and can change its own dependency set -- so they
+  !> must survive the cache round trip.  When they did not, the first build
+  !> applied the feature and every incremental build silently resolved the
+  !> dependency without it.
+  subroutine test_cache_preserves_features(error)
+
+    !> Error handling
+    type(error_t), allocatable, intent(out) :: error
+
+    type(dependency_tree_t) :: deps
+    type(dependency_config_t) :: dep
+    integer :: unit, id
+
+    call new_dependency_tree(deps)
+    call resize(deps%dep, 5)
+    deps%ndep = 2
+
+    dep%name = "dep1"
+    dep%path = "fpm-tmp1-dir"
+    allocate (dep%features(2))
+    dep%features(1)%s = "serial"
+    dep%features(2)%s = "openmp"
+    call new_dependency_node(deps%dep(1), dep, proj_dir=dep%path)
+
+    !> dep2 requests a profile and NO features, so it also pins that one
+    !> entry's optionals do not leak into the next while loading.
+    call dependency_destroy(dep)
+    dep%name = "dep2"
+    dep%path = "fpm-tmp2-dir"
+    dep%profile = "parallel-mpi"
+    call new_dependency_node(deps%dep(2), dep, proj_dir=dep%path)
+
+    open (newunit=unit, status='scratch')
+    call deps%dump_cache(unit, error)
+    if (.not. allocated(error)) then
+      rewind (unit)
+
+      call new_dependency_tree(deps)
+      call resize(deps%dep, 2)
+      call deps%load_cache(unit, error)
+      close (unit)
+    end if
+    if (allocated(error)) return
+
+    id = deps%find("dep1")
+    if (id <= 0) then
+      call test_failed(error, "Dependency 'dep1' missing from the loaded cache")
+      return
+    end if
+    if (.not. allocated(deps%dep(id)%features)) then
+      call test_failed(error, "Cached dependency 'dep1' lost its requested features")
+      return
+    end if
+    if (size(deps%dep(id)%features) /= 2) then
+      call test_failed(error, "Expected two features on 'dep1' after the cache round trip")
+      return
+    end if
+    if (deps%dep(id)%features(1)%s /= "serial" .or. &
+        deps%dep(id)%features(2)%s /= "openmp") then
+      call test_failed(error, "Feature names not preserved by the cache round trip")
+      return
+    end if
+
+    id = deps%find("dep2")
+    if (id <= 0) then
+      call test_failed(error, "Dependency 'dep2' missing from the loaded cache")
+      return
+    end if
+    if (allocated(deps%dep(id)%features)) then
+      call test_failed(error, "Dependency 'dep2' inherited the previous entry's features")
+      return
+    end if
+    if (.not. allocated(deps%dep(id)%profile)) then
+      call test_failed(error, "Cached dependency 'dep2' lost its requested profile")
+      return
+    end if
+    if (deps%dep(id)%profile /= "parallel-mpi") then
+      call test_failed(error, "Profile not preserved by the cache round trip")
+      return
+    end if
+
+  end subroutine test_cache_preserves_features
+
+  !> Differing features must mark a dependency as changed, so a cache entry
+  !> written before the feature was requested is re-resolved instead of being
+  !> accepted as equal.
+  subroutine test_features_change_detection(error)
+
+    !> Error handling
+    type(error_t), allocatable, intent(out) :: error
+
+    type(dependency_config_t) :: cached, manifest
+
+    cached%name = "dep1"
+    cached%path = "fpm-tmp1-dir"
+
+    manifest%name = "dep1"
+    manifest%path = "fpm-tmp1-dir"
+    allocate (manifest%features(1))
+    manifest%features(1)%s = "serial"
+
+    !> Cache has no features, manifest asks for one: that is a change.
+    if (.not. manifest_has_changed(cached=cached, manifest=manifest, &
+                                   verbosity=0, iunit=output_unit)) then
+      call test_failed(error, "Requesting a feature absent from the cache must count as a change")
+      return
+    end if
+
+    !> Same feature on both sides: not a change.
+    allocate (cached%features(1))
+    cached%features(1)%s = "serial"
+    if (manifest_has_changed(cached=cached, manifest=manifest, &
+                             verbosity=0, iunit=output_unit)) then
+      call test_failed(error, "Identical features must not count as a change")
+      return
+    end if
+
+    !> Different feature name: a change again.
+    manifest%features(1)%s = "openmp"
+    if (.not. manifest_has_changed(cached=cached, manifest=manifest, &
+                                   verbosity=0, iunit=output_unit)) then
+      call test_failed(error, "A different feature name must count as a change")
+      return
+    end if
+
+  end subroutine test_features_change_detection
 
   !> Round trip of the dependency cache from a TOML data structure to
   !> a dependency tree to a TOML data structure


### PR DESCRIPTION
I noticed a bug in my codes when I used the `features` attribute: 
```
[features]
serial.preprocess.cpp.macros = ["USE_SERIAL"]
```

This would work, once I did:

```
pic-mpi = { git = "https://github.com/JorgeG94/pic-mpi.git", branch = "main", features=["serial"]}
```

However, after a successful `fpm build` if I issued a second `fpm build` after editing a file or just cuz, the "feature" would get reverted and my code would fail to compile due to some macro shenanigans. This PR address this issue and provides a test for it. 

Claude was used to diagnose the error and provide most of the fix. Since I am terrible at giving good commit messages beyond "fix bug" I had Claude write a nice commit message for future reference. 